### PR TITLE
Fixing div edition nesting

### DIFF
--- a/1001-2000/LIT1252Confes.xml
+++ b/1001-2000/LIT1252Confes.xml
@@ -100,6 +100,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   
                </relation>
             </listRelation>
+         </div>
             <div type="edition" xml:lang="gez">
                <div type="textpart" subtype="paragraph" n="1">
                   <ab>በስመ፡ አብ፡ ወወልድ፡ ወመንፈስ፡ ቅዱስ፡ ፩አምላክ። ዝንቱ፡ ውእቱ፡ ሃይማኖትየ፡ ወሃይማኖተ፡ አበውየ፡ 
@@ -202,7 +203,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </ab>
                </div>
             </div>
-         </div>
+
       </body>
    </text>
 </TEI>

--- a/1001-2000/LIT1423GadlaA.xml
+++ b/1001-2000/LIT1423GadlaA.xml
@@ -81,7 +81,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </bibl>
             </listBibl>
          </div>
-         <div type="edition">
+         
             <div type="edition">
                <div type="textpart" subtype="chapter" n="1" xml:id="Prologue">
                   <label>Prologue</label>
@@ -133,7 +133,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </div>
                </div>
             </div>
-         </div>
+         
       </body>
    </text>
 </TEI>

--- a/1001-2000/LIT1509GadlaW.xml
+++ b/1001-2000/LIT1509GadlaW.xml
@@ -88,6 +88,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <ptr target="bm:Papi1943WalattaPetros"/>
                </bibl>
             </listBibl>
+         </div>
             <div type="edition">
                <div type="textpart" subtype="incipit" xml:id="Introduction">
                   <label>Introduction</label>
@@ -117,8 +118,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                
             </div>
-            
-         </div>
+
       </body>
    </text>
 </TEI>

--- a/1001-2000/LIT1528GadlaZ.xml
+++ b/1001-2000/LIT1528GadlaZ.xml
@@ -93,7 +93,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <ptr target="bm:Sokolinskaia2014ZaraBuruk"/>
                </bibl>
             </listBibl>
-
+         </div>
             <div type="edition">
                <div type="textpart" xml:id="ImageZaraBuruk"/>
                <div type="textpart" xml:id="GadlaZaraBuruk"/>
@@ -128,7 +128,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <div type="textpart" xml:id="Miracle27"/>
                </div>
             </div>
-         </div>
+
       </body>
    </text>
 </TEI>

--- a/1001-2000/LIT1617Homily.xml
+++ b/1001-2000/LIT1617Homily.xml
@@ -59,7 +59,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <listRelation>
            <relation name="saws:isAttributedToAuthor" active="LIT1617Homily" passive="PRS5655Jacobof"/>
         </listRelation>
-
+        </div>
         <div xml:lang="gez" type="edition">
           <note>The incipit is taken from <ref type="mss" corresp="EMML1763"/></note>
           <div type="textpart" subtype="incipit">
@@ -70,7 +70,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </div>
         </div>
 
-        </div>
       </body>
    </text>
 </TEI>

--- a/1001-2000/LIT1665Homily.xml
+++ b/1001-2000/LIT1665Homily.xml
@@ -49,22 +49,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="MKr" when="2021-11-28">Added bibliography</change>
       </revisionDesc>
    </teiHeader>
-          <text xml:base="https://betamasaheft.eu/">
-          <body>
-            <div type="bibliography">
-            <listRelation>
-               <relation name="saws:isAttributedToAuthor" active="LIT1665Homily" passive="PRS8790Severus"/>
-               <relation name="ecrm:P129_is_about" active="LIT1665Homily" passive="PRS6819Mary"/>
-            </listRelation>
-            </div>
-          </body>
-       </text>
-       <text>
+          
+   <text xml:base="https://betamasaheft.eu/">
        <body>
          <div type="bibliography">
         <listBibl type="secondary">
           <bibl><ptr target="bm:Proverbio2001Omelia"/><citedRange unit="page">518</citedRange></bibl>
         </listBibl>
+            <listRelation>
+               <relation name="saws:isAttributedToAuthor" active="LIT1665Homily" passive="PRS8790Severus"/>
+               <relation name="ecrm:P129_is_about" active="LIT1665Homily" passive="PRS6819Mary"/>
+            </listRelation>
+         </div>
          <div xml:lang="gez" type="edition">
            <note>The incipit and the explicit are taken from <ref type="mss" corresp="EMML1763"/></note>
            <div type="textpart" subtype="incipit">
@@ -75,7 +71,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <ab>ወይእዜኒ፡ አኃዊየ፡ ፍቁራን፡ ንግበር፡ ትዝካራ፡ ወናክብር፡ በዓላ፡ በስብሐት፡ ወበማኅሌትL፡ ዘመንፈስ፡ ቅዱስ፡ ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን።</ab>
            </div>
          </div>
-         </div>
+
        </body>
    </text>
 </TEI>

--- a/2001-3000/LIT2111OntheB.xml
+++ b/2001-3000/LIT2111OntheB.xml
@@ -90,7 +90,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <citedRange>293b</citedRange>
                </bibl>
             </listBibl>
-            
+         </div>
             <div type="edition">
                <div type="textpart" subtype="incipit" xml:lang="gez">
                   <ab>
@@ -98,7 +98,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </ab>
                </div>
             </div>
-         </div>
+
       </body>
    </text>
 </TEI>

--- a/2001-3000/LIT2332serata.xml
+++ b/2001-3000/LIT2332serata.xml
@@ -66,7 +66,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <relation name="saws:isDifferentTo" active="LIT2332serata" passive="LIT4020RegulaeHierarchia"/>
                   <relation name="lawd:hasAttestation" active="LIT2332serata" passive="IVEf77"/>
               </listRelation>
-             <div type="edition">
+             <listBibl type="editions">
                  <bibl>
                <ptr target="bm:Griaule1932Serat"/>
             </bibl>
@@ -77,7 +77,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
            <bibl>
          <ptr target="bm:Nosnitsin2010Seratabet"/>
           </bibl>
+             </listBibl>
              </div>
+             <div type="edition">
              <note>The text follows <bibl>
             <ptr target="bm:Griaule1932Serat"/>
            <citedRange unit="page">4</citedRange></bibl>.</note>

--- a/2001-3000/LIT2361somade.xml
+++ b/2001-3000/LIT2361somade.xml
@@ -69,6 +69,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </desc>
                </relation>
             </listRelation>
+         </div>
             <div type="edition">
                <div type="textpart" xml:id="Vigil">
                   <label>Hymn for the vigil of the fast (<foreign xml:lang="gez">ዋዜማ፡ ዘመኅትወ፡ ድራረ፡ ጾም፡</foreign>)</label>
@@ -246,11 +247,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <label>Directives for the parts to be recited beyond Lent</label>
                </div>
 
-            </div>
+            
             <div type="textpart" xml:id="Haleta">
               <label>Table of melodic variations for the Hallelujah <foreign xml:lang="gez">አንቀጸ፡ ሃሌታ፡</foreign></label>
             </div>
-         </div>
+            </div>
       </body>
    </text>
 </TEI>

--- a/2001-3000/LIT2375Synaxa.xml
+++ b/2001-3000/LIT2375Synaxa.xml
@@ -80,7 +80,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <ptr target="bm:Colin1986Maskaram"/>
                   </bibl>
                </listBibl>
-         
+         </div>
 
             <div type="edition">
 
@@ -402,7 +402,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <!-- See BAVet111 and BAVet112 as examples of lists of commemoration entries -->
             </div>
-         </div>
+
 
       </body>
    </text>

--- a/4001-5000/LIT4117Interpretation.xml
+++ b/4001-5000/LIT4117Interpretation.xml
@@ -75,7 +75,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     <relation name="lawd:hasAttestation" active="LIT4117Interpretation" passive="BNFabb157"/>
                 </listRelation>
 
-
+            </div>
         <div type="edition">
            <note>The text edition follows <ref type="mss" corresp="BNFabb195"></ref>.</note>
            <div type="textpart" subtype="incipit" xml:lang="gez">
@@ -89,7 +89,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
               </ab>
               </div>
          </div>
-         </div>
+
       </body>
    </text>
 </TEI>

--- a/4001-5000/LIT4866OntheB.xml
+++ b/4001-5000/LIT4866OntheB.xml
@@ -87,7 +87,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <citedRange>293b</citedRange>
                </bibl>
             </listBibl>
-            
+         </div>
             <div type="edition">
                <div type="textpart" subtype="incipit" xml:lang="gez">
                   <ab>
@@ -95,7 +95,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </ab>
                </div>
             </div>
-         </div>
+
       </body>
    </text>
 </TEI>

--- a/4001-5000/LIT4968SenkessarSec.xml
+++ b/4001-5000/LIT4968SenkessarSec.xml
@@ -55,10 +55,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
         <body>
-            <div type="edition">
-                     <div type="edition">
-            
-           <!-- <div type="textpart" subtype="chapter" n="1" xml:id="Maskaram">
+            <div type="edition">             
+         <!-- 
+         
+         <div type="textpart" subtype="chapter" n="1" xml:id="Maskaram">
                <label>Commemorative notices for the month of <foreign xml:lang="gez">Maskaram</foreign>
                </label>
                <!-\- the following arrangement of the textparts and text of Maskaram is taken from
@@ -971,9 +971,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <div type="textpart" subtype="commemoration" xml:id="Heda9Yeshaq">
                   <label>Commemoration of Yǝsḥaq</label> <!-\-Q1263030-\->
                </div>
-            </div>-->
+            </div>
             
-          <!--  <div type="textpart" subtype="chapter" xml:id="Heda10">
+            <div type="textpart" subtype="chapter" xml:id="Heda10">
                <label>
                   <date>10th <foreign xml:lang="gez">Ḫǝdar</foreign></date>
                </label>
@@ -1182,8 +1182,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <label>Commemoration of </label>
                </div>
             </div>-->
-            
-         </div>
+                   
             
             <!--  <div type="textpart" subtype="chapter" xml:id="Tahsas">
             <label>Commemorative notices for the month of <foreign xml:lang="gez">Tāḫśāś</foreign>
@@ -2117,8 +2116,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <label>Commemoration of </label>
                </div>
             </div>
-         </div>-->
-            
+         </div>
+         
+         -->
             <div type="textpart" subtype="chapter" xml:id="Maggabit">
                <label>Commemorative notices for the month of <foreign xml:lang="gez">Maggābit</foreign>
                </label>

--- a/5001-6000/LIT5639WeddaseMaryamTergwame.xml
+++ b/5001-6000/LIT5639WeddaseMaryamTergwame.xml
@@ -96,19 +96,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
 
                </div>
             </div>
+            </div>
             <div type="bibliography">
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LIT5639WeddaseMaryamTergwame" passive="IVpapadopulokeramevs6"/>
-                </listRelation>
-            </div>
-
-            <div type="edition">
-                <listRelation>
                     <relation name="lawd:hasAttestation" active="LIT5639WeddaseMaryamTergwame" passive="LIT2509Weddas"/>
                 </listRelation>
             </div>
-            </div>
-         <!---->
         </body>
     </text>
 </TEI>

--- a/5001-6000/LIT5656Malheq.xml
+++ b/5001-6000/LIT5656Malheq.xml
@@ -67,8 +67,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LIT5656Malheq" passive="IVorlov33"/>
                 </listRelation>
-
-                <div type="edition">
+            </div>
+<div type="edition">
                    <note>This division into textparts follows
                      <ref type="mss" corresp="IVorlov33"/>.</note>
 
@@ -478,11 +478,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                    <div type="textpart" xml:id="SaturdayWinter">
                       <label>Hymn for the Saturday and the winter</label>
                    </div>
-                </div>
+
                 <div type="textpart" xml:id="Haleta">
                   <label>Table of melodic variations for the Hallelujah <foreign xml:lang="gez">አንቀጸ፡ ሃሌታ፡</foreign></label>
                 </div>
             </div>
+
         </body>
     </text>
 </TEI>

--- a/5001-6000/LIT5895DersanaLedata.xml
+++ b/5001-6000/LIT5895DersanaLedata.xml
@@ -65,6 +65,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <relation name="lawd:hasAttestation" active="LIT5895DersanaLedata" passive="DSEthiop11"/>
                     <relation name="saws:isAttributedToAuthor" active="LIT5895DersanaLedata" passive="PRS5666Jamesth"></relation>
                 </listRelation>
+            </div>
                 <div type="edition">
                    <div type="textpart" subtype="incipit" xml:lang="gez">
                      <note>The incipit is taken from <ref type="mss"
@@ -86,7 +87,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
 
                     </div>
-            </div>
+
         </body>
     </text>
 </TEI>

--- a/5001-6000/LIT5900DersanaMikaelTheo.xml
+++ b/5001-6000/LIT5900DersanaMikaelTheo.xml
@@ -63,6 +63,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <relation name="lawd:hasAttestation" active="LIT5900DersanaMikaelTheo" passive="DSEthiop11"/>
                     <relation name="saws:isAttributedToAuthor" active="LIT5900DersanaMikaelTheo" passive="PRS9477Theodosi"/>
                 </listRelation>
+            </div>
                 <div type="edition">
                    <div type="textpart" subtype="incipit" xml:lang="gez">
                      <note>The incipit is taken from <ref type="mss"
@@ -76,7 +77,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                       </ab>
                    </div>
                     </div>
-            </div>
+
         </body>
     </text>
 </TEI>

--- a/5001-6000/LIT5921SalamLaki.xml
+++ b/5001-6000/LIT5921SalamLaki.xml
@@ -53,6 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="ecrm:P129i_is_subject_of" active="LOC2297DabraL" passive="LIT5921SalamLaki"/>
                 </listRelation>
+            </div>
                 <div type="edition">
                     <div type="textpart" subtype="incipit" xml:lang="gez">
                         <note>The incipit is taken from <ref type="mss" corresp="BDLaethe38#a4"/>.</note>
@@ -61,7 +62,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </ab>
                     </div>
                 </div>
-            </div>
+
         </body>
     </text>
 </TEI>

--- a/5001-6000/LIT5962PrayerThreeNames.xml
+++ b/5001-6000/LIT5962PrayerThreeNames.xml
@@ -54,7 +54,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                      <relation name="lawd:hasAttestation" active="LIT5962PrayerThreeNames" passive="BDLaethf29"/>
                      <relation name="lawd:hasAttestation" active="LIT5962PrayerThreeNames" passive="EMIP00324"/>
                 </listRelation>
-
+            </div>
                 <div type="edition" xml:lang="gez">
                     <note>The prayer's text is taken from <ref type="mss" corresp="BDLaethf29"
                         />.</note>
@@ -64,7 +64,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         ፫አስማት፡ ገደፍኩ፡ እስከ፡ ርእስየ፡ በዘቦቱ፡ ዕመውዕ፡ ፀርየ፡ ለዓለመ፡ ዓለም፡ አሜን። ኦእግዚኦ፡ ዕቀበኒ፡ ለገብርከ፡ <gap reason="ellipsis" resp="SH"></gap>
                     </ab>
                 </div>
-            </div>
 
         </body>
     </text>

--- a/5001-6000/LIT5986CommPsalter.xml
+++ b/5001-6000/LIT5986CommPsalter.xml
@@ -63,6 +63,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <relation name="lawd:hasAttestation" active="LIT5986CommPsalter" passive="ESrqg015"/>
                 <relation name="lawd:hasAttestation" active="LIT5986CommPsalter" passive="BLorient535"/>
     </listRelation>
+            </div>
                 <div type="edition">
                   <note>The division into text parts follows <ref type="mss" corresp="BLorient353"/>.</note>
                    <div type="textpart" subtype="incipit" xml:id="LIT5985CommPsalms">
@@ -105,11 +106,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </l>
                  </ab>
              </div>
-
-
-
           </div>
-            </div>
+
         </body>
     </text>
 </TEI>

--- a/5001-6000/LIT5992Miracle.xml
+++ b/5001-6000/LIT5992Miracle.xml
@@ -64,6 +64,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="ecrm:P129i_is_subject_of" active="PRS5684JesusCh" passive="LIT5992Miracle"/>
                 </listRelation>
+            </div>
                 <div type="edition">
                     <div type="textpart" subtype="incipit" xml:lang="gez">
                         <note>The incipit is provided after <ref type="mss" corresp="BDLaethe38#a3"/>.</note>
@@ -73,7 +74,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </ab>
                     </div>
                 </div>
-            </div>
+
         </body>
     </text>
 </TEI>


### PR DESCRIPTION
While going through the records I noticed that sometimes `div="edition"` is nested within `div="bibliography"` under `body`; I have fixed all such cases, it would be great if we all in the future try to avoid this, `div="edition"` should be the next level after `body`. Thank you so much!!!

xpath test that edition is first-level under body `$config:collection-rootW//t:body/t:div[t:div[@type='edition']]`
/second part to https://github.com/BetaMasaheft/Works/pull/725/