### PR TITLE
New LIT for Zəmmāre za-Hosāʿnā and Zəmmāre za-Dabra Zayt

### DIFF
--- a/new/LIT6847ZemmareHosana.xml
+++ b/new/LIT6847ZemmareHosana.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:id="t1" xml:lang="gez">ዝማሬ፡ ዘሆሳዕና፡</title>
                 <title corresp="#t1" xml:lang="gez" type="normalized">Zəmmāre za-Hosāʿnā</title>
-                <title corresp="#t1" xml:lang="en">Chant of Hosanna</title>
+                <title corresp="#t1" xml:lang="en">Chant for Hosanna</title>
                 <title xml:id="t2">Hymn for Palm Sunday</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>

--- a/new/LIT6847ZemmareHosana.xml
+++ b/new/LIT6847ZemmareHosana.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6847ZemmareHosana" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:id="t1" xml:lang="gez">ዝማሬ፡ ዘሆሳዕና፡</title>
+                <title corresp="#t1" xml:lang="gez" type="normalized">Zəmmāre za-Hosāʿnā</title>
+                <title corresp="#t1" xml:lang="en">Chant of Hosianna</title>
+                <title xml:id="t2">Hymn for Palm Sunday</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Chants"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Poetry"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-07-05">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT6847ZemmareHosana" passive="BMLor148#a1"/>
+                    <relation name="saws:formsPartOf" active="LIT6847ZemmareHosana" passive="LIT2610Zemmar"/>
+                </listRelation>
+            </div>
+            <div type="edition" corresp="a1" xml:lang="gez">
+                <ab><add place="above">ሀዘ</add>ዝማሬ፡ ዘሆሳዕና፡ ግዕዝ፡ ንዜኑ፡ ክብራ፡ ለዐድግት፡ እስመ፡ ተጻዕነ፡ ለዕሌሃ፡ ነደ፡ እሳት፡ ነበልበለ፡ ኀይል። አትሕትና፡ ዘእንበለ፡ 
+                    መስፈርት፡ አትሕትና፡ ዘእንበለ፡ ዐቅም። ለርኁባን፡ ኅብስት፡ ለጽሙዐን፡ አነቅዕት። ኦ። ተቀበልዎ፡ ነሲኦሙ፡ አዕጹቀ፡ በቀልት፡ ደቂቅ፡ አዕሩግ፡ ወሕፃናት። ኦ። ተጽኢኖ፡ ዲበ፡ አድግ፡
+                    ወእዋለ፡ ቡአ፡ እየሩሳሌም፡ በእንተ፡ ሰንበት፡ ወይቤሉ፡ ሆሳዕና፡ በአርያም። ኦ። በከመ፡ ነስአ፡ አብርሃም፡ አዕጽቀ፡ በቀልት፡ ሰብሐ፡ ወዘመረ፡ በ<cb n="1rb"/>በእለተ፡ ሰንበት።
+                    ኦ።<add place="above">እም</add>ተጽዕነ፡ ዲበ፡ ዕዋል፡ ዘይጼዐን፡ ለዕለ፡ <persName ref="PRS13936Kirubel">ኪሩ፡ ቤል፡ </persName>
+                 <note>Text is taken from <ref type="mss" target="BMLor148#a1"/>.</note>
+                </ab>          
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6847ZemmareHosana.xml
+++ b/new/LIT6847ZemmareHosana.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:id="t1" xml:lang="gez">ዝማሬ፡ ዘሆሳዕና፡</title>
                 <title corresp="#t1" xml:lang="gez" type="normalized">Zəmmāre za-Hosāʿnā</title>
-                <title corresp="#t1" xml:lang="en">Chant of Hosianna</title>
+                <title corresp="#t1" xml:lang="en">Chant of Hosanna</title>
                 <title xml:id="t2">Hymn for Palm Sunday</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
@@ -59,7 +59,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <relation name="saws:formsPartOf" active="LIT6847ZemmareHosana" passive="LIT2610Zemmar"/>
                 </listRelation>
             </div>
-            <div type="edition" corresp="a1" xml:lang="gez">
+            <div type="edition" xml:lang="gez">
+                <note>The following text is taken from <ref type="mss" corresp="BMLor148#a1"/>.</note>
                 <ab><add place="above">ሀዘ</add>ዝማሬ፡ ዘሆሳዕና፡ ግዕዝ፡ ንዜኑ፡ ክብራ፡ ለዐድግት፡ እስመ፡ ተጻዕነ፡ ለዕሌሃ፡ ነደ፡ እሳት፡ ነበልበለ፡ ኀይል። አትሕትና፡ ዘእንበለ፡ 
                     መስፈርት፡ አትሕትና፡ ዘእንበለ፡ ዐቅም። ለርኁባን፡ ኅብስት፡ ለጽሙዐን፡ አነቅዕት። ኦ። ተቀበልዎ፡ ነሲኦሙ፡ አዕጹቀ፡ በቀልት፡ ደቂቅ፡ አዕሩግ፡ ወሕፃናት። ኦ። ተጽኢኖ፡ ዲበ፡ አድግ፡
                     ወእዋለ፡ ቡአ፡ እየሩሳሌም፡ በእንተ፡ ሰንበት፡ ወይቤሉ፡ ሆሳዕና፡ በአርያም። ኦ። በከመ፡ ነስአ፡ አብርሃም፡ አዕጽቀ፡ በቀልት፡ ሰብሐ፡ ወዘመረ፡ በ<cb n="1rb"/>በእለተ፡ ሰንበት።

--- a/new/LIT6848ZemmareDabraZa.xml
+++ b/new/LIT6848ZemmareDabraZa.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ዝማሬ፡ ዘደብረ፡ ዘይት፡</title>
                 <title corresp="#t1" xml:lang="gez" type="normalized">Zəmmāre za-Dabra Zayt</title>
-                <title corresp="#t1" xml:lang="en">Chant to the Mount of Olives</title>
+                <title corresp="#t1" xml:lang="en">Chant for Dabra Zayt</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -58,7 +58,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <relation name="saws:formsPartOf" active="LIT6848ZemmareDabraZa" passive="LIT2610Zemmar"/>
                 </listRelation>
             </div>
-            <div type="edition" corresp="a2" xml:lang="gez">
+            <div type="edition" xml:lang="gez">
+                <note>The following text is taken from <ref type="mss" corresp="BMLor148#a2"/>.</note>
                 <ab>ዝማሪ፡ ዘደብረ፡ ዘይት፡ እንዘ፡ ይነብር፡ እግዚእነ፡ ውስተ፡ ደብረ፡ ዘይት፡ ተስእልዎ፡ 
                     አርዳኢሁ፡ ወይቤልዎ፡ ማእዜ፡ ይከውን፡ ምጽእትከ፡ ወለሕልቀተ፡ ዓለም፡ ወይ<gap reason="illegible" unit="chars" quantity="2"/>ሙ፡ ለአርዳኢሁ፡ እምበለስ፡
                     አእምሩ፡ አዕጹቀሁ፡ ወይትነሥአ፡ አሕዝብ፡ ለዕለ፡ ሕዝብ፡ ወይከውን፡ ብድብደ፡ ወድልቅልቅ፡ በበብሔር፡ ዝኵሉ፡ ለእመ፡ ኮነ፡ አሚሀ፡ ኬ፡ ምጽአቱ፡ ለወልደ፡ እጓለ፡ እምሕያው፡ 

--- a/new/LIT6848ZemmareDabraZa.xml
+++ b/new/LIT6848ZemmareDabraZa.xml
@@ -1,0 +1,70 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6848ZemmareDabraZa" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">ዝማሬ፡ ዘደብረ፡ ዘይት፡</title>
+                <title corresp="#t1" xml:lang="gez" type="normalized">Zəmmāre za-Dabra Zayt</title>
+                <title corresp="#t1" xml:lang="en">Chant to the Mount of Olives</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Hymn dedicated to <placeName ref="LOC4878Mounto"/>.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Chants"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Poetry"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-07-05">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT6848ZemmareDabraZa" passive="BMLor148#a2"/>
+                    <relation name="saws:formsPartOf" active="LIT6848ZemmareDabraZa" passive="LIT2610Zemmar"/>
+                </listRelation>
+            </div>
+            <div type="edition" corresp="a2" xml:lang="gez">
+                <ab>ዝማሪ፡ ዘደብረ፡ ዘይት፡ እንዘ፡ ይነብር፡ እግዚእነ፡ ውስተ፡ ደብረ፡ ዘይት፡ ተስእልዎ፡ 
+                    አርዳኢሁ፡ ወይቤልዎ፡ ማእዜ፡ ይከውን፡ ምጽእትከ፡ ወለሕልቀተ፡ ዓለም፡ ወይ<gap reason="illegible" unit="chars" quantity="2"/>ሙ፡ ለአርዳኢሁ፡ እምበለስ፡
+                    አእምሩ፡ አዕጹቀሁ፡ ወይትነሥአ፡ አሕዝብ፡ ለዕለ፡ ሕዝብ፡ ወይከውን፡ ብድብደ፡ ወድልቅልቅ፡ በበብሔር፡ ዝኵሉ፡ ለእመ፡ ኮነ፡ አሚሀ፡ ኬ፡ ምጽአቱ፡ ለወልደ፡ እጓለ፡ እምሕያው፡ 
+                    ምስለ፡ ኵሉ፡ ኀይለ፡ ሰማይት፡ አሜሃ፡ ይውሕዝ፡ <gap reason="illegible" unit="chars" quantity="2"/>ዝ፡ እሳት፡ 
+                    ወ<gap reason="illegible" unit="chars" quantity="4"/>ብሱ፡ አብሕርተ፡ እሳት፡ ወይትረወጹ፡ መላእክት፡ ለአሣተ፡ ጋብአ፡</ab>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created two new ID for Zəmmāre za-Hosāʿnā and Zəmmāre za-Dabra Zayt according to our discussion in Issue #2380. I added a relation to point to the general record of LIT2610Zemmar as it was discussed to treat them as if they were part-texts of the general record (as discussed in Issue #2381).