### PR TITLE
Created LIT for Mawāśəʿt za-ʾArsimā

### DIFF
--- a/1001-2000/LIT1990Mawase.xml
+++ b/1001-2000/LIT1990Mawase.xml
@@ -74,242 +74,242 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </listBibl>
          </div>
          <div type="edition">
-            <div type="textpart" corresp="LIT4424JohnTheBaptist">
+            <div type="textpart" corresp="LIT4424JohnTheBaptist" xml:id="JohnB">
                <label>Antiphon of John the Baptist, 1st Maskaram (<foreign xml:lang="gez">ዘበዓለ፡ ዮሐንስ፡ መጥምቅ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4425River">
+            <div type="textpart" corresp="LIT4425River" xml:id="River">
                <label>Antiphon of the River, i.e. the Jordan River, 2nd Maskaram (<foreign xml:lang="gez">ዘተከዜ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4426Zechariah">
+            <div type="textpart" corresp="LIT4426Zechariah" xml:id="Zechariah">
                <label>Antiphon of Zechariah, 2nd Maskaram (<foreign xml:lang="gez">ዘዘካርያስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4427Stephen1">
+            <div type="textpart" corresp="LIT4427Stephen1" xml:id="Stephen1">
                <label>Antiphon of Stephen the Protomartyr (<foreign xml:lang="gez">ዘእስጢፋኖስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4428Church">
+            <div type="textpart" corresp="LIT4428Church" xml:id="Church">
                <label>Antiphon of the construction of the Church (<foreign xml:lang="gez">ዘሕንጸተ፡ ቤተ፡ ክርስቲያን፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4429Cross">
+            <div type="textpart" corresp="LIT4429Cross" xml:id="Cross">
                <label>Antiphon of the Cross, 17th Maskaram (<foreign xml:lang="gez">ዘመስቀል፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4430Helen">
+            <div type="textpart" corresp="LIT4430Helen" xml:id="Helen">
                <label>Antiphon of Helen, mother of Emperor Constantine (<foreign xml:lang="gez">ዘእሌኒ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4431Righteous">
+            <div type="textpart" corresp="LIT4431Righteous" xml:id="Righteous">
                <label>Antiphon of the Righteous (<foreign xml:lang="gez">ዘጻድቃን፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4432Martyrs">
+            <div type="textpart" corresp="LIT4432Martyrs" xml:id="Martyrs">
                <label>Antiphon of the Martyrs (<foreign xml:lang="gez">ዘሰማዕት፡</foreign> or <foreign xml:lang="gez">ዘሰማዕታት፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4433GabraKrestos">
+            <div type="textpart" corresp="LIT4433GabraKrestos" xml:id="GabraKrestos">
                <label>Antiphon of Gabra Krǝstos (<foreign xml:lang="gez">ዘገብረ፡ ክርስቶስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4434Stephen16">
+            <div type="textpart" corresp="LIT4434Stephen16" xml:id="Stephen16">
                <label>Antiphon of Stephen, on the 16th day (<foreign xml:lang="gez">ዘእስጢፋኖስ፡ አመ፡ ፲ወ፮</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4435Stephen17">
+            <div type="textpart" corresp="LIT4435Stephen17" xml:id="Stephen17">
                <label>Antiphon of Stephen, on the 17th day (<foreign xml:lang="gez">ዘእስጢፋኖስ፡ አመ፡ ፲ወ፯</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4436Yohanni">
+            <div type="textpart" corresp="LIT4436Yohanni" xml:id="Yohanni">
                <label>Antiphon of ʾAbbā Yoḥanni (<foreign xml:lang="gez">ዘአባ፡ ዮሐኒ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4437FourBeasts1">
+            <div type="textpart" corresp="LIT4437FourBeasts1" xml:id="FourBeasts1">
                <label>Antiphon of the Four Beasts (<foreign xml:lang="gez">ዘ፬እንስሳ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4438FourBeasts2">
+            <div type="textpart" corresp="LIT4438FourBeasts2" xml:id="FourBeasts2">
                <label>Antiphon of the Four Beasts (<foreign xml:lang="gez">ዘ፬እንስሳ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4439Michael1">
+            <div type="textpart" corresp="LIT4439Michael1" xml:id="Michael1">
                <label>Antiphon of the Archangel Michael (<foreign xml:lang="gez">ዘሚካኤል፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4440Watchers">
+            <div type="textpart" corresp="LIT4440Watchers" xml:id="Watchers">
                <label>Antiphon of the Watchers, i.e. the Angels (<foreign xml:lang="gez">ዘቱጉሃን፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4441Minas">
+            <div type="textpart" corresp="LIT4441Minas" xml:id="Minas">
                <label>Antiphon of Minas (<foreign xml:lang="gez">ዘሚናስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4442HeavenlyPriests1">
+            <div type="textpart" corresp="LIT4442HeavenlyPriests1" xml:id="Priests1">
                <label>Antiphon of the Heavenly Priests (<foreign xml:lang="gez">ዘካህናተ፡ ሰማይ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4443HeavenlyPriests2">
+            <div type="textpart" corresp="LIT4443HeavenlyPriests2" xml:id="Priests2">
                <label>Antiphon of the Heavenly Priests (<foreign xml:lang="gez">ዘካህናተ፡ ሰማይ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4444Mercurius">
+            <div type="textpart" corresp="LIT4444Mercurius" xml:id="Mercurius">
                <label>Antiphon of Mercurius (<foreign xml:lang="gez">ዘማርቆሬዎስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4445Nagran">
+            <div type="textpart" corresp="LIT4445Nagran" xml:id="Nagran">
                <label>Antiphon of the Martyrs of Nāgrān (<foreign xml:lang="gez">ዘሰማዕታት፡ ዘናግራን፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4446Peter">
+            <div type="textpart" corresp="LIT4446Peter" xml:id="Peter">
                <label>Antiphon of Peter (<foreign xml:lang="gez">ዘጴጥሮስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4447ThreeChildren">
+            <div type="textpart" corresp="LIT4447ThreeChildren" xml:id="ThreeChildren">
                <label>Antiphon of the Three Children (<foreign xml:lang="gez">ዘ፫ደቂቅ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4448Gabriel">
+            <div type="textpart" corresp="LIT4448Gabriel" xml:id="Gabriel">
                <label>Antiphon of the Archangel Gabriel (<foreign xml:lang="gez">ዘገብርኤል፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4449Christmas">
+            <div type="textpart" corresp="LIT4449Christmas" xml:id="Christmas">
                <label>Antiphon of Christmas (<foreign xml:lang="gez">ዘጌና፡ ክርስቶስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4450Nativity">
+            <div type="textpart" corresp="LIT4450Nativity" xml:id="Nativity">
                <label>Antiphon of the Nativity (<foreign xml:lang="gez">ዘልደት፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4451AfterChristmas">
+            <div type="textpart" corresp="LIT4451AfterChristmas" xml:id="AfterChristmas">
                <label>Antiphon of the day after Christmas (<foreign xml:lang="gez">ዘሳኒታ፡ ጌና፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4452SundayChristmas">
+            <div type="textpart" corresp="LIT4452SundayChristmas" xml:id="SundayChristmas">
                <label>Antiphon of the Sunday after Christmas (<foreign xml:lang="gez">ዘሰንበተ፡ በዓለ፡ እግዚእነ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4453Children">
+            <div type="textpart" corresp="LIT4453Children" xml:id="Children">
                <label>Antiphon of the Children (<foreign xml:lang="gez">ዘሕፃናት፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4454Stephen2">
+            <div type="textpart" corresp="LIT4454Stephen2" xml:id="Stephen2">
                <label>Antiphon of Stephen the Protomartyr (<foreign xml:lang="gez">ዘእስጢፋኖስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4455Matta1">
+            <div type="textpart" corresp="LIT4455Matta1" xml:id="Matta1">
                <label>Antiphon of ʾAbbā Maṭṭāʿ or Libānos (<foreign xml:lang="gez">ዘአባ፡ መጣዕ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4456Matta2">
+            <div type="textpart" corresp="LIT4456Matta2" xml:id="Matta2">
                <label>Antiphon of ʾAbbā Maṭṭāʿ or Libānos (<foreign xml:lang="gez">ዘአባ፡ መጣዕ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4457EpiphanyEve">
+            <div type="textpart" corresp="LIT4457EpiphanyEve" xml:id="EpiphanyEve">
                <label>Antiphon of Epiphany Eve (<foreign xml:lang="gez">ዘመኃትወ፡ ኤጰፋንያ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4458Epiphany1">
+            <div type="textpart" corresp="LIT4458Epiphany1" xml:id="Epiphany1">
                <label>Antiphon of Epiphany (<foreign xml:lang="gez">ዘዕለተ፡ ኤጲፋንያ፡</foreign> or <foreign xml:lang="gez">ዘአስተርእዮ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4459Epiphany2">
+            <div type="textpart" corresp="LIT4459Epiphany2" xml:id="Epiphany2">
                <label>Antiphon of Epiphany</label>
             </div>
             <!-- cp. Dillmann 1847 (Cat. Mus. Brit.), p. 33b -->
-            <div type="textpart" corresp="LIT4460AfterEpiphany">
+            <div type="textpart" corresp="LIT4460AfterEpiphany" xml:id="AfterEpiphany">
                <label>Antiphon of the day after Epiphany (<foreign xml:lang="gez">በሰኒታ፡ በዓለ፡ ኤጰፋንያ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4461EpiphanyThird">
+            <div type="textpart" corresp="LIT4461EpiphanyThird" xml:id="EpiphanyThird">
                <label>Antiphon of the third day of Epiphany (<foreign xml:lang="gez">ዘሠሉሰ፡ ኤጲፋንያ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4462EpiphanyBaptism">
+            <div type="textpart" corresp="LIT4462EpiphanyBaptism" xml:id="EpiphanyBaptism">
                <label>Antiphon of the Baptism of Epiphany (<foreign xml:lang="gez">ዘጥምቀተ፡ ኤጲፋንያ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4463EpiphanyEighth">
+            <div type="textpart" corresp="LIT4463EpiphanyEighth" xml:id="EpiphanyEighth">
                <label>Antiphon of the eighth day of Epiphany</label>
             </div>
             <!-- በጥልቀተ፡ ኤጰፋንያ፡ in BAVet4, perhaps a scribal error for በጥምቀተ፡ -->
-            <div type="textpart" corresp="LIT4464CanaInGalilee">
+            <div type="textpart" corresp="LIT4464CanaInGalilee" xml:id="Cana">
                <label>Antiphon of Cana in Galilee (<foreign xml:lang="gez">ዘቃና፡ ዘገሊላ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4465Community">
+            <div type="textpart" corresp="LIT4465Community" xml:id="Community">
                <label>Antiphon of the community of saints (<foreign xml:lang="gez">ዘማኅበረ፡ ቅዱሳን፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4466Annunciation">
+            <div type="textpart" corresp="LIT4466Annunciation" xml:id="Annunciation">
                <label>Antiphon of the Annunciation (<foreign xml:lang="gez">ዘዜና፡ ገብርኤል፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4467PalmSunday">
+            <div type="textpart" corresp="LIT4467PalmSunday" xml:id="PalmSunday">
                <label>Antiphon of the Palm Sunday (<foreign xml:lang="gez">ዘሆሣዕና፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4468EasterEve1">
+            <div type="textpart" corresp="LIT4468EasterEve1" xml:id="EasterEve1">
                <label>Antiphon of Easter Eve, i.e. Good Friday (<foreign xml:lang="gez">ዘመኃትወ፡ ፋሲካ፡ መዋሥእት፡ ዘሰርክ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4469EasterEve2">
+            <div type="textpart" corresp="LIT4469EasterEve2" xml:id="EasterEve2">
                <label>Antiphon of other Easter Eve, i.e. Holy Saturday (<foreign xml:lang="gez">ዘዳግም፡</foreign> or <foreign xml:lang="gez">ዘሰንበተ፡ አይሁድ፡ በመኃትወ፡ ፋሲካ፡ ነግህ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4470EasterSunday">
+            <div type="textpart" corresp="LIT4470EasterSunday" xml:id="EasterSunday">
                <label>Antiphon of Easter Sunday (<foreign xml:lang="gez">ዘዕለተ፡ ፋሲካ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4471EasterMonday">
+            <div type="textpart" corresp="LIT4471EasterMonday" xml:id="EasterMonday">
                <label>Antiphon of Easter Monday (<foreign xml:lang="gez">ዘሰኑየ፡ ፋሲካ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4472EasterTuesday">
+            <div type="textpart" corresp="LIT4472EasterTuesday" xml:id="EasterTuesday">
                <label>Antiphon of Easter Tuesday (<foreign xml:lang="gez">ዘሠሉሰ፡ ፋሲካ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4473EasterWednesday">
+            <div type="textpart" corresp="LIT4473EasterWednesday" xml:id="EasterWednesday">
                <label>Antiphon of Easter Wednesday (<foreign xml:lang="gez">ዘረቡዐ፡ ፋሲካ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4474EasterThursday">
+            <div type="textpart" corresp="LIT4474EasterThursday" xml:id="EasterThursday">
                <label>Antiphon of Easter Thursday (<foreign xml:lang="gez">ዘኀሙሰ፡ ፋሲካ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4475EasterFriday">
+            <div type="textpart" corresp="LIT4475EasterFriday" xml:id="EasterFriday">
                <label>Antiphon of Easter Friday (<foreign xml:lang="gez">ዘዐርበ፡ ፋሲካ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4476EasterSaturday">
+            <div type="textpart" corresp="LIT4476EasterSaturday" xml:id="EasterSaturday">
                <label>Antiphon of Easter Saturday (<foreign xml:lang="gez">ዘሰቡዐ፡ ፋሲካ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4477InAlbis">
+            <div type="textpart" corresp="LIT4477InAlbis" xml:id="InAlbis">
                <label>Antiphon of the Dominica In Albis (<foreign xml:lang="gez">ዘሰንበተ፡ ክርስቲያን፡</foreign> or <foreign xml:lang="gez">ዘጥልቀተ፡ ፋሲካ፡</foreign> or <foreign xml:lang="gez">ዘ፰፡ ፋሲካ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4478Garments">
+            <div type="textpart" corresp="LIT4478Garments" xml:id="Garments">
                <label>Antiphon of Garments of the Virgins (<foreign xml:lang="gez">ዘአንብሮ፡ አልባስ፡ ዘደናግል፡</foreign>)</label>
             </div>
             <!-- ?? -->
-            <div type="textpart" corresp="LIT4479George">
+            <div type="textpart" corresp="LIT4479George" xml:id="George">
                <label>Antiphon of George (<foreign xml:lang="gez">ዘጊዮርጊስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4480CouncilOfPriests">
+            <div type="textpart" corresp="LIT4480CouncilOfPriests" xml:id="Council">
                <label>Antiphon of the council of priests, on the 25th day after Easter (<foreign xml:lang="gez">ዘረክበተ፡ ካህናት፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4481Egypt">
+            <div type="textpart" corresp="LIT4481Egypt" xml:id="Egypt">
                <label>Antiphon of the Flight to Egypt (<foreign xml:lang="gez">ዘበአተ፡ ግብጽ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4482Ascension">
+            <div type="textpart" corresp="LIT4482Ascension" xml:id="Ascension">
                <label>Antiphon of the Ascension Day (<foreign xml:lang="gez">ዘበዓለ፡ ፵</foreign> or <foreign xml:lang="gez">ዘዕለተ፡ ዕርገት፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4483Awet">
+            <div type="textpart" corresp="LIT4483Awet" xml:id="Awet">
                <label>Antiphon of the Nativity of John the Baptist, on the 30 Sane (<foreign xml:lang="gez">ዘአዌት፡ ዮሐንስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4484Pentecost">
+            <div type="textpart" corresp="LIT4484Pentecost" xml:id="Pentecost">
                <label>Antiphon of Pentecost (<foreign xml:lang="gez">በበዓለ፡ ፶</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4485Michael2">
+            <div type="textpart" corresp="LIT4485Michael2" xml:id="Michael2">
                <label>Antiphon of Michael (<foreign xml:lang="gez">ዘሚካኤል፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4486Garima1">
+            <div type="textpart" corresp="LIT4486Garima1" xml:id="Garima1">
                <label>Antiphon of ʾAbbā Garimā (<foreign xml:lang="gez">ዘአባ፡ ገሪማ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4487Garima2">
+            <div type="textpart" corresp="LIT4487Garima2" xml:id="Garima2">
                <label>Antiphon of ʾAbbā Garimā (<foreign xml:lang="gez">ዘአባ፡ ገሪማ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4488Apostles">
+            <div type="textpart" corresp="LIT4488Apostles" xml:id="Apostles">
                <label>Antiphon of the Apostles (<foreign xml:lang="gez">ዘሐዋርያት፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4489Qirqos">
+            <div type="textpart" corresp="LIT4489Qirqos" xml:id="Qirqos">
                <label>Antiphon of Cyriacus (<foreign xml:lang="gez">ዘቂርቆስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4490Virgins">
+            <div type="textpart" corresp="LIT4490Virgins" xml:id="Virgins">
                <label>Antiphon of the Virgins (<foreign xml:lang="gez">ዘደናግል፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4491Firstborn">
+            <div type="textpart" corresp="LIT4491Firstborn" xml:id="Firstborn">
                <label>Antiphon of the Firstborn (<foreign xml:lang="gez">ዘማኅበረ፡ በኵር፡</foreign>)</label>
                <!-- In BAVet15#p1_i9 an antiphon "in hiemali congregatione (ዘማኅበር፡ ዘክረምት፡)" -->
             </div>
-            <div type="textpart" corresp="LIT4492DabraTabor">
+            <div type="textpart" corresp="LIT4492DabraTabor" xml:id="DabraTabor">
                <label>Antiphon of Mount Tabor, i.e. the Transfiguration of Jesus Christ (<foreign xml:lang="gez">ዘደብረ፡ ታቦር፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4493Mary">
+            <div type="textpart" corresp="LIT4493Mary" xml:id="Mary">
                <label>Antiphon of Our Lady Mary (<foreign xml:lang="gez">ዘእግዝእትነ፡ ማርያም፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4494Abraham">
+            <div type="textpart" corresp="LIT4494Abraham" xml:id="Abraham">
                <label>Antiphon of Abraham (<foreign xml:lang="gez">ዘአብርሃም፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4495Melchizedek">
+            <div type="textpart" corresp="LIT4495Melchizedek" xml:id="Melchizedek">
                <label>Antiphon of Melchizedek (<foreign xml:lang="gez">ዘመልከ፡ ጼዴቅ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4496Beheading">
+            <div type="textpart" corresp="LIT4496Beheading" xml:id="Beheading">
                <label>Antiphon of the beheading of John the Baptist (<foreign xml:lang="gez">ዘምትረተ፡ ርእሱ፡ ለዮሐንስ፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4497Libanos">
+            <div type="textpart" corresp="LIT4497Libanos" xml:id="Libanos">
                <label>Antiphon of ʾAbbā Libānos</label>
             </div>
-            <div type="textpart" corresp="LIT4498Pilgrims">
+            <div type="textpart" corresp="LIT4498Pilgrims" xml:id="Pilgrims">
                <label>Antiphon of Pilgrims (<foreign xml:lang="gez">ዘፈላስያን፡</foreign>)</label>
             </div>
-            <div type="textpart" corresp="LIT4499Sunday">
+            <div type="textpart" corresp="LIT4499Sunday" xml:id="Sunday">
                <label>Antiphon of Sunday  (<foreign xml:lang="gez">ዘሰንበተ፡ ክርስቲያን፡</foreign>)</label>
             </div>
             <div type="textpart" xml:id="Haleta">
               <label>Table of melodic variations for the Hallelujah <foreign xml:lang="gez">አንቀጸ፡ ሃሌታ፡</foreign></label>
             </div>
-            <div type="textpart" xml:id="LIT6841MawArsima">
+            <div type="textpart" corresp="LIT6841MawArsima" xml:id="Arsima">
                <label>Antiphon of ʾArsima (<foreign xml:lang="gez">መዋሥእት፡ ዘአርሲማ፡</foreign></label>
             </div>
          </div>

--- a/1001-2000/LIT1990Mawase.xml
+++ b/1001-2000/LIT1990Mawase.xml
@@ -309,7 +309,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <div type="textpart" xml:id="Haleta">
               <label>Table of melodic variations for the Hallelujah <foreign xml:lang="gez">አንቀጸ፡ ሃሌታ፡</foreign></label>
             </div>
-
+            <div type="textpart" xml:id="LIT6841MawArsima">
+               <label>Antiphon of ʾArsima (<foreign xml:lang="gez">መዋሥእት፡ ዘአርሲማ፡</foreign></label>
+            </div>
          </div>
       </body>
    </text>

--- a/new/LIT6841MawArsima.xml
+++ b/new/LIT6841MawArsima.xml
@@ -1,0 +1,91 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6841MawArsima" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Mawāśəʿt za-ʾArsimā</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Antiphon attributed to <persName ref="PRS8126Rhipsime"/>. 
+                    According to <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">91</citedRange></bibl> 
+                    with just one witnesses in <ref type="mss" target="BMLor148#ms_i2"/>, but edited and translated in 
+                    <bibl><ptr target="bm:Cerulli1964LOriente"/><citedRange unit="page">34-40</citedRange></bibl>.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Liturgy"/>
+                    <term key="Chants"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-06-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="secondary">
+                    <bibl><ptr target="bm:Marrassini1987manoscrittietiopici"/><citedRange unit="page">91</citedRange></bibl>
+                </listBibl>
+                <listBibl type="editions">
+                    <bibl><ptr target="bm:Cerulli1956LetteraturaEtiop"/><citedRange unit="page">213-220</citedRange></bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT6841MawArsima" passive="BMLor148"/>
+                    <relation name="dcterms:isPartOf" active="LIT6841MawArsima" passive="LIT1990Mawase"/>
+                </listRelation>
+            </div>
+            <div type="edition" subtype="incipit" xml:lang="gez">
+                <ab><hi rend="rubric">መዋሥእት፡ ዘ<persName ref="PRS8126Rhipsime">አርሲማ፡</persName> ብፅዕት፡ ዘ፫</hi>መልዕልተ፡ ኰኵሕ፡ ዲበ፡ 
+                    ወርቅ፡ ሐነጸት፡ ቤታ፡ ነፋሳት፡ ዘኢይክሉ፡ አንቀልቅሎታ፡ ብፅዕት፡ አርሲማ፡ በስመ፡ ኢየሱስ፡ ጸንዐ፡ መሰረታ። ዘ፬፡ ረሰየት፡ ሥጋሃ፡ ከመ፡ ጽኑዕ፡ ሐመር፡ ዘኢይቀርቦ፡ ማዕበል፡ ካልእኒሃ፡ 
+                    ታስተጻንዕ፡ በገድል፡ እንዘ፡ ትየውሆሙ፡ በቃል። ዘ<hi rend="rubric">፲፬፡</hi> <add place="above">ኀ</add>በ፡ እቶነ፡ እሳት፡ ወረወት፡ ርእሳ፡ እማይ፡ 
+                    ወእመንፈስ፡ እሳተ፡ ለቢሳ፡ በከመ፡ ተጽሕፈ፡ በወንጌል፡ መጠወት፡ ነፍሳ። </ab>
+            </div>
+            <div type="edition" subtype="explicit" xml:lang="gez">
+                <ab>ተዝካሬ፡ <gap reason="illegible" unit="chars" quantity="6"/>ጋቢአነ፡ አሐቲ፡ <gap reason="illegible" unit="chars" quantity="4"/>ን፡ 
+                    እምኵ<gap reason="illegible" unit="chars" quantity="8"/><pb n="4va"/>ብ፡ መዝገበ፡ ዘኢይማስን፡ በፃፄ፡ ወናምስጥ፡ እምዕፄ። 
+                    <hi rend="rubric">ወዓዲ፡</hi> አልቦ፡ ዘይዐቢያ፡ እምኵሎን፡ አንስት፡ ዘእንበለ፡ ማርያም፡ ሙዳየ፡ ትንቢት፡ ዐቢይ፡ ስማ፡ በመንግሥተ፡ ሰማያት፡ ንግበር፡ ተዝካራ፡ 
+                    በስብሓት። ። ። ።
+                    ሱቀነ፡ ኢያስጥመነ፡ ሰርመ፡ ኃጢአት። በትንብልናሃ፡ ለ<persName ref="PRS8126Rhipsime">አርሲማ፡</persName> በፅዕት፡ ወእለ፡ ምስሌሃ፡ ስማዕት። 
+                    ክፍለነ፡ ነሀሉ፡ በቀዳሚ፡ ርስት፡ በዐሠርቱ፡ ምእት፡ ዓመት፡ አመ፡ ትነግሥ፡ ለሰማዕታት፡ በሀገር፡ ቅድስ<gap reason="illegible" unit="chars" quantity="1"/>፡ 
+                    በከመ፡ ብፅዕት፡ <persName ref="PRS8126Rhipsime">አርሲማ፡</persName> ዘአዕደዋ፡ እምባሕር፡ ሐዲፎ፡ በከመ፡ ብፅዕት፡ 
+                    <persName ref="PRS8126Rhipsime">አርሲማ፡</persName> እምነኪር፡ ይምሕኮ፡ ለአድኅኖ፡ ይፌኑ፡ መልአኮ። ከመ፡ 
+                    <persName ref="PRS8126Rhipsime">አርሲማ፡</persName> ዘያኀሦ፡ ጽሂቆ፡ በየማኑ፡ ይሰውቆ፡ ለዘ፡ ከመዝ፡ ያሰረጉ፡ 
+                    ጽድቆ<gap reason="illegible" unit="chars" quantity="1"/>፡ ብፅዕት፡ <persName ref="PRS8126Rhipsime">አርሲማ፡</persName>
+                    ወእለ፡ ምስሌሃ፡ ሰማዕት፡ ፈጸሙ፡ ገድሎሙ፡ ኀብስተ፡ እምሰማይ፡ ወሀቦሙ፡ ወመጠዎሙ፡ ጽዋዐ፡ ምሉአ፡ ማየ፡ ገነት፡ ፀዐዳ፡ በልዑ፡ ወጸግቡ፡ በመንፈስ፡ ቅዱስ፡ ጸንዑ፡ 
+                    በገ<add place="inline">ድ</add>ሎሙ፡ ሞኡ፡ ሀገሮሙ፡ ቦኡ፡ ይክፍለነ፡ ምስሌሆሙ፡ በሐዳስ፡ ምድር፡ መንግሥቶ፡ 
+                    ወጽ<add place="above">ድ</add>ቆ፡ በዳግም፡ ቀመር።</ab>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created a LIT ID for Mawāśəʿt za-ʾArsimā, as attested in BMLor148 and discussed in Issue [#2381](https://github.com/BetaMasaheft/Documentation/issues/2381). I added this ID also to the general record as `<div>`, because quiet a good number of Antiphons is listed there as `<div>` already.