### PR TITLE
Fixing div edition nesting

### DIFF
--- a/3001-4000/LIT3138Negeranni.xml
+++ b/3001-4000/LIT3138Negeranni.xml
@@ -70,6 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <citedRange unit="page">261-264</citedRange>
                </bibl>
             </listBibl>
+         </div>
             <div type="edition">
                <div type="textpart" subtype="incipit" xml:lang="gez">
                   <ab>
@@ -80,7 +81,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </ab>
                </div>
             </div>
-         </div>
+
       </body>
    </text>
 </TEI>

--- a/3001-4000/LIT3309Qerellos.xml
+++ b/3001-4000/LIT3309Qerellos.xml
@@ -119,6 +119,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
               <relation name="saws:hasUsed" active="LIT3309Qerellos#VitaOfCyril" passive="LIT1011Abusak"></relation>
               <relation name="saws:hasUsed" active="LIT3309Qerellos#VitaOfCyril" passive="LIT4723TarikaWaldaAmid"></relation>
             </listRelation>
+         </div>
             <div type="edition">
               <note>Following text structure is based on
                 <bibl>
@@ -227,7 +228,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
               </div>
 
             </div>
-         </div>
+
       </body>
    </text>
 </TEI>

--- a/6001-7000/LIT6368PsaltComm.xml
+++ b/6001-7000/LIT6368PsaltComm.xml
@@ -63,7 +63,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <relation name="saws:contains" active="LIT6368PsaltComm" passive="LIT5986CommPsalter"/>
                     <relation name="lawd:hasAttestation" active="LIT6368PsaltComm" passive="BNFabb41"/>
                 </listRelation>
-
+            </div>
            <div type="edition">
              <note>The division into text parts follows <ref type="mss" corresp="BNFabb41"/>.</note>
               <div type="textpart" subtype="incipit" xml:id="Psalms">
@@ -114,7 +114,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         </div>
 
        </div>
-            </div>
+
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6383EgzienaAmlakenaLeuldibekwellu.xml
+++ b/6001-7000/LIT6383EgzienaAmlakenaLeuldibekwellu.xml
@@ -59,28 +59,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <relation name="saws:formsPartOf" active="LIT6383EgzienaAmlakenaLeuldibekwellu" passive="LIT2230Saatat" cert="medium"/>
                     <relation name="lawd:hasAttestation" active="LIT6383EgzienaAmlakenaLeuldibekwellu" passive="BNFabb111"/>
                     <relation name="lawd:hasAttestation" active="LIT6383EgzienaAmlakenaLeuldibekwellu" passive="BLadd11622"/>
-                </listRelation>
-
-                <div type="edition">
-                  <note>The text below follows <ref type="mss" corresp="BNFabb111"/>.</note>
-                   <div type="textpart" subtype="incipit">
-                     <ab>
-                     ኦእግዚእነ፡ ወአምላክነ፡ ኢየሱስ፡ ክርስቶስ፡
-                     ወልደ፡ እግዚአብሔር፡ ሕያው፡ ልዑል፡ ዲበ፡ ኵሉ፡ ኀይለ፡
-                      ቅዱሰን፡ ሀበነ፡ ረድኤተ፡ ከመ፡ ንሖር፡ በኅግከ፡
-                      ወበሥርዓትከ፡ ኵሎ፡ መዋዕለ፡ ሕይወትነ፨<sic resp="DN">እእግዚኦ፡</sic>
-                       ምህረነ፡ ትእዛዛቲከ፡ ማኅየዊተ፡ ከመ፡ ንርከብ፡ ሣህለ፡ ወምሕረተ፡ በቅድመ፡ መንበርከ፡ ልዑል፡
-                     </ab>
-                   </div>
-                     <div type="textpart" subtype="incipit">
-                       <ab>
-                       ኦእግዚእነ፡ አብጥል፡ እምኔነ፡ ኵሎ፡ ሕሊና፡ ዘኢትፈቅድ፨ ምርሐኒ፡ ፍኖተ፡
-                       ምሕረትከ፡ እስመ፡ ለከ፡ ስብሐት፡ ወክብር፡ ለዓለመ፡ ዓለም፡ አሜን፨
-                          </ab>
-                   </div>
-                   </div>
+                </listRelation>                
              </div>
-
+            <div type="edition">
+                <note>The text below follows <ref type="mss" corresp="BNFabb111"/>.</note>
+                <div type="textpart" subtype="incipit">
+                    <ab>
+                        ኦእግዚእነ፡ ወአምላክነ፡ ኢየሱስ፡ ክርስቶስ፡
+                        ወልደ፡ እግዚአብሔር፡ ሕያው፡ ልዑል፡ ዲበ፡ ኵሉ፡ ኀይለ፡
+                        ቅዱሰን፡ ሀበነ፡ ረድኤተ፡ ከመ፡ ንሖር፡ በኅግከ፡
+                        ወበሥርዓትከ፡ ኵሎ፡ መዋዕለ፡ ሕይወትነ፨<sic resp="DN">እእግዚኦ፡</sic>
+                        ምህረነ፡ ትእዛዛቲከ፡ ማኅየዊተ፡ ከመ፡ ንርከብ፡ ሣህለ፡ ወምሕረተ፡ በቅድመ፡ መንበርከ፡ ልዑል፡
+                    </ab>
+                </div>
+                <div type="textpart" subtype="incipit">
+                    <ab>
+                        ኦእግዚእነ፡ አብጥል፡ እምኔነ፡ ኵሎ፡ ሕሊና፡ ዘኢትፈቅድ፨ ምርሐኒ፡ ፍኖተ፡
+                        ምሕረትከ፡ እስመ፡ ለከ፡ ስብሐት፡ ወክብር፡ ለዓለመ፡ ዓለም፡ አሜን፨
+                    </ab>
+                </div>
+            </div>
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6384Sawwer.xml
+++ b/6001-7000/LIT6384Sawwer.xml
@@ -56,6 +56,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LIT6384Sawwer" passive="BNFabb111"/>
                 </listRelation>
+            </div>
                 <div type="edition">
                   <note>The text below follows <ref type="mss" corresp="BNFabb111"/>.</note>
                    <div type="textpart" subtype="incipit">
@@ -71,7 +72,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                           </ab>
                    </div>
                    </div>
-             </div>
+
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6385WeddaseSan.xml
+++ b/6001-7000/LIT6385WeddaseSan.xml
@@ -56,24 +56,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LIT6385WeddaseSan" passive="BNFabb111"/>
                 </listRelation>
-                <div type="edition">
-                  <note>The text below follows <ref type="mss" corresp="BNFabb111"/>.</note>
-                   <div type="textpart" subtype="incipit">
-                     <ab>
-                       ወዳሴ፡ በሰንበተ፡ ክርስቲያን፡ እግዚአብሔር፡ አኀዜ፡ ኩሉ፡ ዓለም፡ ንጉሠ፡ ነገሥት፡ ወእግዚእ፡
-                         አጋእስት፡ ወስልጣናት፡ ዘትቤላ፡ ለማርያም፡ እምከ፨ ንዒ፡ ርግብየ፡ ወንዒ፡ ሠናይትየ፡ እንዘ፡
-                          አመቱ፡ ልዑል፡ እሙ፡ ረሰያ፡ ዘመጽአ፡
-                         ኀቤኪ፡ በመንክር፡ ግርማ፡ ፍሥሒ፡ ለኪ፡ ምርያም፨ ወበእንተዝ፡ ናዐቢየኪ፡ እግዚእ፡ ውእቱ፡ ዘከለላ፡ 
-                     </ab>
-                   </div>
-                     <div type="textpart" subtype="incipit">
-                       <ab>
-                       ወንሕናኒ፡ አልብና፡ ከልአ፡ ዘእንበለ፡ ወልድኪ፨ አንሥአ፡ ለነ፡ ቀርነ፡ መድኀኒተነ፡ እምቤተ፡ ዳዊት፡ ገብሮ፨
-                       ጸሎታ፡ ለማርያም፡ ወሥእለታ፡ ያድኅነነ፡ እመዐተ፡ ወልዳ፨ አሜን፨
-                          </ab>
-                   </div>
-                   </div>
+                
              </div>
+            <div type="edition">
+                <note>The text below follows <ref type="mss" corresp="BNFabb111"/>.</note>
+                <div type="textpart" subtype="incipit">
+                    <ab>
+                        ወዳሴ፡ በሰንበተ፡ ክርስቲያን፡ እግዚአብሔር፡ አኀዜ፡ ኩሉ፡ ዓለም፡ ንጉሠ፡ ነገሥት፡ ወእግዚእ፡
+                        አጋእስት፡ ወስልጣናት፡ ዘትቤላ፡ ለማርያም፡ እምከ፨ ንዒ፡ ርግብየ፡ ወንዒ፡ ሠናይትየ፡ እንዘ፡
+                        አመቱ፡ ልዑል፡ እሙ፡ ረሰያ፡ ዘመጽአ፡
+                        ኀቤኪ፡ በመንክር፡ ግርማ፡ ፍሥሒ፡ ለኪ፡ ምርያም፨ ወበእንተዝ፡ ናዐቢየኪ፡ እግዚእ፡ ውእቱ፡ ዘከለላ፡ 
+                    </ab>
+                </div>
+                <div type="textpart" subtype="incipit">
+                    <ab>
+                        ወንሕናኒ፡ አልብና፡ ከልአ፡ ዘእንበለ፡ ወልድኪ፨ አንሥአ፡ ለነ፡ ቀርነ፡ መድኀኒተነ፡ እምቤተ፡ ዳዊት፡ ገብሮ፨
+                        ጸሎታ፡ ለማርያም፡ ወሥእለታ፡ ያድኅነነ፡ እመዐተ፡ ወልዳ፨ አሜን፨
+                    </ab>
+                </div>
+            </div>
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6388HymnTrinity.xml
+++ b/6001-7000/LIT6388HymnTrinity.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
       <body>
-        <div type="bibliography">
+        
           <div type="edition">
             <note>the text follows <ref type="mss" corresp="EMIP00764"/> ff. 40r-43r</note>
             <div type="textpart" subtype="incipit" xml:lang="gez">
@@ -71,7 +71,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
               </ab>
             </div>
           </div>
-        </div>
+        
       </body>
     </text>
     <text>

--- a/6001-7000/LIT6389MalkeaTewodros.xml
+++ b/6001-7000/LIT6389MalkeaTewodros.xml
@@ -50,7 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-          <div type="bibliography">
+          
             <div type="edition">
               <note>the text follows <ref type="mss" corresp="EMIP00764"/> ff. 92r-94r</note>
               <div type="textpart" subtype="incipit" xml:lang="gez">
@@ -69,7 +69,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </ab>
               </div>
             </div>
-          </div>
+          
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6390HymnVictor.xml
+++ b/6001-7000/LIT6390HymnVictor.xml
@@ -52,7 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-          <div type="bibliography">
+          
             <div type="edition">
               <note>the text follows <ref type="mss" corresp="EMIP00764"/> ff. 116r-118v</note>
               <div type="textpart" subtype="incipit" xml:lang="gez">
@@ -74,7 +74,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </ab>
               </div>
             </div>
-          </div>
+          
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6391HymnGabraMasqal.xml
+++ b/6001-7000/LIT6391HymnGabraMasqal.xml
@@ -52,7 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-          <div type="bibliography">
+      
             <div type="edition">
               <note>the text follows <ref type="mss" corresp="EMIP00764"/> ff. 128r-129v</note>
               <div type="textpart" subtype="incipit" xml:lang="gez">
@@ -72,7 +72,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </ab>
               </div>
             </div>
-          </div>
+          
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6392HymnInnocents.xml
+++ b/6001-7000/LIT6392HymnInnocents.xml
@@ -52,7 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-          <div type="bibliography">
+          
             <div type="edition">
               <note>the text follows <ref type="mss" corresp="EMIP00764"/> ff. 129v-131v</note>
               <div type="textpart" subtype="incipit" xml:lang="gez">
@@ -73,7 +73,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </ab>
               </div>
             </div>
-          </div>
+          
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6404Dersan4recA.xml
+++ b/6001-7000/LIT6404Dersan4recA.xml
@@ -59,7 +59,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </text>
     <text>
     <body>
-    <div type="bibliography">
+    
     <div xml:lang="gez" type="edition">
     <note>The incipit is taken from <ref type="mss" corresp="BLorient691"/></note>
     <div type="textpart" subtype="incipit">
@@ -67,7 +67,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       ዘይትነበብ፡ በሰላመ፡ እግዚአብሔር፡ አሜን። አመ፡ ተስእልዎ፡ ሊቃውንት፡ ወሥዩማን፡ ወይቤልዎ፡ አስትየነ፡ እምነቅዓ፡ ማየ፡ ሕይወት፡ ዘይፈለፍል፡ እምክናፍሪከ።</ab>
     </div>
     </div>
-    </div>
+    
     </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6425MJTriumphalEntry.xml
+++ b/6001-7000/LIT6425MJTriumphalEntry.xml
@@ -55,11 +55,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6425MJTriumphalEntry" passive="LIT2382Taamme"/>
                 </listRelation>
-                <div type="edition">
+                <listBibl type="text">
                   <bibl>
                     <ptr target="bm:RompayArras1975Miracles"/><citedRange unit="item">34</citedRange>
                   </bibl>
-                </div>
+                </listBibl>
 
             </div>
             <div type="edition">

--- a/6001-7000/LIT6434Hymn.xml
+++ b/6001-7000/LIT6434Hymn.xml
@@ -53,15 +53,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LIT6434Hymn" passive="BLorient613"/>
                 </listRelation>
-
-                <div xml:lang="gez" type="edition">
-                            <note>The incipit is taken from <ref type="mss" corresp="BLorient613"/></note>
-                            <div type="textpart" subtype="incipit">
-                             <ab xml:lang="gez">እብል፡ አንሰ፡ ገባእተ፡ ሥላሴ፡ እምርሑቅ። በገጸ፡ አዜብ፡ ወመስዕ፡ በገጸ፡ ዓረብ፡ ወሠርቅ፡ በቀስተ፡ አፉየ፡ ሐፀ፡ ስሞሙ፡ ውሱቅ።</ab>
-                            </div>
-                  </div>
-
-            </div><!---->
+            </div>
+            <div xml:lang="gez" type="edition">
+                <note>The incipit is taken from <ref type="mss" corresp="BLorient613"/></note>
+                <div type="textpart" subtype="incipit">
+                    <ab xml:lang="gez">እብል፡ አንሰ፡ ገባእተ፡ ሥላሴ፡ እምርሑቅ። በገጸ፡ አዜብ፡ ወመስዕ፡ በገጸ፡ ዓረብ፡ ወሠርቅ፡ በቀስተ፡ አፉየ፡ ሐፀ፡ ስሞሙ፡ ውሱቅ።</ab>
+                </div>
+            </div>
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6454Dersan.xml
+++ b/6001-7000/LIT6454Dersan.xml
@@ -51,7 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography">
+            
                <div xml:lang="gez" type="edition">
             <note>The incipit is taken from <ref type="mss" corresp="ESap005"/></note>
             <div type="textpart" subtype="incipit">
@@ -61,7 +61,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:isDifferentTo" active="LIT6454Dersan" passive="LIT5862OnSpiritualEaster"/>
                 </listRelation>
-            </div><!---->
+            <!---->
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6467Heresies.xml
+++ b/6001-7000/LIT6467Heresies.xml
@@ -55,6 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="saws:formsPartOf" active="LIT6467Heresies" passive="LIT1952Mashaf"/>
                 </listRelation>
+            </div>
                 <div type="edition">
                   <note>The incipit is taken from <ref type="mss" corresp="EMIP00705"></ref></note>
                   <div type="textpart" subtype="incipit">
@@ -62,7 +63,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                       ንቤ፡ ፫ቱ፡ ገጽ፡ ፩ራዕይ፡ ፫ቱ፡ አካል፡</ab>
                   </div>
                 </div>
-            </div><!---->
+
         </body>
     </text>
 </TEI>

--- a/6001-7000/LIT6472MalkeaMamas.xml
+++ b/6001-7000/LIT6472MalkeaMamas.xml
@@ -52,7 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography">
+           
               <div type="edition">
                   <div type="textpart" subtype="incipit" xml:lang="gez">
                       <note>The incipit is taken from <ref type="mss" corresp="ESaqm002"/>.</note>
@@ -75,7 +75,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <relation name="lawd:hasAttestation" active="LIT6480MalkeaMamas" passive="ESaqm002"/>
                     <relation name="ecrm:CLP46i_may_form_part_of" active="LIT6480MalkeaMamas" passive="LIT6481DossierMamas"/>                    
                 </listRelation>
-            </div><!---->
+            <!---->
         </body>
     </text>
 </TEI>

--- a/new/LIT6513Nagar.xml
+++ b/new/LIT6513Nagar.xml
@@ -60,14 +60,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <relation name="ecrm:P129_is_about" active="LIT6513Nagar" passive="Masqal"/>
                     <relation name="ecrm:P129_is_about" active="LIT6513Nagar" passive="TrueCross"/>
                 </listRelation>
+            
+            </div>
             <div xml:lang="gez" type="edition">
-            <note>The incipit is taken from <ref type="mss" corresp="EMML1763"/></note>
-            <div type="textpart" subtype="incipit">
-             <ab xml:lang="gez">፡ብፁዕ፡ ጳውሎስ፡ ሐዋርያ፡ እንዘ፡ ይነግር፡ እንተ፡ እግዚአብሔር፡ አብ፡ አፍቅሮ፡ ሰብእ፡ ወኂሩቶ፡ ዘአርአየ፡ እግዚአብሔር፡ በላዕሌነ፡
-             በዋሕድ፡ ወልዱ፡ እግዚእነ፡ ይጼውዐነ፡ ለኵልነ፡ በአኰቴት፡ ወበስብሓት፡ ከመ፡ ንፈኑ፡ ለእግዚአብሔር፡ አኰቴተ፡ እንዘ፡ ንብል።</ab>
+                
+                <div type="textpart" subtype="incipit">
+                    <ab xml:lang="gez">፡ብፁዕ፡ ጳውሎስ፡ ሐዋርያ፡ እንዘ፡ ይነግር፡ እንተ፡ እግዚአብሔር፡ አብ፡ አፍቅሮ፡ ሰብእ፡ ወኂሩቶ፡ ዘአርአየ፡ እግዚአብሔር፡ በላዕሌነ፡
+                        በዋሕድ፡ ወልዱ፡ እግዚእነ፡ ይጼውዐነ፡ ለኵልነ፡ በአኰቴት፡ ወበስብሓት፡ ከመ፡ ንፈኑ፡ ለእግዚአብሔር፡ አኰቴተ፡ እንዘ፡ ንብል።</ab>
+                    <note>The incipit is taken from <ref type="mss" corresp="EMML1763"/></note>
+                </div>
             </div>
-            </div>
-            </div><!---->
         </body>
     </text>
 </TEI>

--- a/new/LIT6515DersanApostles.xml
+++ b/new/LIT6515DersanApostles.xml
@@ -58,7 +58,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <relation name="ecrm:P129_is_about" active="LIT6515DersanApostles" passive="PRS11430Apostles"/>
                 </listRelation>
             </div>
-            <div type="bibliography"/>
+            
           <div xml:lang="gez" type="edition">
             <note>The incipit is taken from <ref type="mss" corresp="EMML1763"/></note>
             <div type="textpart" subtype="incipit">

--- a/new/LIT6535DersYaqLenten.xml
+++ b/new/LIT6535DersYaqLenten.xml
@@ -62,17 +62,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <citedRange unit="page">571-587</citedRange>
                  </bibl>
               </listBibl>
-              <div xml:lang="gez" type="edition">
-           <note>The incipit is taken from <ref type="mss" corresp="EMML1763"/></note>
-           <div type="textpart" subtype="incipit">
-            <ab xml:lang="gez">ፍሬ፡ ጥዑም፡ ወረባሕ፡ እምጾም፡ ቀሰምኩ፡ <sic>እግዚኣ፡</sic> ለገነት፡ ተወከፍ፡ መባእየ፡ ውስተ፡ ማእድከ። ጾም፡ በፍቅሩ፡ ፄወየ፡
-            ሕሊናየ፡ ከመ፡ እትናገር፡ በእንቲኣሁ።</ab>
-           </div>
-           </div>
+              
                 <listRelation>
                     <relation name="saws:isAttributedToAuthor" active="LIT6535DersYaqLenten" passive="PRS5655Jacobof"/>
                 </listRelation>
-            </div><!---->
+            </div>
+            <div xml:lang="gez" type="edition">
+                <note>The incipit is taken from <ref type="mss" corresp="EMML1763"/></note>
+                <div type="textpart" subtype="incipit">
+                    <ab xml:lang="gez">ፍሬ፡ ጥዑም፡ ወረባሕ፡ እምጾም፡ ቀሰምኩ፡ <sic>እግዚኣ፡</sic> ለገነት፡ ተወከፍ፡ መባእየ፡ ውስተ፡ ማእድከ። ጾም፡ በፍቅሩ፡ ፄወየ፡
+                        ሕሊናየ፡ ከመ፡ እትናገር፡ በእንቲኣሁ።</ab>
+                </div>
+            </div>
         </body>
     </text>
 </TEI>


### PR DESCRIPTION
While going through the records I noticed that sometimes `div="edition"` is nested within `div="bibliography"` under body; I have fixed all such cases, it would be great if we all in the future try to avoid this, `div="edition"` should be the next level after body. Thank you so much!!!

xpath test that edition is first-level under body `$config:collection-rootW//t:body/t:div[t:div[@type='edition']]`