### PR TITLE
Works in bgv009

### DIFF
--- a/new/LIT6350MEMiracle.xml
+++ b/new/LIT6350MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">First miracle of ʾEwosṭātewos: the saint's heavenly journey from Armenia</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the saint's heavenly journey from Armenia</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT6350MEMiracle.xml
+++ b/new/LIT6350MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">First miracle of ʾEwosṭātewos: his heavnely journey from Armenia</title>
+                <title xml:lang="en" xml:id="t1">First miracle of ʾEwosṭātewos: the saint's heavenly journey from Armenia</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT6350MEMiracle.xml
+++ b/new/LIT6350MEMiracle.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (1st miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (1st miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6350MEMiracle.xml
+++ b/new/LIT6350MEMiracle.xml
@@ -69,10 +69,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፩ ተአምሪሁ፡ ለቅዱስ፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዘይትነበብ፡ አመ፡ ፲ወ፭ ለወርኃ፡ ታኅሣሥ።  <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፩ ተአምሪሁ፡ ለቅዱስ፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዘይትብነበብ፡ አመ፡ ፲ወ፭ ለወርኃ፡ ታኅሣሥ።  <gap reason="ellipsis" resp="MV"/>
                         ወሶበ፡ ተመይጠ፡ እምአርማንያ፡ አቡነ፡ ኤዎስጣቴውስ፡ ውስተ፡ ብሔረ፡ ኢትዮጵያ፡
                         ተፅዒኖ፡ በሠረገላ፡ መንፈስ፡ በከመ፡ ተመሥጠ፡ ሄኖክ፡ ነቢይ፡ በነኰርኳረ፡ ነፍሳት።
                     </ab>

--- a/new/LIT6350MEMiracle.xml
+++ b/new/LIT6350MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6350MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6350MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6350MEMiracle.xml
+++ b/new/LIT6350MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">First miracle of ʾEwosṭātewos: his heavnely journey from Armenia</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (1st miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">71-72 (1st miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6350MEMiracle.xml
+++ b/new/LIT6350MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,7 +66,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6350MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
-            </div><!---->
-        </body>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፩ ተአምሪሁ፡ ለቅዱስ፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዘይትብነበብ፡ አመ፡ ፲ወ፭ ለወርኃ፡ ታኅሣሥ።  <gap reason="ellipsis" resp="MV"/>
+                        ወሶበ፡ ተመይጠ፡ እምአርማንያ፡ አቡነ፡ ኤዎስጣቴውስ፡ ውስተ፡ ብሔረ፡ ኢትዮጵያ፡
+                        ተፅዒኖ፡ በሠረገላ፡ መንፈስ፡ በከመ፡ ተመሥጠ፡ ሄኖክ፡ ነቢይ፡ በነኰርኳረ፡ ነፍሳት።
+                    </ab>
+                </div>
+                    <div type="textpart" subtype="explicit" xml:lang="gez">
+                        <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                        <ab> 
+                            በረከተ፡ እሉ፡ አበው፡ መተንብላን፡ ይዕቀቦ፡ ለገብሩ፡ <gap reason="ellipsis" resp="MV"/> ለአቡነ፡ ኤዎስጣቴዎስ፡
+                            ዘይትአመን፡ ወይሰወር፡ እምባህለ፡ ልሳን፡ ወእምግብረ፡ ሰይጣን፡ ዘይትቃረን፡ ወይሩሲ፡ መዋዕሊሁ፡ ለጉንዱይ፡ አዝማን፡ ለዓለመ፡ ዓለም፡ አሜን።
+                        </ab>
+                    </div>
+                </div>
+            </body>
     </text>
 </TEI>

--- a/new/LIT6351MEMiracle.xml
+++ b/new/LIT6351MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6351MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፪። ተአምሪሁ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
+                        ወሀለወት፡ አሐቲ፡ ብእሲት፡ ዘትገብር፡ ተዝካሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ለለዓመት። ወትንበር፡ በሥርዓቱ፡ ወታከብር፡ ሰንበታተ፡ በተጠናቅቆ፡ በከመ፡
+                        ትምህርቱ። ወአሐተ፡ ዕለተ፡ ዓርበ፡ ወፈረት፡ ምስለ፡ አዋልዲሃ፡ ከመ፡ ትቀርም፡ ኀበ፡ ገራህት፡ በዕለተ፡ ዓርብ።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ጸሎቱ፡ ወበረከቱ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ለእግዚአብሔር፡ ቅዱስ፡ ዘዓቀመ፡ ፀሐየ። በጸውዖ፡ ስሙ፡ ከመ፡ ኢያሱ።
+                        የሃሉ። ምስለ፡ <gap reason="ellipsis" resp="MV"/> ለዓቂበ፡ ሥጋሁ፡ 
+                        ወነፍሱ፡ ወለመግቦ፡ ንግሡ። ለዓለመ፡ ዓለም፡ አሜን።
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6351MEMiracle.xml
+++ b/new/LIT6351MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the woman who could observe the Sabbath</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (2nd miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">72-73 (2nd miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>
@@ -72,7 +73,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
                         ፪። ተአምሪሁ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
-                        ወሀለወት፡ አሐቲ፡ ብእሲት፡ ዘትገብር፡ ተዝካሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ለለዓመት። ወትንበር፡ በሥርዓቱ፡ ወታከብር፡ ሰንበታተ፡ በተጠናቅቆ፡ በከመ፡
+                        ወሀለወት፡ አሐቲ፡ ብእሲት፡ ዘትገብር፡ ተዝካሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ለለዓመት። ወትነበር፡ በሥርዓቱ፡ ወታከብር፡ ሰንበታተ፡ በተጠናቅቆ፡ በከመ፡
                         ትምህርቱ። ወአሐተ፡ ዕለተ፡ ዓርበ፡ ወፈረት፡ ምስለ፡ አዋልዲሃ፡ ከመ፡ ትቀርም፡ ኀበ፡ ገራህት፡ በዕለተ፡ ዓርብ።
                     </ab>
                 </div>

--- a/new/LIT6351MEMiracle.xml
+++ b/new/LIT6351MEMiracle.xml
@@ -79,12 +79,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፪። ተአምሪሁ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፪። ተአምሪሁ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
-                        ወሀለወት፡ አሐቲ፡ ብእሲት፡ ዘትገብር፡ ተዝካሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ለለዓመት። ወትነበር፡ በሥርዓቱ፡ ወታከብር፡ ሰንበታተ፡ በተጠናቅቆ፡ በከመ፡
-                        ትምህርቱ። ወአሐተ፡ ዕለተ፡ ዓርበ፡ ወፈረት፡ ምስለ፡ አዋልዲሃ፡ ከመ፡ ትቀርም፡ ኀበ፡ ገራህት፡ በዕለተ፡ ዓርብ።
+                        ወሀለወት፡ አሐቲ፡ ብእሲት፡ ዘትገብር፡ ተዝካሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ለለዓመት። ወትነብር፡ በሥርዓቱ፡ ወታከብር፡ ሰንበታተ፡ በተጠናቅቆ፡ በከመ፡
+                        ትምህርቱ። ወአሐተ፡ ዕለተ፡ ዓርብ፡ ወፈረት፡ ምስለ፡ አዋልዲሃ፡ ከመ፡ ትቀርም፡ ኀበ፡ ገራህት፡ በዕለተ፡ ዓርብ።
                     </ab>
                 </div>
                 <div type="textpart" subtype="explicit" xml:lang="gez">

--- a/new/LIT6351MEMiracle.xml
+++ b/new/LIT6351MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the woman who stopped the sun to finish her daily work before the Sabbath</title>
+                <title xml:id="t2" xml:lang="la">Miraculum de muliere, quae sole retento panem percoxit</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -47,6 +48,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>     
             <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,10 +70,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:GrebTiss1935Codices"/>
                         <citedRange unit="page">196</citedRange>
+                        <citedRange unit="item">Vat 46, 2.3 (3rd miracle)</citedRange>
                     </bibl>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">130</citedRange>
+                        <citedRange unit="item">EMML 1636 2.1 (1st miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6351MEMiracle.xml
+++ b/new/LIT6351MEMiracle.xml
@@ -45,8 +45,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-20">Created entity</change>     
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (2nd miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (2nd miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6351MEMiracle.xml
+++ b/new/LIT6351MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6351MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6351MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6351MEMiracle.xml
+++ b/new/LIT6351MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the woman who could observe the Sabbath</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the woman who stopped the sun to finish her daily work before the Sabbath</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -62,6 +62,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
                         <citedRange unit="page">72-73 (2nd miracle)</citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:GrebTiss1935Codices"/>
+                        <citedRange unit="page">196</citedRange>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">130</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6352MEMiracle.xml
+++ b/new/LIT6352MEMiracle.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (3rd miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (3rd miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6352MEMiracle.xml
+++ b/new/LIT6352MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6352MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፫። ተአምሪሁ፡ ለአᎇነ፡ ኤዎስጣቴውሶ፡ ገባሬ፡ ተአምራት፡ ወመንክራት፡ ክቡድ። <gap reason="ellipsis" resp="MV"/>
+                        ወሀለወት፡ አሐቲ፡ ብእሲት፡ ዘስማ፡ ቡርክት፡ ማርያም፡ እንተ፡ ሐይወት፡ በትምህርቱ። ለአቡነ፡ ኤዎስጣቴዎስ፡
+                        ወትገብር፡ ተዝካሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ በምሒረ፡ ነዳያን፡ ወበመባልዕት፡ ብዙኅ። ወእምዝ፡ ሐመት፡ 
+                        ወአልጸቀት፡ ለመዊት።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        በረከተ፡ ጸሎቱ፡ ወኃይለ፡ ረድኤቱ። ዘአድኅና፡ ለዛቲ፡ ነፍስ፡ ብእሲት፡ ዘተአምነት፡ ቦቱ፡ ይባልሐ፡
+                        <gap reason="ellipsis" resp="MV"/> ለሰይጣን፡ እምሥርገቱ፡ ኢይትፈለጥ፡ እምኔሆሙ፡ በሞቶሙ፡ ወበሕይወቶሙ፡ ለዓለመ፡ ዓለም፡ አሜን።
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6352MEMiracle.xml
+++ b/new/LIT6352MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the vision of the widow Burǝkt Māryām</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (3rd miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">73-74 (3rd miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6352MEMiracle.xml
+++ b/new/LIT6352MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6352MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6352MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6352MEMiracle.xml
+++ b/new/LIT6352MEMiracle.xml
@@ -79,10 +79,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፫። ተአምሪሁ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ገባሬ፡ ተአምራት፡ ወመንክራት፡ ክቡድ። <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፫። ተአምሪሁ፡ ለአᎇነ፡ ኤዎስጣቴውሶ፡ ገባሬ፡ ተአምራት፡ ወመንክራት፡ ክቡድ። <gap reason="ellipsis" resp="MV"/>
                         ወሀለወት፡ አሐቲ፡ ብእሲት፡ ዘስማ፡ ቡርክት፡ ማርያም፡ እንተ፡ ሐይወት፡ በትምህርቱ። ለአቡነ፡ ኤዎስጣቴዎስ፡
                         ወትገብር፡ ተዝካሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ በምሒረ፡ ነዳያን፡ ወበመባልዕት፡ ብዙኅ። ወእምዝ፡ ሐመት፡ 
                         ወአልጸቀት፡ ለመዊት።

--- a/new/LIT6352MEMiracle.xml
+++ b/new/LIT6352MEMiracle.xml
@@ -6,6 +6,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the widow Burǝkt Māryām who was saved from death</title>
+                <title xml:lang="en" xml:id="t2">The widow (Burǝkt Māryām?) who was saved from death because she gave a commemorative feast in honor of ʾAbuna ʾEwosṭātewos</title>
+                <title xml:id="t3" xml:lang="la">Miraculum de vidua infirma, quae visionem caeli habuit</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -47,6 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
             <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,10 +71,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:GrebTiss1935Codices"/>
                         <citedRange unit="page">196</citedRange>
+                        <citedRange unit="item">Vat 46, 2.4 (4th miracle)</citedRange>
                     </bibl>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">130</citedRange>
+                        <citedRange unit="item">EMML 1636 2.2 (2nd miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6352MEMiracle.xml
+++ b/new/LIT6352MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the vision of the widow Burǝkt Māryām</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the widow Burǝkt Māryām who was saved from death</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -62,6 +62,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
                         <citedRange unit="page">73-74 (3rd miracle)</citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:GrebTiss1935Codices"/>
+                        <citedRange unit="page">196</citedRange>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">130</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6353MEMiracle.xml
+++ b/new/LIT6353MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6353MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6353MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6353MEMiracle.xml
+++ b/new/LIT6353MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the evil man who was saved by the saint</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the evil man who was saved from the demons by the saint</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -62,6 +62,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
                         <citedRange unit="page">74-75 (4th miracle)</citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:GrebTiss1935Codices"/>
+                        <citedRange unit="page">196</citedRange>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">130</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6353MEMiracle.xml
+++ b/new/LIT6353MEMiracle.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the evil man who was saved from the demons by the saint</title>
-                <title xml:lang="en" xml:id="t2">The murderer who used to give commemorstive feasts in honor of the saint</title>
+                <title xml:lang="en" xml:id="t2">The murderer who used to give commemorative feasts in honor of the saint</title>
                 <title xml:id="t3" xml:lang="la">Miraculum de latrone, quem s. Eustathius a daemonibus liberavit</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>

--- a/new/LIT6353MEMiracle.xml
+++ b/new/LIT6353MEMiracle.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (4th miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (4th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6353MEMiracle.xml
+++ b/new/LIT6353MEMiracle.xml
@@ -79,10 +79,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፬ ተአምሪሁ፡ ለአብ፡ ክቡር፡ መክብበ፡ መነኮሳት፡ ኤዎስጣቴዎስ፡ መክብበ፡ ቅዱሳን፡ <gap reason="ellipsis" resp="MV"/> 
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፬ ተአምሪሁ፡ ለአብ፡ ክቡር፡ መክብበ፡ መነኮሳት፡ ኤዎስጣቴዎስ፡ መክብበ፡ ቅዱሳን፡ <gap reason="ellipsis" resp="MV"/>
                         ተብህለ፡ ከመ፡ ሀሎ፡ ፩ ብእሲ፡ ቃታሌ፡ ነፍስ፡ ሰብአ፡ ወሠራቂ፡ ወሃያዲ፡ ወባሕቱ፡ ይትአመን፡ በጸሎተ፡ አቡነ፡ ኤዎስጣቴዎስ፡
                         ወይገብር፡ ተዝካሮ፡ ይጠብሕ፡ አልህምተ፡ በዕለተ፡ ተዝካሩ፡ ወእምዝ፡ ሐመ፡ ውእቱ፡ ብእሲ፡ ወነሥኡ፡ ነፍሶ፡ መላእክተ፡ ጽልመት፡ ወተበሃሉ፡ በበይናቲሆሙ፡ 
                     </ab>

--- a/new/LIT6353MEMiracle.xml
+++ b/new/LIT6353MEMiracle.xml
@@ -6,6 +6,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the evil man who was saved from the demons by the saint</title>
+                <title xml:lang="en" xml:id="t2">The murderer who used to give commemorstive feasts in honor of the saint</title>
+                <title xml:id="t3" xml:lang="la">Miraculum de latrone, quem s. Eustathius a daemonibus liberavit</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -47,6 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
             <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,10 +71,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:GrebTiss1935Codices"/>
                         <citedRange unit="page">196</citedRange>
+                        <citedRange unit="item">Vat 46, 2.5 (5th miracle)</citedRange>
                     </bibl>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">130</citedRange>
+                        <citedRange unit="item">EMML 1636 2.3 (3rd miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6353MEMiracle.xml
+++ b/new/LIT6353MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the evil man who was saved by the saint</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (4th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">74-75 (4th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6353MEMiracle.xml
+++ b/new/LIT6353MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6353MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፬ ተአምሪሁ፡ ለአብ፡ ክቡር፡ መክብበ፡ መነኮሳት፡ ኤዎስጣቴዎስ፡ መክብበ፡ ቅዱሳን፡ <gap reason="ellipsis" resp="MV"/>
+                        ተብህለ፡ ከመ፡ ሀሎ፡ ፩ ብእሲ፡ ቃታሌ፡ ነፍስ፡ ሰብአ፡ ወሠራቂ፡ ወሃያዲ፡ ወባሕቱ፡ ይትአመን፡ በጸሎተ፡ አቡነ፡ ኤዎስጣቴዎስ፡
+                        ወይገብር፡ ተዝካሮ፡ ይጠብሕ፡ አልህምተ፡ በዕለተ፡ ተዝካሩ፡ ወእምዝ፡ ሐመ፡ ውእቱ፡ ብእሲ፡ ወነሥኡ፡ ነፍሶ፡ መላእክተ፡ ጽልመት፡ ወተበሃሉ፡ በበይናቲሆሙ፡ 
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ወከማሁ፡ ያድኅኖ፡ በጸሎቱ፡ ቅድስት፡ ለገብሩ፡ <gap reason="ellipsis" resp="MV"/> 
+                        እምዕለት፡ አኪት፡ ወእምሰዓታተ፡ መንሱት። ወእምአፍ፡ ጠንቌሊት፡ ወእምልሳን፡ ዓማፂት፡ አሜን።
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6354MEMiracle.xml
+++ b/new/LIT6354MEMiracle.xml
@@ -75,10 +75,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፭። ተአምሪሁ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ማር፡ <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፭። ተአምሪሁ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ማር፡ <gap reason="ellipsis" resp="MV"/>
                         ወሀሎ፡ ካዕበ፡ ፩ ብእሲ፡ እምሰብአ፡ አፍርንጊ፡ ወእሙሰ፡ እምሰብአ፡ ኣርማንያ። ስምዓ፡ ኮነ፡ ወይቤ፡ ርኢክዎ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ 
                         እንዘ፡ የሐውር፡ ዲበ፡ ባሕር። ወእንዘ፡ የሐውር፡ መጽአ፡ ኀበ፡ ሀገረ፡ አርማንያ፡ ወርእይዎ፡ ማዕከለ፡ ባሕር፡ ሰብአ፡ አርማንያ፡ ዘእንበለ፡ ሐመር፡
                     </ab>

--- a/new/LIT6354MEMiracle.xml
+++ b/new/LIT6354MEMiracle.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (first part of the 5th miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (first part of the 5th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6354MEMiracle.xml
+++ b/new/LIT6354MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how the people of Armenia saw the saint walking on the sea</title>
+                <title xml:lang="en" xml:id="t2">The saint walks on the sea</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,6 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <bibl>
                     <ptr target="bm:EMML5"/>
                     <citedRange unit="page">130</citedRange>
+                    <citedRange unit="item">EMML 1636 2.4 (4th miracle)</citedRange>
                 </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6354MEMiracle.xml
+++ b/new/LIT6354MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the apparition of the saint from the sea to the people of Armenia</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how the people of Armenia saw the saint walking on the sea</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -63,6 +63,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
                         <citedRange unit="page">75-76 (first part of the 5th miracle)</citedRange>
                     </bibl>
+                </listBibl>
+                <listBibl type="secondary">
+                <bibl>
+                    <ptr target="bm:EMML5"/>
+                    <citedRange unit="page">130</citedRange>
+                </bibl>
                 </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6354MEMiracle" passive="LIT4315Miracles"/>

--- a/new/LIT6354MEMiracle.xml
+++ b/new/LIT6354MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: the apparition of the saint from the sea to the people of Armenia</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (first part of the 5th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">75-76 (first part of the 5th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6354MEMiracle.xml
+++ b/new/LIT6354MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6354MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6354MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6354MEMiracle.xml
+++ b/new/LIT6354MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -67,6 +67,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <relation name="saws:formsPartOf" active="LIT6354MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
             </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፭። ተአምሪሁ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ማር፡ <gap reason="ellipsis" resp="MV"/>
+                        ወሀሎ፡ ካዕበ፡ ፩ ብእሲ፡ እምሰብአ፡ አፍርንጊ፡ ወእሙሰ፡ እምሰብአ፡ ኣርማንያ። ስምዓ፡ ኮነ፡ ወይቤ፡ ርኢክዎ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ 
+                        እንዘ፡ የሐውር፡ ዲበ፡ ባሕር። ወእንዘ፡ የሐውር፡ መጽአ፡ ኀበ፡ ሀገረ፡ አርማንያ፡ ወርእይዎ፡ ማዕከለ፡ ባሕር፡ ሰብአ፡ አርማንያ፡ ዘእንበለ፡ ሐመር፡
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ወከማሁ፡ ተወከፎ፡ ለገብረ፡ ክርስቶስ፡ ውስተ፡ ርስቱ፡ ዘለዓለም፡ በመንግሥተ፡ ሰማያት፡ ኀበ፡ ኢይማስን፡ ወኢይበሊ። በረከተ፡
+                        ጸሎቱ፡ ለንዝቱ፡ አብ፡ ተጋደሊ፡ የሃሉ፡ ምስለ፡ ገብሩ፡ <gap reason="ellipsis" resp="MV"/> ለዓለመ፡ ዓለም፡ አሜን።                         
+                    </ab>
+                    </div>
+                </div>
         </body>
     </text>
 </TEI>

--- a/new/LIT6355MEMiracle.xml
+++ b/new/LIT6355MEMiracle.xml
@@ -75,10 +75,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፮። ተአምሪሁ፡ ለአቡነ፡ ዝንቱ፡ ክቡር፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዘበእንተ፡ ጽድቅ፡ ነጋዲ፡ <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፮። ተአምሪሁ፡ ለአቡነ፡ ዝንቱ፡ ክቡር፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዘበእንተ፡ ጽድቅ፡ ነጋዲ፡ <gap reason="ellipsis" resp="MV"/>
                         ወኮነ፡ እምቅድመ፡ ይሙት፡ ገብረ፡ ክርስቶስ፡ አዘዞ፡ ለወልዱ፡ ተአማኒ፡ በእግዚእ። ወይቤሎ፡ አምጣነ፡ ብከ፡ ወትክል፡ ወሂበ፡ ኢታፅርዕ፡ ገቢረ፡ ተዝካሩ፡ ለአቡነ፡ 
                         ኤዎስጣቴዎስ፡ ወስምዓ፡ ቃለ፡ አቡሁ። ወገብረ፡ ተዝካሮ፡ በአስተሐምሞ፡ ወበሃይማኖት፡
                     </ab>

--- a/new/LIT6355MEMiracle.xml
+++ b/new/LIT6355MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Taʾamāni Baʾǝgziʾ succeeded to observe the saint's commemoration</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Gabra Krǝstos ordered his son Taʾamāni Baʾǝgziʾ to observe the saint's commemoration</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -64,6 +64,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <citedRange unit="page">76-77 (second part of the 5th miracle)</citedRange>
                     </bibl>
                 </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">130</citedRange>
+                    </bibl>
+                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6355MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
@@ -73,7 +79,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
                         ፮። ተአምሪሁ፡ ለአቡነ፡ ዝንቱ፡ ክቡር፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዘበእንተ፡ ጽድቅ፡ ነጋዲ፡ <gap reason="ellipsis" resp="MV"/>
-                        ወኮነ፡ እምቅድመ፡ ይሙት፡ ገብረ፡ ክርስቶስ፡ አዘዞ፡ ለወልዱ፡ ተአማኒ፡ በእግዚአ። ወይቤሎ፡ አምጣነ፡ ብከ፡ ወትክል፡ ወሂበ፡ ኢታፅርዕ፡ ገቢረ፡ ተዝካሩ፡ ለአቡነ፡ 
+                        ወኮነ፡ እምቅድመ፡ ይሙት፡ ገብረ፡ ክርስቶስ፡ አዘዞ፡ ለወልዱ፡ ተአማኒ፡ በእግዚእ። ወይቤሎ፡ አምጣነ፡ ብከ፡ ወትክል፡ ወሂበ፡ ኢታፅርዕ፡ ገቢረ፡ ተዝካሩ፡ ለአቡነ፡ 
                         ኤዎስጣቴዎስ፡ ወስምዓ፡ ቃለ፡ አቡሁ። ወገብረ፡ ተዝካሮ፡ በአስተሐምሞ፡ ወበሃይማኖት፡
                     </ab>
                 </div>

--- a/new/LIT6355MEMiracle.xml
+++ b/new/LIT6355MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Taʾamāni Baʾǝgziʾ could observe the saint's commemoration</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (second part of the 5th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">76-77 (second part of the 5th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6355MEMiracle.xml
+++ b/new/LIT6355MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6355MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፮። ተአምሪሁ፡ ለአቡነ፡ ዝንቱ፡ ክቡር፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዘበእንተ፡ ጽድቅ፡ ነጋዲ፡ <gap reason="ellipsis" resp="MV"/>
+                        ወኮነ፡ እምቅድመ፡ ይሙት፡ ገብረ፡ ክርስቶስ፡ አዘዞ፡ ለወልዱ፡ ተአማኒ፡ በእግዚአ። ወይቤሎ፡ አምጣነ፡ ብከ፡ ወትክል፡ ወሂበ፡ ኢታፅርዕ፡ ገቢረ፡ ተዝካሩ፡ ለአቡነ፡ 
+                        ኤዎስጣቴዎስ፡ ወስምዓ፡ ቃለ፡ አቡሁ። ወገብረ፡ ተዝካሮ፡ በአስተሐምሞ፡ ወበሃይማኖት፡
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        በጸሎቱ፡ ወበረከቱ፡ ለዝንቱ፡ ቅዱስ፡ ይዕቀቦ፡ ለገብሩ፡ <gap reason="ellipsis" resp="MV"/>
+                        በሥጋ፡ ወነፍሱ፡ እስከ፡ ደኃሪት፡ እስትንፋስ። ለዓለመ፡ ዓለም፡ አሜን።
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6355MEMiracle.xml
+++ b/new/LIT6355MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6355MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6355MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6355MEMiracle.xml
+++ b/new/LIT6355MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Gabra Krǝstos ordered his son Taʾamāni Baʾǝgziʾ to observe the saint's commemoration</title>
+                <title xml:lang="en" xml:id="t2">Gabra Krǝstos orders his son to commemorate the days dedicated to the saint</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,6 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">130</citedRange>
+                        <citedRange unit="item">EMML 1636 2.5 (5th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6355MEMiracle.xml
+++ b/new/LIT6355MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Taʾamāni Baʾǝgziʾ could observe the saint's commemoration</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Taʾamāni Baʾǝgziʾ succeeded to observe the saint's commemoration</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (second part of the 5th miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (second part of the 5th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6356MEMiracle.xml
+++ b/new/LIT6356MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6356MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፯ ተአምሪሁ፡ ለዝንቱ፡ አብ፡ ክቡር፡ መንፈሳዊ፡ ኤዎስጣቴዎስ፡ ኖላዊ። <gap reason="ellipsis" resp="MV"/>
+                        ወኮነ፡ ካዕበ፡ ዘእንበለ፡ ይሙት፡ ተአሚኖ፡ በእግዚእ፡ አዘዞ፡ ለወልዱ፡ ብርሃነ፡ መስቀል፡ ይግበር፡ በአስተሐምሞ፡ ተዝካረ፡ አቡነ፡ ኤዎስጣቴዎስ፡ 
+                        ውእቱሂ፡ ተወክፈ፡ ነገሮ፡ ወአኃዘ፡ ይግበር፡ ተዝካሮ፡ ለለዓመት፡ በተአምኖ፡ ወበጻሕቅ፡ ነቢረ፡ በክብር፡ ወበብዕል። ወእምዝ፡ አመከሮ፡ እግዚአብሔር።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ረድኤተ፡ ጸሎቱ፡ የሃሉ፡ ምስለ፡ <gap reason="ellipsis" resp="MV"/> የሐድፋ፡ ከመ፡ ብርሃነ፡ መስቀል፡ ወይትወከፋ። እንዘ፡ ይሰፍሕ፡ ዓጽፋ፡
+                        እም፡ ሞገደ፡ አዝማን፡ ይሕልፋ። በመንግሥተ፡ ሰማያት፡ ውስተ፡ ሕፅኑ፡ ያዕርፋ። አሜን።                      
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6356MEMiracle.xml
+++ b/new/LIT6356MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Bǝrhāna Masqal succeeded to observe the saint's commemoration</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Taʾammino Baʾǝgziʾ ordered his son Bǝrhāna Masqal to observe the saint's commemoration</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -52,6 +52,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="bibliography">
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">131</citedRange>
+                    </bibl>
+                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6356MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>

--- a/new/LIT6356MEMiracle.xml
+++ b/new/LIT6356MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Bǝrhāna Masqal could observe the saint's commemoration</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -51,18 +51,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="bibliography">
-                <listBibl type="editions">
-                    <bibl>
-                        <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
-                    </bibl>
-                </listBibl>
-                <listBibl type="translation">
-                    <bibl>
-                        <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
-                    </bibl>
-                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6356MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>

--- a/new/LIT6356MEMiracle.xml
+++ b/new/LIT6356MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Bǝrhāna Masqal could observe the saint's commemoration</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Bǝrhāna Masqal succeeded to observe the saint's commemoration</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT6356MEMiracle.xml
+++ b/new/LIT6356MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6356MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6356MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6356MEMiracle.xml
+++ b/new/LIT6356MEMiracle.xml
@@ -63,10 +63,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፯ ተአምሪሁ፡ ለዝንቱ፡ አብ፡ ክቡር፡ መንፈሳዊ፡ ኤዎስጣቴዎስ፡ ኖላዊ። <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፯ ተአምሪሁ፡ ለዝንቱ፡ አብ፡ ክቡር፡ መንፈሳዊ፡ ኤዎስጣቴዎስ፡ ኖላዊ። <gap reason="ellipsis" resp="MV"/>
                         ወኮነ፡ ካዕበ፡ ዘእንበለ፡ ይሙት፡ ተአሚኖ፡ በእግዚእ፡ አዘዞ፡ ለወልዱ፡ ብርሃነ፡ መስቀል፡ ይግበር፡ በአስተሐምሞ፡ ተዝካረ፡ አቡነ፡ ኤዎስጣቴዎስ፡ 
                         ውእቱሂ፡ ተወክፈ፡ ነገሮ፡ ወአኃዘ፡ ይግበር፡ ተዝካሮ፡ ለለዓመት፡ በተአምኖ፡ ወበጻሕቅ፡ ነቢረ፡ በክብር፡ ወበብዕል። ወእምዝ፡ አመከሮ፡ እግዚአብሔር።
                     </ab>

--- a/new/LIT6356MEMiracle.xml
+++ b/new/LIT6356MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how Taʾammino Baʾǝgziʾ ordered his son Bǝrhāna Masqal to observe the saint's commemoration</title>
+                <title xml:lang="en" xml:id="t2">Taʾammino Baʾǝgziʾ orders his son, Bǝrhāna Masqal, to commemorate the days dedicated to the saint</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Fixed title</change>
+            <change who="MV" when="2021-01-21">Fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -56,6 +58,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">131</citedRange>
+                        <citedRange unit="item">EMML 1636 2.6 (6th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6357MEMiracle.xml
+++ b/new/LIT6357MEMiracle.xml
@@ -75,10 +75,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፰። ተአምሪሁ፡ ለአብ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፰። ተአምሪሁ፡ ለአብ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
                         ተብህለ፡ ከመ፡ ሀሎ፡ ፩ መነኮስ፡ ዘይነብር፡ ውስተ፡ ፈለግ፡ እንተ፡ ትሰመይ፡ ሮማ። ወክቡር፡ ውእቱ፡ መነኮስ፡ በኀበ፡ 
                         እግዚአብሔር፡ ወምንኵስናሁሰ፡ በውስተ፡ ደብረ፡ አባ፡ ተክለ፡ ሃይማኖት፡ እንተ፡ ትሰመይ፡ ደብረ፡ ሊባኖስ፡ ወመነኮሰ፡ 
                         በውስቴታ፡ እምኀበ፡ አባ፡ እንድርያስ።

--- a/new/LIT6357MEMiracle.xml
+++ b/new/LIT6357MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the monk who lived near the Romā river</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (8th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">81-83 (8th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6357MEMiracle.xml
+++ b/new/LIT6357MEMiracle.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (8th miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (8th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6357MEMiracle.xml
+++ b/new/LIT6357MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how a monk who lived near the Romā river told the governor about the greatness of the saint</title>
+                <title xml:lang="en" xml:id="t2">A monk from Dabra Libānos, i.e., a follower of ʾAbuna Takla Hāymānot, tells Gabra Bǝrhān, the governor of Goǧǧām (G<hi rend="apex">w</hi>azzān Nagāśi), about the greatness of Mār ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,6 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">131</citedRange>
+                        <citedRange unit="item">EMML 1636 2.7 (7th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6357MEMiracle.xml
+++ b/new/LIT6357MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6357MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6357MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6357MEMiracle.xml
+++ b/new/LIT6357MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the monk who lived near the Romā river</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how a monk who lived near the Romā river told the governor about the greatness of the saint</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -62,6 +62,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
                         <citedRange unit="page">81-83 (8th miracle)</citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">131</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6357MEMiracle.xml
+++ b/new/LIT6357MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6357MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፰። ተአምሪሁ፡ ለአብ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
+                        ተብህለ፡ ከመ፡ ሀሎ፡ ፩ መነኮስ፡ ዘይነብር፡ ውስተ፡ ፈለግ፡ እንተ፡ ትሰመይ፡ ሮማ። ወክቡር፡ ውእቱ፡ መነኮስ፡ በኀበ፡ 
+                        እግዚአብሔር፡ ወምንኵስናሁሰ፡ በውስተ፡ ደብረ፡ አባ፡ ተክለ፡ ሃይማኖት፡ እንተ፡ ትሰመይ፡ ደብረ፡ ሊባኖስ፡ ወመነኮሰ፡ 
+                        በውስቴታ፡ እምኀበ፡ አባ፡ እንድርያስ።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ወባሕቱ፡ እስመ፡ ኮነ፡ እምደቂቀ፡ ተክለ፡ ሃይማኖት፡ ውእቱ፡ መነኮስ፡ ዘዜነወኒ፡ ዕበዮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ጸሎቱ፡ ወበረከቱ፡
+                        የሃሉ፡ ምስለ፡ <gap reason="ellipsis" resp="MV"/> በረድኤቱ፡ ይሰወቁ። ውስተ፡ መሥገርተ፡ አርዌ፡ ከመ፡ ኢይደቁ።
+                        ለዓለመ፡ ዓለም፡ አሜን።                            
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6358MEMiracle.xml
+++ b/new/LIT6358MEMiracle.xml
@@ -5,7 +5,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how the saint appeared and saved a pious priest who was being slendered before the king</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how the saint appeared and saved a pious priest who was being slandered before the king</title>
+                <title xml:lang="en" xml:id="t2">A priest monk is saved from his enemy, who wanted to take his office by slandering him to the King</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -52,6 +53,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="bibliography">
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">131</citedRange>
+                        <citedRange unit="item">EMML 1636 2.8 (8th miracle)</citedRange>
+                    </bibl>
+                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6358MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>

--- a/new/LIT6358MEMiracle.xml
+++ b/new/LIT6358MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6358MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፱። ተአምሪሁ፡ ለአቡነ፡ ኤዎሥጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/> ተብህለ፡ ከመ፡ ሀሎ፡ ፩ መነኮስ፡ ቀሲስ፡ ወአበ፡ ምኔት፡ ውእቱ። 
+                        ወኮነ፡ ያፈቅሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ይትመኃፀን፡ በጸሎቱ፡ ወኢያበጥል፡ ዝክረ፡ ስሙ፡ እምአፉሁ፡ በንብረቱ፡ ወበተንሥአቱ። 
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        እስመ፡ ያፈጥን፡ ረዲዓ፡ ለእለ፡ ጸውዑ፡ ስሞ። በረከተ፡ ጸጋሁ፡ የሃሉ፡ ምስለ፡ <gap reason="ellipsis" resp="MV"/>
+                        ይኩና፡ <unclear unit="chars" quantity="1" resp="MV"/>ቃቤ፡ ወይበልሐ፡ እምኵሉ፡ ምንዳቤ። አሜን።
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6358MEMiracle.xml
+++ b/new/LIT6358MEMiracle.xml
@@ -51,18 +51,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="bibliography">
-                <listBibl type="editions">
-                    <bibl>
-                        <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
-                    </bibl>
-                </listBibl>
-                <listBibl type="translation">
-                    <bibl>
-                        <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
-                    </bibl>
-                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6358MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>

--- a/new/LIT6358MEMiracle.xml
+++ b/new/LIT6358MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6358MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6358MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6358MEMiracle.xml
+++ b/new/LIT6358MEMiracle.xml
@@ -57,10 +57,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፱። ተአምሪሁ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፱። ተአምሪሁ፡ ለአቡነ፡ ኤዎሥጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/> ተብህለ፡ ከመ፡ ሀሎ፡ ፩ መነኮስ፡ ቀሲስ፡ ወአበ፡ ምኔት፡ ውእቱ። 
+                        ተብህለ፡ ከመ፡ ሀሎ፡ ፩ መነኮስ፡ ቀሲስ፡ ወአበ፡ ምኔት፡ ውእቱ። 
                         ወኮነ፡ ያፈቅሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ይትመኃፀን፡ በጸሎቱ፡ ወኢያበጥል፡ ዝክረ፡ ስሙ፡ እምአፉሁ፡ በንብረቱ፡ ወበተንሥኦቱ። 
                     </ab>
                 </div>

--- a/new/LIT6358MEMiracle.xml
+++ b/new/LIT6358MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how the saint appeared and saved a pious priest who was being slendered before the king</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -60,7 +61,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
                         ፱። ተአምሪሁ፡ ለአቡነ፡ ኤዎሥጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/> ተብህለ፡ ከመ፡ ሀሎ፡ ፩ መነኮስ፡ ቀሲስ፡ ወአበ፡ ምኔት፡ ውእቱ። 
-                        ወኮነ፡ ያፈቅሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ይትመኃፀን፡ በጸሎቱ፡ ወኢያበጥል፡ ዝክረ፡ ስሙ፡ እምአፉሁ፡ በንብረቱ፡ ወበተንሥአቱ። 
+                        ወኮነ፡ ያፈቅሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ይትመኃፀን፡ በጸሎቱ፡ ወኢያበጥል፡ ዝክረ፡ ስሙ፡ እምአፉሁ፡ በንብረቱ፡ ወበተንሥኦቱ። 
                     </ab>
                 </div>
                 <div type="textpart" subtype="explicit" xml:lang="gez">

--- a/new/LIT6359MEMiracle.xml
+++ b/new/LIT6359MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6359MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6359MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6359MEMiracle.xml
+++ b/new/LIT6359MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6359MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲። ተአምሪሁ፡ ለአብ፡ ክቡር፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዓምድ፡ ዓቢይ፡ ዘብሔረ፡ ኢትዮጵያ። <gap reason="ellipsis" resp="MV"/>
+                        ወሀሎ፡ ፪ ብእሲ፡ በብሔረ፡ አክሱም። ዘኮነ፡ ያፈቅሮ፡ ለአቡነ፡ ወይገብር፡ ተዝካሮ፡ በጻሕቅ፡ ወበዓቢይ፡ አስተሐምሞ። ወበአሐቲ፡ 
+                        ዕለት፡ ሖረ፡ ፍኖተ፡ ኀበ፡ ትካዙ፡ ወእንዘ፡ ሀሎ፡ ውስተ፡ ፍኖት፡ እንበለ፡ ይብጻሕ፡ ሀገረ፡ ጸልመ፡ መዓልት፡ በቅድሜሁ፡ ወተከድነ፡ 
+                        ሰማይ፡ በዎባር፡ ጸሊም፡ እስመ፡ መዋዕለ፡ ክረምት፡ ውእቱ።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        እምአሜሃ፡ ዕለት፡ አፈድፈደ፡ ውእቱ፡ ብእሲ፡ ገቢረ፡ ተዝካሩ፡ እምዘ፡ ኮነ፡ ቀዳሚ፡ ይገብሮ፡ ወይጼውዕ፡ ሰብአ፡ ኀበ፡ ገቢረ፡ ተዝካሩ፡ ለአቡነ፡ 
+                        ኤዎስጣቴዎስ፡ በረከተ፡ ጸጋሁ፡ የሃሉ፡ ምስለ፡ <gap reason="ellipsis" resp="MV"/>
+                        ዘወረሰት፡ መንበሮ፡ ይትከዓው፡ ዲቤሃ፡ መንፈሰ፡ አእምሮ። ወበመንግሥተ፡ ሰማያት፡ ውስተ፡ ሕጽኑ፡ ያርፍቃ፡ ወያሕድራ፡ አሜን።
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6359MEMiracle.xml
+++ b/new/LIT6359MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how a man from ʾAksum was saved from the downpour during his journey</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (9th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">83-84 (9th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6359MEMiracle.xml
+++ b/new/LIT6359MEMiracle.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (9th miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (9th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6359MEMiracle.xml
+++ b/new/LIT6359MEMiracle.xml
@@ -64,6 +64,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <citedRange unit="page">83-84 (9th miracle)</citedRange>
                     </bibl>
                 </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">131</citedRange>
+                    </bibl>
+                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6359MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>

--- a/new/LIT6359MEMiracle.xml
+++ b/new/LIT6359MEMiracle.xml
@@ -75,13 +75,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲። ተአምሪሁ፡ ለአብ፡ ክቡር፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዓምድ፡ ዓቢይ፡ ዘብሔረ፡ ኢትዮጵያ። <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፲። ተአምሪሁ፡ ለአብ፡ ክቡር፡ አቡነ፡ ኤዎስጣቴዎስ፡ ዓምድ፡ ዓቢይ፡ ዘብሔረ፡ ኢትዮጵያ። <gap reason="ellipsis" resp="MV"/>
                         ወሀሎ፡ ፪ ብእሲ፡ በብሔረ፡ አክሱም። ዘኮነ፡ ያፈቅሮ፡ ለአቡነ፡ ወይገብር፡ ተዝካሮ፡ በጻሕቅ፡ ወበዓቢይ፡ አስተሐምሞ። ወበአሐቲ፡ 
                         ዕለት፡ ሖረ፡ ፍኖተ፡ ኀበ፡ ትካዙ፡ ወእንዘ፡ ሀሎ፡ ውስተ፡ ፍኖት፡ እንበለ፡ ይብጻሕ፡ ሀገረ፡ ጸልመ፡ መዓልት፡ በቅድሜሁ፡ ወተከድነ፡ 
-                        ሰማይ፡ በዎባር፡ ጸሊም፡ እስመ፡ መዋዕለ፡ ክረምት፡ ውእቱ።
+                        ሰማይ፡ በቆባር፡ ጸሊም፡ እስመ፡ መዋዕለ፡ ክረምት፡ ውእቱ።
                     </ab>
                 </div>
                 <div type="textpart" subtype="explicit" xml:lang="gez">

--- a/new/LIT6359MEMiracle.xml
+++ b/new/LIT6359MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how a man from ʾAksum was saved from the downpour during his journey</title>
+                <title xml:lang="en" xml:id="t2">A man from Axum is saved from heavy rain and thunderstorms</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,6 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">131</citedRange>
+                        <citedRange unit="item">EMML 1636 2.9 (9th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6360MEMiracle.xml
+++ b/new/LIT6360MEMiracle.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (10th miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (10th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6360MEMiracle.xml
+++ b/new/LIT6360MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the blind woman from ʾAksum who recovered her sight</title>
+                <title xml:lang="en" xml:id="t2">The blind woman from Axum who recovered her sight</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,6 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">131</citedRange>
+                        <citedRange unit="item">EMML 1636 2.10 (10th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6360MEMiracle.xml
+++ b/new/LIT6360MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the blind woman who was healed by the saint</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (10th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">84 (10th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6360MEMiracle.xml
+++ b/new/LIT6360MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the blind woman who was healed by the saint</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the blind woman from ʾAksum who recovered her sight</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -62,6 +62,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
                         <citedRange unit="page">84 (10th miracle)</citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">131</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6360MEMiracle.xml
+++ b/new/LIT6360MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6360MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6360MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6360MEMiracle.xml
+++ b/new/LIT6360MEMiracle.xml
@@ -75,10 +75,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲፩። ተአምሪሁ፡ ለአብ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፲፩። ተአምሪሁ፡ ለአብ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
                         ተብህለ፡ ከመ፡ ሀለወት፡ ብእሲት፡ በአክሱም፡ ሀገረ፡ ንጉሥ፡ እንተ፡ ኮነት፡ ትገብር፡ ተዝካሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ በበዓመት፡
                         ዘውእቱ፡ አመ፡ ፲ወ፰ ለመስከረም፡ እንዘ፡ ታጸግብ፡ ርኁባነ፡ ወእንዘ፡ ታረዊ፡ ፅሙዓነ፡ ወትሁብ፡ ምጽዋት፡
                     </ab>

--- a/new/LIT6360MEMiracle.xml
+++ b/new/LIT6360MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6360MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲፩። ተአምሪሁ፡ ለአብ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
+                        ተብህለ፡ ከመ፡ ሀለወት፡ ብእሲት፡ በአክሱም፡ ሀገረ፡ ንጉሥ፡ እንተ፡ ኮነት፡ ትገብር፡ ተዝካሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ በበዓመት፡
+                        ዘውእቱ፡ አመ፡ ፲ወ፰ ለመስከረም፡ እንዘ፡ ታጸግብ፡ ርኁባነ፡ ወእንዘ፡ ታረዊ፡ ፅሙዓነ፡ ወትሁብ፡ ምጽዋት፡
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        በጸሎቱ፡ ለቅዱስ፡ ኤዎስጣቴዎስ፡ እስመ፡ ጸሎተ፡ ጻድቅ፡ ትረድእ፡ ትክል፡ ወታስልጥ። በረከተ፡ ጸሎቱ፡ የሃሉ፡ ምስለ፡ <gap reason="ellipsis" resp="MV"/> 
+                        እንበለ፡ ተፈልጦ። ኃይለ፡ ጸላዒ፡ ከመ፡ ኢይምስግ። ታሕተ፡ እገሪሁ፡ ፍጡነ፡ ይቀጥቅጦ። አሜን።
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6361MEMiracle.xml
+++ b/new/LIT6361MEMiracle.xml
@@ -63,10 +63,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲ወ፪። ተአምሪሁ፡ ለአቡነ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ ነቢይ፡ ወሐዋርያ፡ ድንግል፡ ወካህን። <gap reason="ellipsis" resp="MV"/>           
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
-                    <ab>
-                        ፲ወ፪። ተአምሪሁ፡ ለአቡነ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ ነቢይ፡ ወሐዋርያ፡ ድንግል፡ ወካህን። <gap reason="ellipsis" resp="MV"/>                 
+                    <ab>   
                         ወካዕበ፡ ተብህለ፡ በእንተ፡ ፩ መነኮስ፡ ዘኮነ፡ ያፈቅሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ስዩመ፡ ውእቱ፡ ላዕለ፡ ደብሩ፡ ወሀለዉ፡ መነኮሳት፡ 
                         እለ፡ ኮኑ፡ ይጸልዕዎ፡ ወዓርጉ፡ ኀበ፡ ንጉሥ፡ ያስተዋድይዎ፡ ከመ፡ ያዕትቶ፡ እምኔሆሙ፡ ወይሢም፡ ሎሙ፡ ካልአ።
                     </ab>

--- a/new/LIT6361MEMiracle.xml
+++ b/new/LIT6361MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the pious monk who was unjustly imprisoned and was rescued by the saint's appearance</title>
+                <title xml:lang="en" xml:id="t2">The abbot who was imprisoned unjustly</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Fixed title</change>
+            <change who="MV" when="2021-01-21">Fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -56,6 +58,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">131</citedRange>
+                        <citedRange unit="item">EMML 1636 2.11 (11th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6361MEMiracle.xml
+++ b/new/LIT6361MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6361MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲ወ፪። ተአምሪሁ፡ ለአቡነ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ ነቢይ፡ ወሐዋርያ፡ ድንግል፡ ወካህን። <gap reason="ellipsis" resp="MV"/>                 
+                        ወካዕበ፡ ተብህለ፡ በእንተ፡ ፩ መነኮስ፡ ዘኮነ፡ ያፈቅሮ፡ ለአቡነ፡ ኤዎስጣቴዎስ፡ ስዩመ፡ ውእቱ፡ ላዕለ፡ ደብሩ፡ ወሀለዉ፡ መነኮሳት፡ 
+                        እለ፡ ኮኑ፡ ይጸልዕዎ፡ ወዓርጉ፡ ኀበ፡ ንጉሥ፡ ያስተዋድይዎ፡ ከመ፡ ያዕትቶ፡ እምኔሆሙ፡ ወይሢም፡ ሎሙ፡ ካልአ።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ወሎቱሰ፡ ፈትሖ፡ እምነ፡ ሞቅሕ፡ ወሜጦ፡ ኀበ፡ ክብሩ፡ ዘቀዳሚ፡ ምስለ፡ እኁሁ፡ ወምስለ፡ ኵሎሙ፡ ደቂቁ፡ እለ፡ ፃመዉ፡ ምስሌሁ፡ እስመ፡ ይተነብል፡ 
+                        ወትረ፡ ቅድመ፡ እግዚአብሔር፡ በእንተ፡ እለ፡ ይገብሩ፡ ተዝካሮ፡ ወይጼውዑ፡ ስሞ። ትንብልናሁ፡ ይርድኦ፡ ለገብሩ፡
+                        <gap reason="ellipsis" resp="MV"/> ይእዜ። ወኢያጸርዕ፡ ዐቂቦቱ፡ በኵሉ፡ ጊዜ፡ አሜን።
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6361MEMiracle.xml
+++ b/new/LIT6361MEMiracle.xml
@@ -51,18 +51,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="bibliography">
-                <listBibl type="editions">
-                    <bibl>
-                        <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
-                    </bibl>
-                </listBibl>
-                <listBibl type="translation">
-                    <bibl>
-                        <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
-                    </bibl>
-                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6361MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>

--- a/new/LIT6361MEMiracle.xml
+++ b/new/LIT6361MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the pious monk who was rescued by the saint's appearance</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the pious monk who was unjustly imprisoned and was rescued by the saint's appearance</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -52,6 +52,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="bibliography">
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">131</citedRange>
+                    </bibl>
+                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6361MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>

--- a/new/LIT6361MEMiracle.xml
+++ b/new/LIT6361MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the pious monk who was rescued by the saint's appearance</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT6361MEMiracle.xml
+++ b/new/LIT6361MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6361MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6361MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6362MEMiracle.xml
+++ b/new/LIT6362MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6362MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲፫። ተአምሪሁ፡ ለአብ፡ ማር፡ ኤዎስጣቴዎስ፡ ኖላዌ፡ ኖሎት፡ ዘውእቱ፡ አርሳይ፡ መቅርደስ፡ <gap reason="ellipsis" resp="MV"/>
+                        ተብህለ፡ ከመ፡ ሀለወት፡ አሐቲ፡ ሀገር፡ እምርት፡ እምአህጉረ፡ ኢትዮጵያ። ወሀለዉ፡ ውስቴታ፡ ሰብእ፡ ኄራን፡ እለ፡ ኮኑ፡ ያፈቅርዎ፡ ለዝንቱ፡ ብፁዓዊ፡
+                        ኤዎስጣቴዎስ፡ ተዘኪሮሙ፡ ንግደቶ፡ ዘበእንተ፡ ጽፍቅ፡ ይገብሩ፡ ተዝካሮ፡ በጾም፡ ወበጸሎት፡ በትጋህ፡ ወስብሐት፡ በውሂበ፡ ምጽዋት፡
+                        ወበአዕርጎ፡ መሥዋዕት።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ወዛቲ፡ ትእምርት፡ ኮነት፡ ልማደ፡ እስከ፡ ዮም፡ በእንተ፡ ፍቅሩ፡ ለቅዱስ፡ ኤዎስጣቴዎስ፡ በረከተ፡ ጸሎቱ፡ ወሀብተ፡ ረድኤቱ፡
+                        ወምሕረተ፡ አምላኩ፡ የሃሉ፡ ምስለ፡ <gap reason="ellipsis" resp="MV"/> ለዓለመ፡ ዓለም፡ አሜን።
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6362MEMiracle.xml
+++ b/new/LIT6362MEMiracle.xml
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (11th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">84-85 (11th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6362MEMiracle.xml
+++ b/new/LIT6362MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how God granted the rain over the country of the pious men</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the people of a certain district of Ethiopia who never suffered from drought or famine</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -62,6 +62,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
                         <citedRange unit="page">84-85 (11th miracle)</citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">131</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6362MEMiracle.xml
+++ b/new/LIT6362MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6362MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6362MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6362MEMiracle.xml
+++ b/new/LIT6362MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the people of a certain district of Ethiopia who never suffered from drought or famine</title>
+                <title xml:lang="en" xml:id="t2">The people of a certain distict of Ethiopia who never suffered from drought or famine</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,6 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">131</citedRange>
+                        <citedRange unit="item">EMML 1636 2.12 (12th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6362MEMiracle.xml
+++ b/new/LIT6362MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how God granted the rain over the country of the pious men</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (11th miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (11th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6362MEMiracle.xml
+++ b/new/LIT6362MEMiracle.xml
@@ -75,10 +75,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲፫። ተአምሪሁ፡ ለአብ፡ ማር፡ ኤዎስጣቴዎስ፡ ኖላዌ፡ ኖሎት፡ ዘውእቱ፡ አርሳይ፡ መቅርደስ፡ <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፲፫። ተአምሪሁ፡ ለአብ፡ ማር፡ ኤዎስጣቴዎስ፡ ኖላዌ፡ ኖሎት፡ ዘውእቱ፡ አርሳይ፡ መቅርደስ፡ <gap reason="ellipsis" resp="MV"/>
                         ተብህለ፡ ከመ፡ ሀለወት፡ አሐቲ፡ ሀገር፡ እምርት፡ እምአህጉረ፡ ኢትዮጵያ። ወሀለዉ፡ ውስቴታ፡ ሰብእ፡ ኄራን፡ እለ፡ ኮኑ፡ ያፈቅርዎ፡ ለዝንቱ፡ ብፁዓዊ፡
                         ኤዎስጣቴዎስ፡ ተዘኪሮሙ፡ ንግደቶ፡ ዘበእንተ፡ ጽፍቅ፡ ይገብሩ፡ ተዝካሮ፡ በጾም፡ ወበጸሎት፡ በትጋህ፡ ወስብሐት፡ በውሂበ፡ ምጽዋት፡
                         ወበአዕርጎ፡ መሥዋዕት።

--- a/new/LIT6363MEMiracle.xml
+++ b/new/LIT6363MEMiracle.xml
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"><!-- page range --> (12th miracle)</citedRange>
+                        <citedRange unit="page"><!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 --> (12th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">

--- a/new/LIT6363MEMiracle.xml
+++ b/new/LIT6363MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the saint's apparition at his sepulchre in Armenia</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Added bibliography</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -54,13 +55,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listBibl type="editions">
                     <bibl>
                         <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page"><!-- page range --> (12th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listBibl type="translation">
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
+                        <citedRange unit="page">85-86 (12th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6363MEMiracle.xml
+++ b/new/LIT6363MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6363MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6363MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6363MEMiracle.xml
+++ b/new/LIT6363MEMiracle.xml
@@ -75,10 +75,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲፬ ተአምሪሁ፡ ለአቡነ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፲፬ ተአምሪሁ፡ ለአቡነ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
                         ስምዑ፡ ካዕበ፡ ዘኮነ፡ ተአምረ፡ በብሔረ፡ አርማንያ፡ እምድኅረ፡ አዕረፈ፡ አቡነ፡ ኤዎስጣቴዎስ፡
                         ነሥኡ፡ ሥጋሁ፡ ሰብእ፡ መሃይምናን፡ መፍቀርያነ፡ እግዚአብሔር፡ ገነዝዎ፡ በሕገ፡ ክርስቲያን። ወወደይዎ፡ ውስተ፡ መቃብር፡ ዘሐነፁ፡ ሎቱ፡
                         በአዕባን፡ አፍራፅ፡ ክቡራት፡ እለ፡ ያንጸበርቃ፡ ከመ፡ አዕናቍ፡ ወርቅ፡ ወከመ፡ ብረልያት፡ ቅዕድዋት።
@@ -89,7 +94,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
                         በረከተ፡ ጸሎቱ፡ ወሐብተ፡ ረድኤቱ፡ የሃሉ፡ ምስለ፡ <gap reason="ellipsis" resp="MV"/> ኢይንሥቶሙ፡ በእደ፡ ሰይጣን፡ ይትክሎሙ፡ ወኢይምልሖሙ፡
-                        መዋግደ፡ አዝማን። እስመ፡ ብውህ፡ ሊተ፡ ውእቱ፡ ለሐኒጽ፡ ወለነሲት፡ ለተኪል፡ ወለመሊሕ፡ ከመ፡ ኤርምያስ፡ ካህን።
+                        መዋግደ፡ አዝማን። እስመ፡ ብውህ፡ ሊተ፡ ውእቱ፡ ለሐኒጽ፡ ወለነሲት፡ ለተኪል፡ ወለመሊሕ፡ ከመ፡ ኤር<surplus resp="MV">ይ</surplus>ምያስ፡ ካህን።
                         ዘተሠምየ፡ አረፍተ፡ ብርት፡ ወዓምደ፡ ኃፂን። ለዓለመ፡ ዓለም፡ አሜን።    
                     </ab>
                 </div>

--- a/new/LIT6363MEMiracle.xml
+++ b/new/LIT6363MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the ruler who tried to take stones from the saint's sepulchre</title>
+                <title xml:lang="en" xml:id="t2">Tthe ruler who tried to take stones from the tomb of the saint for a building</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>
+            <change who="MV" when="2021-01-21">Added bibliography, fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -68,6 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">131</citedRange>
+                        <citedRange unit="item">EMML 1636 2.13 (13th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6363MEMiracle.xml
+++ b/new/LIT6363MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the saint's apparition at his sepulchre in Armenia</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: on the ruler who tried to take stones from the saint's sepulchre</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -62,6 +62,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:Turaev1906Ewostatewos"/>
                         <citedRange unit="page">85-86 (12th miracle)</citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">131</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6363MEMiracle.xml
+++ b/new/LIT6363MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,6 +66,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6363MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲፬ ተአምሪሁ፡ ለአቡነ፡ ክቡር፡ ማር፡ ኤዎስጣቴዎስ፡ <gap reason="ellipsis" resp="MV"/>
+                        ስምዑ፡ ካዕበ፡ ዘኮነ፡ ተአምረ፡ በብሔረ፡ አርማንያ፡ እምድኅረ፡ አዕረፈ፡ አቡነ፡ ኤዎስጣቴዎስ፡
+                        ነሥኡ፡ ሥጋሁ፡ ሰብእ፡ መሃይምናን፡ መፍቀርያነ፡ እግዚአብሔር፡ ገነዝዎ፡ በሕገ፡ ክርስቲያን። ወወደይዎ፡ ውስተ፡ መቃብር፡ ዘሐነፁ፡ ሎቱ፡
+                        በአዕባን፡ አፍራፅ፡ ክቡራት፡ እለ፡ ያንጸበርቃ፡ ከመ፡ አዕናቍ፡ ወርቅ፡ ወከመ፡ ብረልያት፡ ቅዕድዋት።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>
+                        This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        በረከተ፡ ጸሎቱ፡ ወሐብተ፡ ረድኤቱ፡ የሃሉ፡ ምስለ፡ <gap reason="ellipsis" resp="MV"/> ኢይንሥቶሙ፡ በእደ፡ ሰይጣን፡ ይትክሎሙ፡ ወኢይምልሖሙ፡
+                        መዋግደ፡ አዝማን። እስመ፡ ብውህ፡ ሊተ፡ ውእቱ፡ ለሐኒጽ፡ ወለነሲት፡ ለተኪል፡ ወለመሊሕ፡ ከመ፡ ኤርምያስ፡ ካህን።
+                        ዘተሠምየ፡ አረፍተ፡ ብርት፡ ወዓምደ፡ ኃፂን። ለዓለመ፡ ዓለም፡ አሜን።    
+                    </ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT6364MEMiracle.xml
+++ b/new/LIT6364MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how the saint saved a monk who had been captured by the pagans near Dabra Bizan</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how the saint saved a monk from Dabra Bizan who had been taken captive by slave hunters</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -52,6 +52,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="bibliography">
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:EMML5"/>
+                        <citedRange unit="page">131</citedRange>
+                    </bibl>
+                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6364MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>

--- a/new/LIT6364MEMiracle.xml
+++ b/new/LIT6364MEMiracle.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6364MEMiracle" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Hagiography"/>
+                    <term key="Miracle"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2021-01-20">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Turaiev1905Eustathii"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listBibl type="translation">
+                    <bibl>
+                        <ptr target="bm:Turaev1906Ewostatewos"/>
+                        <citedRange unit="page"></citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6364MEMiracle" passive="LIT4315Miracles"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6364MEMiracle.xml
+++ b/new/LIT6364MEMiracle.xml
@@ -63,10 +63,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </div>
             <div type="edition">
+                <div type="textpart" subtype="title" xml:lang="gez">
+                    <note>This title is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲፭። ተአምሪሁ፡ ዘገብረ፡ አቡነ፡ ኤዎስጣቴዎስ። ውስተ፡ ደብረ፡ ቢዘን።
+                    </ab>
+                </div>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
                     <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
                     <ab>
-                        ፲፭። ተአምሪሁ፡ ዘገብረ፡ አቡነ፡ ኤዎስጣተዎስ። ውስተ፡ ደብረ፡ ቢዘን። ወሖረ፡ ፩ መነኮስ፡ ከመ፡ ይቅዳሕ፡ ማየ፡ ዘይከውን፡ ለገቢረ፡ ተዝካሩ። ወሶበ፡ ረከብዎ፡ 
+                        ወሖረ፡ ፩ መነኮስ፡ ከመ፡ ይቅዳሕ፡ ማየ፡ ዘይከውን፡ ለገቢረ፡ ተዝካሩ። ወሶበ፡ ረከብዎ፡ 
                         አረማውያን፡ ወሰድዎ፡ አሢሮሙ፡ ከመ፡ ይሢጥዎ። ወሶበ፡ ስምዑ፡ አኃዊሁ፡ ዓውየዉ፡ ወመነኮሳትሂ፡ አብዝኁ፡ ብካየ፡ ገዓረ፡ ወጸልዩ፡ ወተማኅፀንዎ፡
                         ለአቡነ፡ ኤዎስጣቴዎስ፡ ወሰከይዎ፡ ኀበ፡ እግዚአብሔር፡ እንዘ፡ ይብሉ።
                     </ab>

--- a/new/LIT6364MEMiracle.xml
+++ b/new/LIT6364MEMiracle.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how the saint saved a monk from Dabra Bizan who had been taken captive by slave hunters</title>
+                <title xml:lang="en" xml:id="t2">The monk of Dabra Bizan who was taken captive by slave hunters while he was fetching water</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +47,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
-            <change who="MV" when="2021-01-21">Fixed title</change>
+            <change who="MV" when="2021-01-21">Fixed title</change>     
+            <change who="MV" when="2021-01-26">Changes after PR</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -56,6 +58,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <bibl>
                         <ptr target="bm:EMML5"/>
                         <citedRange unit="page">131</citedRange>
+                        <citedRange unit="item">EMML 1636 2.14 (14th miracle)</citedRange>
                     </bibl>
                 </listBibl>
                 <listRelation>

--- a/new/LIT6364MEMiracle.xml
+++ b/new/LIT6364MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -66,7 +66,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6364MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>
-            </div><!---->
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ፲፭። ተአምሪሁ፡ ዘገብረ፡ አቡነ፡ ኤዎስጣተዎስ። ውስተ፡ ደብረ፡ ቢዘን። ወሖረ፡ ፩ መነኮስ፡ ከመ፡ ይቅዳሕ፡ ማየ፡ ዘይከውን፡ ለገቢረ፡ ተዝካሩ። ወሶበ፡ ረከብዎ፡ 
+                        አረማውያን፡ ወሰድዎ፡ አሢሮሙ፡ ከመ፡ ይሢጥዎ። ወሶበ፡ ስምዑ፡ አኃዊሁ፡ ዓውየዉ፡ ወመነኮሳትሂ፡ አብዝኁ፡ ብካየ፡ ገዓረ፡ ወጸልዩ፡ ወተማኅፀንዎ፡
+                        ለአቡነ፡ ኤዎስጣቴዎስ፡ ወሰከይዎ፡ ኀበ፡ እግዚአብሔር፡ እንዘ፡ ይብሉ።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This explicit is taken from <ref type="mss" corresp="BGV009"/>.</note>
+                    <ab>
+                        ወከማሆሙ፡ ይረድአነ፡ ወኢያስተኃፍረነ፡ እምተስፋሁ፡ ለገብሩ፡ <gap reason="ellipsis" resp="MV"/> ለዓለመ፡ ዓለም፡ አሜን።
+                    </ab>
+                </div>
+            </div>
         </body>
     </text>
 </TEI>

--- a/new/LIT6364MEMiracle.xml
+++ b/new/LIT6364MEMiracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos</title>
+                <title xml:lang="en" xml:id="t1">Miracle of ʾEwosṭātewos: how the saint saved a monk who had been captured by the pagans near Dabra Bizan</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,23 +46,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="MV" when="2021-01-20">Created entity</change>
+            <change who="MV" when="2021-01-21">Fixed title</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
             <div type="bibliography">
-                <listBibl type="editions">
-                    <bibl>
-                        <ptr target="bm:Turaiev1905Eustathii"/>
-                        <citedRange unit="page"></citedRange>
-                    </bibl>
-                </listBibl>
-                <listBibl type="translation">
-                    <bibl>
-                        <ptr target="bm:Turaev1906Ewostatewos"/>
-                        <citedRange unit="page"></citedRange>
-                    </bibl>
-                </listBibl>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6364MEMiracle" passive="LIT4315Miracles"/>
                 </listRelation>


### PR DESCRIPTION
Dear all,

here come the 15 miracles of ʾEwosṭātewos contained in the first part of ms BGV-009.
The records are incomplete. I have left the following comment within `<listBibl type="editions">`:
`<!-- insert page range from Turaiev's Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii, pp. 134-177 -->`
I could identify most of the mss after collation from Turaiev's Latin translation of the text, published in CSCO. But I currently do not have access to the edition of the text, published in _Monumenta Aethiopiae Hagiologica: Vita et Miracula Eustathii._ I only know that the miracles are printed on pp. 134-177.
The identification is quite simple, because I have indicated the numbering of the miracle in Turaiev, so it's just a matter of giving page numbers. I think this can be done at a later stage by someone who will be able to get access to that book. Luckily, it does not involve strictly our catalogue.

Thanks!
