### PR TITLE
PDFedits

### DIFF
--- a/3001-4000/LIT3058RepCh338.xml
+++ b/3001-4000/LIT3058RepCh338.xml
@@ -8,8 +8,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
             <title xml:lang="gez" xml:id="t1">እሰግድ፡ ለኪ፡ እሰግድ፡ ለኪ፡ እሰግድ፡ ለኪ፡ ወእዌድሰኪ፡ </title>
             <title  xml:lang="gez" corresp="#t1" type="normalized">ʾƎsaggǝd laki ʾǝsaggǝd laki ʾǝsaggǝd laki wa-ʾǝweddǝsaki</title>
-            <title  xml:lang="gez" corresp="#t1">ʾI worship you, I worship you, I worship you and I praise you...</title>
-            <title xml:lang="en" xml:id="t2" type="main">I worship thee...</title>
+            <title  xml:lang="en" corresp="#t1">I worship you, I worship you, I worship you and I praise you...</title>
+            <title xml:lang="en" xml:id="t2">I worship thee...</title>
             <editor role="generalEditor" key="AB"/>
         <editor key="DN"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/3001-4000/LIT3093RepCh373.xml
+++ b/3001-4000/LIT3093RepCh373.xml
@@ -8,7 +8,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <title xml:id="t2">ʾO-ʾǝgzǝʾtǝya Māryām ʾǝmmu la-ʾIyasus Krǝstos kahāli ... </title>
             <title xml:lang="gez" xml:id="t3">እሰግድ፡ ለኪ፡ ኦእግዝእትየ፡ ቅድስት፡ ድንግል፡ ማርያም፡ ማሪሃም፡ እሙ፡ ለኢየሱስ፡ ክርስቶስ፡ ከሃሊ።</title>
             <title xml:lang="gez" type="normalized" corresp="#t3">ʾƎsaggǝd laki ʾo-ʾǝgzǝʾtǝya qǝddǝst dǝngǝl Māryām Mārihām ʾǝmmu la-ʾIyasus Krǝstos kahāli ...</title>
-            <title xml:lang="en" corresp="#t3">worship Thee, O my Lady, Holy Virgin Mary, Mother of Jesus Christ the Almighty</title>
+            <title xml:lang="en" corresp="#t3">I worship you, oh my Lady, Holy Virgin Mary, Mother of Jesus Christ the Almighty</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>

--- a/3001-4000/LIT3507Epistle.xml
+++ b/3001-4000/LIT3507Epistle.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="work" xml:lang="en" xml:id="LIT3507Epistle">
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="work" xml:lang="en" xml:id="LIT3507Epistle">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
             <title xml:id="t1" xml:lang="en" type="main">First Epistle of Peter</title>
+            <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጴጥሮስ፡ ቀዳሚት፡</title>
+            <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Ṗeṭros qadāmit</title>
             <title type="short">1 Petr.</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/3001-4000/LIT3507Epistle.xml
+++ b/3001-4000/LIT3507Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">First Epistle of Peter</title>
+            <title xml:id="t1" xml:lang="en">First Epistle of Peter</title>
             <title type="short">1 Petr.</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/3001-4000/LIT3507Epistle.xml
+++ b/3001-4000/LIT3507Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1" xml:lang="en">First Epistle of Peter</title>
+            <title xml:id="t1" xml:lang="en" type="main">First Epistle of Peter</title>
             <title type="short">1 Petr.</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/3001-4000/LIT3509Epistle.xml
+++ b/3001-4000/LIT3509Epistle.xml
@@ -5,6 +5,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       <fileDesc>
          <titleStmt>
             <title xml:id="t1" xml:lang="en" type="main">First Epistle of John</title>
+            <title xml:id="t2" xml:lang="gez">መልእክተ፡ ዮሐንስ፡ ሐዋርያ፡ ቀዳማዊ፡</title>
+            <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Yoḥannǝs ḥawāryā qadāmāwi</title>
             <title type="short">1 Joh.</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/3001-4000/LIT3509Epistle.xml
+++ b/3001-4000/LIT3509Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">First Epistle of John</title>
+            <title xml:id="t1" xml:lang="en">First Epistle of John</title>
             <title type="short">1 Joh.</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/3001-4000/LIT3509Epistle.xml
+++ b/3001-4000/LIT3509Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1" xml:lang="en">First Epistle of John</title>
+            <title xml:id="t1" xml:lang="en" type="main">First Epistle of John</title>
             <title type="short">1 Joh.</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/3001-4000/LIT3512Epistle.xml
+++ b/3001-4000/LIT3512Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1" xml:lang="en">Epistle of James</title>
+            <title xml:id="t1" xml:lang="en" type="main">Epistle of James</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>

--- a/3001-4000/LIT3512Epistle.xml
+++ b/3001-4000/LIT3512Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Epistle of James</title>
+            <title xml:id="t1" xml:lang="en">Epistle of James</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>

--- a/3001-4000/LIT3512Epistle.xml
+++ b/3001-4000/LIT3512Epistle.xml
@@ -5,6 +5,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       <fileDesc>
          <titleStmt>
             <title xml:id="t1" xml:lang="en" type="main">Epistle of James</title>
+            <title xml:id="t2" xml:lang="gez">መልእክተ፡ ያዕቆብ፡ እኁሁ፡ ለእግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡</title>
+            <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Yāʿqob ʾǝḫuhu la-ʾǝgziʾǝna ʾIyasus Krǝstos</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>

--- a/3001-4000/LIT3516Epistle.xml
+++ b/3001-4000/LIT3516Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">First Epistle to the Corinthians</title>
+            <title xml:id="t1" xml:lang="en" type="main">First Epistle to the Corinthians</title>
             <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጳውሎስ፡ ቀዳማዊ፡ ኀበ፡ ሰብአ፡ ቆሮንቶስ፡፡</title>
             <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Ṗāwlos qadāmāwi ḫaba sabʾa Qorontos</title>
             <title type="short">1 Cor.</title>

--- a/3001-4000/LIT3516Epistle.xml
+++ b/3001-4000/LIT3516Epistle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       <fileDesc>
          <titleStmt>
             <title xml:id="t1" xml:lang="en" type="main">First Epistle to the Corinthians</title>
-            <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጳውሎስ፡ ቀዳማዊ፡ ኀበ፡ ሰብአ፡ ቆሮንቶስ፡፡</title>
+            <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጳውሎስ፡ ቀዳማዊ፡ ኀበ፡ ሰብአ፡ ቆሮንቶስ።</title>
             <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Ṗāwlos qadāmāwi ḫaba sabʾa Qorontos</title>
             <title type="short">1 Cor.</title>
 

--- a/3001-4000/LIT3517Epistle.xml
+++ b/3001-4000/LIT3517Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1" xml:lang="en">Second Epistle to the Corinthians</title>
+            <title xml:id="t1" xml:lang="en" type="main">Second Epistle to the Corinthians</title>
             <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጳውሎስ፡ ዳግማዊ፡ ኀበ፡ ሰብአ፡ ቆሮንቶስ፡፡</title>
             <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Ṗāwlos dāgmāwi ḫaba sabʾa Qorontos</title>
             <title type="short">2 Cor.</title>

--- a/3001-4000/LIT3517Epistle.xml
+++ b/3001-4000/LIT3517Epistle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       <fileDesc>
          <titleStmt>
             <title xml:id="t1" xml:lang="en" type="main">Second Epistle to the Corinthians</title>
-            <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጳውሎስ፡ ዳግማዊ፡ ኀበ፡ ሰብአ፡ ቆሮንቶስ፡፡</title>
+            <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጳውሎስ፡ ዳግማዊ፡ ኀበ፡ ሰብአ፡ ቆሮንቶስ።</title>
             <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Ṗāwlos dāgmāwi ḫaba sabʾa Qorontos</title>
             <title type="short">2 Cor.</title>
             <editor role="generalEditor" key="AB"/>

--- a/3001-4000/LIT3517Epistle.xml
+++ b/3001-4000/LIT3517Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Second Epistle to the Corinthians</title>
+            <title xml:id="t1" xml:lang="en">Second Epistle to the Corinthians</title>
             <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጳውሎስ፡ ዳግማዊ፡ ኀበ፡ ሰብአ፡ ቆሮንቶስ፡፡</title>
             <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Ṗāwlos dāgmāwi ḫaba sabʾa Qorontos</title>
             <title type="short">2 Cor.</title>

--- a/3001-4000/LIT3524Epistle.xml
+++ b/3001-4000/LIT3524Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Epistle to the Hebrews</title>
+            <title xml:id="t1" xml:lang="en">Epistle to the Hebrews</title>
             <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጳውሎስ፡ ኀበ፡ ሰብአ፡ ዕብራዊያን፡</title>
             <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Ṗāwlos ḫaba sabʾa ʿǝbrāwiyan</title>
             <title type="short">Hebr.</title>

--- a/3001-4000/LIT3524Epistle.xml
+++ b/3001-4000/LIT3524Epistle.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1" xml:lang="en">Epistle to the Hebrews</title>
+            <title xml:id="t1" xml:lang="en" type="main">Epistle to the Hebrews</title>
             <title xml:id="t2" xml:lang="gez">መልእክተ፡ ጳውሎስ፡ ኀበ፡ ሰብአ፡ ዕብራዊያን፡</title>
             <title corresp="#t2" xml:lang="gez" type="normalized">Malʾǝkta Ṗāwlos ḫaba sabʾa ʿǝbrāwiyan</title>
             <title type="short">Hebr.</title>

--- a/3001-4000/LIT3584Intro.xml
+++ b/3001-4000/LIT3584Intro.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Introductive exhortation to the Taʾammǝra Māryām</title>
+            <title xml:id="t1" xml:lang="en">Introductive exhortation to the Taʾammǝra Māryām</title>
          </titleStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>

--- a/3001-4000/LIT3586Miracle.xml
+++ b/3001-4000/LIT3586Miracle.xml
@@ -4,8 +4,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Miracle of Mary: Miracle of Hildephonsus (Dexius) of Toledo</title>
-            <title xml:id="t2">About Ildefonsus
+            <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of Hildephonsus (Dexius) of Toledo</title>
+            <title xml:id="t2" xml:lang="en">About Ildefonsus
                (Daqǝsyos) of Toledo (Ṭǝlṭǝlyāyā)</title>
          </titleStmt>
          <publicationStmt>

--- a/3001-4000/LIT3588Miracle.xml
+++ b/3001-4000/LIT3588Miracle.xml
@@ -4,10 +4,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Miracle of Mary: Miracle of a picture of Mary speaking to a worker</title>
-            <title xml:id="t2">The Virgin Mary and the Artificer</title>
-            <title xml:id="t3">The peasant who complained to St. Mary because she did not reply to his Hail Mary</title>
-            <title xml:id="t4">The Virgin Mary and the workman</title>
+            <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of a picture of Mary speaking to a worker</title>
+            <title xml:id="t2" xml:lang="en">The Virgin Mary and the Artificer</title>
+            <title xml:id="t3" xml:lang="en">The peasant who complained to St. Mary because she did not reply to his Hail Mary</title>
+            <title xml:id="t4" xml:lang="en">The Virgin Mary and the workman</title>
          </titleStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>

--- a/3001-4000/LIT3589Miracle.xml
+++ b/3001-4000/LIT3589Miracle.xml
@@ -4,9 +4,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Miracle of Mary: Miracle of a Jew of ʾAḫmīm</title>
-            <title xml:id="t2">The pious monk whom St Mary made young</title>
-            <title xml:id="t3">The Jew of the city of Akhmim</title>
+            <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of a Jew of ʾAḫmīm</title>
+            <title xml:id="t2" xml:lang="en">The pious monk whom St Mary made young</title>
+            <title xml:id="t3" xml:lang="en">The Jew of the city of Akhmim</title>
          </titleStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>

--- a/3001-4000/LIT3590Miracle.xml
+++ b/3001-4000/LIT3590Miracle.xml
@@ -4,9 +4,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Miracle of Mary: Miracle of the scribe Damianus from Philippi</title>
+            <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of the scribe Damianus from Philippi</title>
             <title xml:id="t2" xml:lang="en">The pious monk scribe who used to write St Mary's name in golden ink</title>
-            <title xml:id="t3">The Virgin Mary and the scribe Damianus (Dǝmyanos) of Philippi</title>
+            <title xml:id="t3" xml:lang="en">The Virgin Mary and the scribe Damianus (Dǝmyanos) of Philippi</title>
          </titleStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>

--- a/3001-4000/LIT3591Miracle.xml
+++ b/3001-4000/LIT3591Miracle.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Miracle of Mary: Miracle of the Bishop of Rome, ʾAbbās (Leo)</title>
+            <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of the Bishop of Rome, ʾAbbās (Leo)</title>
             <title xml:id="t2" xml:lang="en">The Muslim whom St Mary told to receive baptism; later, as bishop of Rome, he cut off his hand because of a carnal thought</title>
          </titleStmt>
          <publicationStmt>

--- a/3001-4000/LIT3592Miracle.xml
+++ b/3001-4000/LIT3592Miracle.xml
@@ -4,9 +4,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Miracle of Mary: Miracle of the monk Isaac</title>
-            <title xml:id="t2">Miracle of the monk Yǝsḥāq</title>
-            <title xml:id="t3">The monk, Yǝsḥaq, who prayed for seven years that St Mary would appear to him</title>
+            <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of the monk Isaac</title>
+            <title xml:id="t2" xml:lang="en">Miracle of the monk Yǝsḥāq</title>
+            <title xml:id="t3" xml:lang="en">The monk, Yǝsḥaq, who prayed for seven years that St Mary would appear to him</title>
          </titleStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>

--- a/3001-4000/LIT3594Miracle.xml
+++ b/3001-4000/LIT3594Miracle.xml
@@ -4,9 +4,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Miracle of Mary: Miracle of a French painter whose scaffold was overthrown by the devil</title>
-            <title xml:id="t2">The French artist who fell from the scaffolding while painting frescoes</title>
-            <title xml:id="t3">The Virgin Mary and the painter decorating a church
+            <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of a French painter whose scaffold was overthrown by the devil</title>
+            <title xml:id="t2" xml:lang="en">The French artist who fell from the scaffolding while painting frescoes</title>
+            <title xml:id="t3" xml:lang="en">The Virgin Mary and the painter decorating a church
                in France</title>
          </titleStmt>
          <publicationStmt>

--- a/3001-4000/LIT3595Miracle.xml
+++ b/3001-4000/LIT3595Miracle.xml
@@ -4,9 +4,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Miracle of a sick man in a hospital whom Mary carries to Jerusalem</title>
-            <title xml:id="t2">St Mary carries a dying monk to Jerusalem</title>
-            <title xml:id="t3">The Virgin Mary and
+            <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of a sick man in a hospital whom Mary carries to Jerusalem</title>
+            <title xml:id="t2" xml:lang="en">St Mary carries a dying monk to Jerusalem</title>
+            <title xml:id="t3" xml:lang="en">The Virgin Mary and
                the sick monk in the Monastery of Pilgrims (Dabra Naggādǝyān)</title>
          </titleStmt>
          <publicationStmt>

--- a/3001-4000/LIT3622Miracle.xml
+++ b/3001-4000/LIT3622Miracle.xml
@@ -4,8 +4,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1">Miracle of Mary: Homily on a potter from Syria</title>
-            <title xml:id="t2">The composition of the Wǝddāse Māryām by the Syrian potter</title>
+            <title xml:id="t1" xml:lang="en">Miracle of Mary: Homily on a potter from Syria</title>
+            <title xml:id="t2" xml:lang="en">The composition of the Wǝddāse Māryām by the Syrian potter</title>
          </titleStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>

--- a/5001-6000/LIT5052SobaAshafa.xml
+++ b/5001-6000/LIT5052SobaAshafa.xml
@@ -6,6 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ሶበ፡ አጽሐፈ፡ ደቅስዮስ፡ ተአምርኪ፡ ቅዱሰ፡</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">Soba ʾaṣḥafa Daqsǝyos taʾammǝrǝki qǝddusa</title>
+                <title xml:lang="en" corresp="#t1" type="normalized">When Daqsǝyos had your holy miracles written</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="DR"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>


### PR DESCRIPTION
Here are further edits necessary for a better visualisation of the titles of works in our PDF.
For cases in which only the English title is given (like the individual miracles), t1 is printed.
The rules for visualisation for titles that are given in Geez and English differentiate between cases in which the literal translation of the Ethiopic title is given and cases where a more common, standard English version of the title is given:
1. ‘Literal translation of Ethiopic title’ (Ethiopic title in fidal), CAe XXXX, i.e. ‘Gospel of Matthew’ (ብስራተ፡ ማቴዎስ፡), CAe 2709.
if the work entry has `<title xml:lang="gez" xml:id="tX">`, `<title xml:lang="gez" corresp="#tX" type="normalized">` and `<title xml:lang="en" corresp="#tX" type="normalized">`,
or
2. Standard English Title (Ethiopic title in fidal), CAe XXXX, i.e. First Epistle to the Corinthians (መልእክተ፡ ጳውሎስ፡ ቀዳማዊ፡ ኀበ፡ ሰብአ፡ቆሮንቶስ።), CAe 3516.
if there is another title element that has `@xml:lang="en"` and `@type="main" `

If you have general questions or conceptual issues with this that go beyond the actual edits of this PR, we probably would better discuss it by email or zoom.
Thanks!