### PR TITLE
Created 3 new LIT IDs for Mastabqweʿ za-Māryām and updated LIT4713Liton

### DIFF
--- a/4001-5000/LIT4713Liton.xml
+++ b/4001-5000/LIT4713Liton.xml
@@ -25,11 +25,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 </availability>
             </publicationStmt>
             <sourceDesc>
-            <p>Work of the literatures of Ethiopia and Eritrea</p>
+                <listWit>
+                    <witness corresp="ESakm009"/>
+                    <witness corresp="ESam007"/>
+                    <witness corresp="EMML4190"/>
+                </listWit> 
          </sourceDesc>
-         <sourceDesc>
-                <p/>
-            </sourceDesc>
         </fileDesc>
         <encodingDesc>
             <p>A digital born TEI file</p>
@@ -42,10 +43,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <profileDesc>
             <creation/>
             <abstract>
-                <p>
-                    The office contains prayers for the sick, the pilgrims, the rain, the fruits of the earth, the water of the rivers, the king, the sleepers, the offerers, the 
-                    catechumens, the peace, the Church.
-                </p>
+                <p>The office contains prayers for the sick, the pilgrims, the rain, the fruits of the earth, the water of the rivers, the king, the sleepers, the offerers, the 
+                    catechumens, the peace, the Church.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -62,13 +61,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
       <body>
-          <div type="bibliography">
-              <listRelation>
-                  <relation name="lawd:hasAttestation" active="LIT6907MastabqMar" passive="ESakm009"/>
-                  <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="ESam007"/>
-                  <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="EMML4190"/>
-              </listRelation>
-          </div>
           <div type="bibliography">
               <listBibl type="editions">
                   <bibl>

--- a/4001-5000/LIT4713Liton.xml
+++ b/4001-5000/LIT4713Liton.xml
@@ -7,6 +7,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <title xml:lang="gez" xml:id="t1">ሊጦን፡ ዘመስቀል፡</title>
                 <title corresp="#t1" xml:lang="gez">Liṭon za-masqal</title>
                 <title corresp="#t1" xml:lang="en">Litany of the Cross</title>
+                <title xml:lang="gez" xml:id="t2">መስተብቍዕ፡ ዘመስቀል፡</title>
+                <title xml:lang="gez" corresp="#t2" type="normalized">Mastabqʷǝʿ za-Masqal</title>
+                <title xml:lang="gez" xml:id="t3">መስተብቍዕ፡ ዘመድኃኔ፡ ዓለም፡</title>
+                <title xml:lang="gez" corresp="#t3" type="normalized">Mastabqʷǝʿ za-Madḫane ʿālam</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -47,6 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <keywords>
                     <term key="Liturgy"/>
                     <term key="ChristianLiterature"/>
+                    <term key="Prayers"/>
                 </keywords>
             </textClass>
             <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
@@ -57,13 +62,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
       <body>
-        <div type="edition">
-            <div type="textpart" subtype="incipit" xml:lang="gez" xml:id="Incipit">
-                <ab>
-                    ወካዕበ፡ ናስተበቍዖ፡ ለዕፀ፡ መስቀል፡ ቅዱስ፡ ጽኑአ፡ ሥልጣን፡ ወኃይል፡
-                </ab>
-            </div>
-        </div>
+          <div type="bibliography">
+              <listRelation>
+                  <relation name="lawd:hasAttestation" active="LIT6907MastabqMar" passive="ESakm009"/>
+                  <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="ESam007"/>
+                  <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="EMML4190"/>
+              </listRelation>
+          </div>
+          <div type="bibliography">
+              <listBibl type="editions">
+                  <bibl>
+                      <ptr target="bm:Getachew2004Estifanos"/><citedRange>38-41</citedRange>
+                  </bibl>
+              </listBibl>
+          </div>
+        <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez" xml:id="Incipit">
+            <ab>ወካዕበ፡ ናስተበቍዖ፡ ለዕፀ፡ ቅዱስ፡ መስቀል፡ ጽኑዐ፡ ሥልጣን፡ ወኀይል፡ ወሊሉየ፡ መልክእ፡ ወአካል፡ እመልክአ፡ በትሩ፡ ለአሮን፡ ካህነ፡ ጽላሎት፡ ወአምሳል፡</ab>
+        </div></div>
+        <div type="edition"><div type="textpart" subtype="explicit" xml:lang="gez" xml:id="Explicit">
+                  <ab>ለእሉ፡ ክልኤ፡ ፍጡራን፡ ስብሐተ፡ ፈጣሪ፡ ይደልዎሙ፡ እስመ፡ ተዐረዩ፡ በክብሮሙ፡ ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን።</ab>
+        </div></div>
       </body>
     </text>
 </TEI>

--- a/new/LIT6906MastabqMar.xml
+++ b/new/LIT6906MastabqMar.xml
@@ -5,7 +5,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Mastabqʷǝʿ za-Māryām (ʾƎgziʾabǝḥer ʾƎgziʾo)</title>
+                <title xml:lang="gez" xml:id="t1">መስተብቍዕ፡ ዘማርያም፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Mastabqʷǝʿ za-Māryām</title>
+                <title xml:id="t2">Mastabqʷǝʿ za-Māryām I</title>
+                <title xml:lang="gez" xml:id="t3">እግዚአብሔር፡ እግዚኦ፡</title>
+                <title xml:lang="gez" corresp="#t3">ʾƎgziʾabǝḥer ʾƎgziʾo</title>
+                <title xml:lang="gez" xml:id="t4">ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ዘወትር።</title>
+                <title xml:lang="gez" corresp="#t4" type="normalized">ṣalot za-ʾƎgzəʾətəna Māryām zawatər</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -21,7 +27,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <p/>
+                <listWit>
+                    <witness corresp="ESakm009"></witness>
+                    <witness corresp="BLorient545"></witness>
+                    <witness corresp="BNFet13"></witness>
+                    <witness corresp="EMML1434"></witness>
+                    <witness corresp="EMML4190"></witness>
+                </listWit>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -34,11 +46,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
-                    <term key="Chants"/>
                     <term key="ChristianLiterature"/>
                     <term key="Liturgy"/>
-                    <term key="Missal"/>
-                    <term key="Religion"/>
+                    <term key="Prayers"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -52,11 +62,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive=""/>
-                </listRelation>
-            </div><!---->
+            <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
+                <ab>እግዚአብሔር፡ እግዚኦ፡ ኢየሱስ፡ ክርስቶስ፡ አምላክነ፡ ዘትቤሎ፡ ለፍቁርከ፡ ዮሐንስ፡ እንዘ፡ ሀሎከ፡ ዲበ፡ 
+                    ዕፀ፡ መስቀል፡ ቅዱስ፡ ወትቤላ፡ ለማርያም፡ ነዋ፡ ወልድኪ፡ ወለረድእከኒ፡ ነያ፡ እምከ፡</ab>
+            </div></div>
+            <div type="edition"><div type="textpart" subtype="explicit" xml:lang="gez">
+                <ab>ስማዕ፡ ጸሎተ፡ ኵሉ፡ ዘሥጋ፡ በእንተ፡ ማርያም፡ ምልእተ፡ ጸጋ፡ ይእዜኒ፡ ወዘልፈኒ፡ ወለዓለመ፡ ዓለም፡ አሜን።</ab>
+            </div></div><!---->
         </body>
-    </text>
+  </text>
 </TEI>

--- a/new/LIT6906MastabqMar.xml
+++ b/new/LIT6906MastabqMar.xml
@@ -11,7 +11,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="gez" xml:id="t3">እግዚአብሔር፡ እግዚኦ፡</title>
                 <title xml:lang="gez" corresp="#t3">ʾƎgziʾabǝḥer ʾƎgziʾo</title>
                 <title xml:lang="gez" xml:id="t4">ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ዘወትር።</title>
-                <title xml:lang="gez" corresp="#t4" type="normalized">Ṣalot za-ʾǝgzǝʾǝtǝna Māryām za-watǝr</title>
+                <title xml:lang="gez" corresp="#t4" type="normalized">Ṣalot za-ʾǝgzǝʾtǝna Māryām za-watr</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -42,8 +42,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="#LIT4713Liton"/>, but also circulate 
-                    independently together with <ref type="work" corresp="LIT6907MastabqMar"/>.</p>
+                <p/>
             </abstract>
             <textClass>
                 <keywords>

--- a/new/LIT6906MastabqMar.xml
+++ b/new/LIT6906MastabqMar.xml
@@ -63,6 +63,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
+            <listBibl type="secondary">
+                <bibl>
+                    <ptr target="bm:Bahr2023Litanies"/>
+                </bibl>
+            </listBibl>
             <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
                 <ab>እግዚአብሔር፡ እግዚኦ፡ ኢየሱስ፡ ክርስቶስ፡ አምላክነ፡ ዘትቤሎ፡ ለፍቁርከ፡ ዮሐንስ፡ እንዘ፡ ሀሎከ፡ ዲበ፡ 
                     ዕፀ፡ መስቀል፡ ቅዱስ፡ ወትቤላ፡ ለማርያም፡ ነዋ፡ ወልድኪ፡ ወለረድእከኒ፡ ነያ፡ እምከ፡</ab>

--- a/new/LIT6906MastabqMar.xml
+++ b/new/LIT6906MastabqMar.xml
@@ -1,0 +1,62 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6906MastabqMar" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Mastabqʷǝʿ za-Māryām (ʾƎgziʾabǝḥer ʾƎgziʾo)</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Chants"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Liturgy"/>
+                    <term key="Missal"/>
+                    <term key="Religion"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-22">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive=""/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6906MastabqMar.xml
+++ b/new/LIT6906MastabqMar.xml
@@ -11,7 +11,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="gez" xml:id="t3">እግዚአብሔር፡ እግዚኦ፡</title>
                 <title xml:lang="gez" corresp="#t3">ʾƎgziʾabǝḥer ʾƎgziʾo</title>
                 <title xml:lang="gez" xml:id="t4">ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ዘወትር።</title>
-                <title xml:lang="gez" corresp="#t4" type="normalized">ṣalot za-ʾƎgzəʾətəna Māryām zawatər</title>
+                <title xml:lang="gez" corresp="#t4" type="normalized">ṣalot za-ʾƎgzǝʾǝtǝna Māryām zawatǝr</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT6906MastabqMar.xml
+++ b/new/LIT6906MastabqMar.xml
@@ -11,7 +11,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="gez" xml:id="t3">እግዚአብሔር፡ እግዚኦ፡</title>
                 <title xml:lang="gez" corresp="#t3">ʾƎgziʾabǝḥer ʾƎgziʾo</title>
                 <title xml:lang="gez" xml:id="t4">ጸሎት፡ ዘእግዝእትነ፡ ማርያም፡ ዘወትር።</title>
-                <title xml:lang="gez" corresp="#t4" type="normalized">ṣalot za-ʾƎgzǝʾǝtǝna Māryām zawatǝr</title>
+                <title xml:lang="gez" corresp="#t4" type="normalized">Ṣalot za-ʾǝgzǝʾǝtǝna Māryām za-watǝr</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -42,7 +42,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p/>
+                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="#LIT4713Liton"/>, but also circulate 
+                    independently together with <ref type="work" corresp="LIT6907MastabqMar"/>.</p>
             </abstract>
             <textClass>
                 <keywords>

--- a/new/LIT6907MastabqMar.xml
+++ b/new/LIT6907MastabqMar.xml
@@ -27,7 +27,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <p/>
+                <listWit>
+                    <witness corresp="ESakm009"></witness>
+                    <witness corresp="BLorient545"></witness>
+                    <witness corresp="BNFet13"></witness>
+                    <witness corresp="EMML1434"></witness>
+                    <witness corresp="EMML4190"></witness>
+                </listWit>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -57,15 +63,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT6907MastabqMar" passive="ESakm009"/>
-                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="BLorient545"/>
-                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="BNFet13"/>
-                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="EMML1434"/>
-                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="EMML4190"/>
-                </listRelation>
-            </div>
             <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
                 <ab>ወካዕበ፡ ናስተበቍዓ፡ ለንግሥተ፡ ኵልነ፡ ማርያም፡ እምነ፡ ወእሙ፡ ለእግዚእነ፡ ወመድኀኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ንስእል፡ ወነኀሥሥ፡ ናስተበቍዕ፡ ወንዌድስ፡ ዕበየ፡ 
                     ተአምሪሃ፡ ብዙኀ፡ ለእመ፡ ጸባኦት፡ ንጉሥ፡</ab>

--- a/new/LIT6907MastabqMar.xml
+++ b/new/LIT6907MastabqMar.xml
@@ -11,7 +11,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="gez" xml:id="t3">ወካዕበ፡ ናስተበቍዓ፡ ለንግሥተ፡ ኵልነ፡</title>
                 <title xml:lang="gez" corresp="#t3">wa-kāʿba nāstabaqqʷǝʿā la-nǝgǝśta kʷǝllǝna</title>
                 <title xml:lang="gez" xml:id="t4">ዓዲ፡ መስተብቍዕ፡ ዘማርያም፡</title>
-                <title xml:lang="gez" corresp="#t4" type="normalized">ʿĀdi Mastabqʷəʿ za-Māryām</title>
+                <title xml:lang="gez" corresp="#t4" type="normalized">ʿĀdi Mastabqʷǝʿ za-Māryām</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT6907MastabqMar.xml
+++ b/new/LIT6907MastabqMar.xml
@@ -63,6 +63,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
+            <listBibl type="secondary">
+                <bibl>
+                    <ptr target="bm:Bahr2023Litanies"/>
+                </bibl>
+            </listBibl>
             <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
                 <ab>ወካዕበ፡ ናስተበቍዓ፡ ለንግሥተ፡ ኵልነ፡ ማርያም፡ እምነ፡ ወእሙ፡ ለእግዚእነ፡ ወመድኀኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ንስእል፡ ወነኀሥሥ፡ ናስተበቍዕ፡ ወንዌድስ፡ ዕበየ፡ 
                     ተአምሪሃ፡ ብዙኀ፡ ለእመ፡ ጸባኦት፡ ንጉሥ፡</ab>

--- a/new/LIT6907MastabqMar.xml
+++ b/new/LIT6907MastabqMar.xml
@@ -9,9 +9,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="gez" corresp="#t1" type="normalized">Mastabqʷǝʿ za-Māryām</title>
                 <title xml:id="t2">Mastabqʷǝʿ za-Māryām II</title>
                 <title xml:lang="gez" xml:id="t3">ወካዕበ፡ ናስተበቍዓ፡ ለንግሥተ፡ ኵልነ፡</title>
-                <title xml:lang="gez" corresp="#t3">wa-kāʿba nāstabaqqʷǝʿā la-nǝgǝśta kʷǝllǝna</title>
+                <title xml:lang="gez" corresp="#t3">Wa-kāʿba nāstabaqqʷǝʿā la-nǝgǝśta kʷǝllǝna</title>
                 <title xml:lang="gez" xml:id="t4">ዓዲ፡ መስተብቍዕ፡ ዘማርያም፡</title>
-                <title xml:lang="gez" corresp="#t4" type="normalized">ʿĀdi Mastabqʷǝʿ za-Māryām</title>
+                <title xml:lang="gez" corresp="#t4" type="normalized">ʿĀdi mastabqʷǝʿ za-Māryām</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -42,8 +42,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>It is one of the prayers that are part of the fixed collection <ref target="#LIT4713Liton"/>, but also circulate independently 
-                    together with <ref target="LIT6906MastabqMar"/>.</p>
+                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="#LIT4713Liton"/>, but also circulate independently 
+                    together with <ref type="work" corresp="LIT6906MastabqMar"/>.</p>
             </abstract>
             <textClass>
                 <keywords>

--- a/new/LIT6907MastabqMar.xml
+++ b/new/LIT6907MastabqMar.xml
@@ -42,7 +42,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="#LIT4713Liton"/>, but also circulate independently 
+                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="LIT4713Liton"/>, but also circulate independently 
                     together with <ref type="work" corresp="LIT6906MastabqMar"/>.</p>
             </abstract>
             <textClass>

--- a/new/LIT6907MastabqMar.xml
+++ b/new/LIT6907MastabqMar.xml
@@ -42,8 +42,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="LIT4713Liton"/>, but also circulate independently 
-                    together with <ref type="work" corresp="LIT6906MastabqMar"/>.</p>
+                <p/>
             </abstract>
             <textClass>
                 <keywords>

--- a/new/LIT6907MastabqMar.xml
+++ b/new/LIT6907MastabqMar.xml
@@ -1,0 +1,78 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6907MastabqMar" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">መስተብቍዕ፡ ዘማርያም፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Mastabqʷǝʿ za-Māryām</title>
+                <title xml:id="t2">Mastabqʷǝʿ za-Māryām II</title>
+                <title xml:lang="gez" xml:id="t3">ወካዕበ፡ ናስተበቍዓ፡ ለንግሥተ፡ ኵልነ፡</title>
+                <title xml:lang="gez" corresp="#t3">wa-kāʿba nāstabaqqʷǝʿā la-nǝgǝśta kʷǝllǝna</title>
+                <title xml:lang="gez" xml:id="t4">ዓዲ፡ መስተብቍዕ፡ ዘማርያም፡</title>
+                <title xml:lang="gez" corresp="#t4" type="normalized">ʿĀdi Mastabqʷəʿ za-Māryām</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>It is one of the prayers that are part of the fixed collection <ref target="#LIT4713Liton"/>, but also circulate independently 
+                    together with <ref target="LIT6906MastabqMar"/>.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Liturgy"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Prayers"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-22">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT6907MastabqMar" passive="ESakm009"/>
+                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="BLorient545"/>
+                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="BNFet13"/>
+                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="EMML1434"/>
+                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="EMML4190"/>
+                </listRelation>
+            </div>
+            <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
+                <ab>ወካዕበ፡ ናስተበቍዓ፡ ለንግሥተ፡ ኵልነ፡ ማርያም፡ እምነ፡ ወእሙ፡ ለእግዚእነ፡ ወመድኀኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ንስእል፡ ወነኀሥሥ፡ ናስተበቍዕ፡ ወንዌድስ፡ ዕበየ፡ 
+                    ተአምሪሃ፡ ብዙኀ፡ ለእመ፡ ጸባኦት፡ ንጉሥ፡</ab>
+            </div></div>
+             <div type="edition"><div type="textpart" subtype="explicit" xml:lang="gez">
+                    <ab>በምድር፡ ወበሰማያት፡ በባሕር፡ ወበቀላያት፡ ለዓለመ፡ ዓለም፡ አሜን።</ab>
+             </div></div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6908MastabqMarIII.xml
+++ b/new/LIT6908MastabqMarIII.xml
@@ -29,7 +29,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <witness corresp="EMML2969"></witness>
                     <witness corresp="BerOrOct993"></witness>
                     <witness corresp="EMML1206"></witness>
-                    <witness corresp="EMML1434"></witness>
                 </listWit>
             </sourceDesc>
         </fileDesc>
@@ -39,7 +38,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="LIT4713Liton"/>, but also circulate independently.</p>
+                <p/>
             </abstract>
             <textClass>
                 <keywords>

--- a/new/LIT6908MastabqMarIII.xml
+++ b/new/LIT6908MastabqMarIII.xml
@@ -39,7 +39,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="#LIT4713Liton"/>, but also circulate independently.</p>
+                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="LIT4713Liton"/>, but also circulate independently.</p>
             </abstract>
             <textClass>
                 <keywords>

--- a/new/LIT6908MastabqMarIII.xml
+++ b/new/LIT6908MastabqMarIII.xml
@@ -25,7 +25,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <p/>
+                <listWit>
+                    <witness corresp="EMML2969"></witness>
+                    <witness corresp="BerOrOct993"></witness>
+                    <witness corresp="EMML1206"></witness>
+                    <witness corresp="EMML1434"></witness>
+                </listWit>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -54,13 +59,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT6907MastabqMar" passive="EMML2969"/>
-                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="BerOrOct993"/>
-                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="EMML1206"/>
-                </listRelation>
-            </div>
             <div type="bibliography">
                 <listBibl type="editions">
                     <bibl>

--- a/new/LIT6908MastabqMarIII.xml
+++ b/new/LIT6908MastabqMarIII.xml
@@ -9,7 +9,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="gez" corresp="#t1" type="normalized">Mastabqʷǝʿ za-Māryām</title>
                 <title xml:id="t2">Mastabqʷǝʿ za-Māryām III</title>
                 <title xml:lang="gez" xml:id="t3">ወካዕበ፡ ናስተበቍዓ፡ ለነቅዐ፡ ሕይወት፡</title>
-                <title xml:lang="gez" corresp="#t3">wa-kāʿba nāstabaqqʷǝʿā la-naqʿa ḥǝywat</title>
+                <title xml:lang="gez" corresp="#t3">Wa-kāʿba nāstabaqqʷǝʿā la-naqʿa ḥǝywat</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -39,7 +39,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>It is one of the prayers that are part of the fixed collection <ref target="#LIT4713Liton"/>, but also circulate independently.</p>
+                <p>It is one of the prayers that are part of the fixed collection <ref type="work" corresp="#LIT4713Liton"/>, but also circulate independently.</p>
             </abstract>
             <textClass>
                 <keywords>

--- a/new/LIT6908MastabqMarIII.xml
+++ b/new/LIT6908MastabqMarIII.xml
@@ -1,0 +1,80 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6908MastabqMarIII" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">መስተብቍዕ፡ ዘማርያም፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Mastabqʷǝʿ za-Māryām</title>
+                <title xml:id="t2">Mastabqʷǝʿ za-Māryām III</title>
+                <title xml:lang="gez" xml:id="t3">ወካዕበ፡ ናስተበቍዓ፡ ለነቅዐ፡ ሕይወት፡</title>
+                <title xml:lang="gez" corresp="#t3">wa-kāʿba nāstabaqqʷǝʿā la-naqʿa ḥǝywat</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>It is one of the prayers that are part of the fixed collection <ref target="#LIT4713Liton"/>, but also circulate independently.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Liturgy"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Prayers"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-22">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT6907MastabqMar" passive="EMML2969"/>
+                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="BerOrOct993"/>
+                    <relation name="lawd:hasAttestation" active="LIT6906MastabqMar" passive="EMML1206"/>
+                </listRelation>
+            </div>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl>
+                        <ptr target="bm:Getachew2004Estifanos"/><citedRange>36-38</citedRange>
+                    </bibl>
+                </listBibl>
+            </div>
+            <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
+                <ab>ወካዕበ፡ ናስተበቍዓ፡ ለነቅዐ፡ ሕይወት፡ ለቅድስት፡ ደብተራ፡ ዘወለደት፡ ወአግመረት፡ ጵርስፎራ፡ ይትነከር፡ ዕበየ፡ ክብራ፡ ጊዜ፡ ይትነበብ፡ ተአምራ፡ ጽልሕወ፡ ልብ፡ ብእሲ፡ 
+                    ሥጋ፡ ቢጹ፡ ዘበልዐ፡</ab>
+            </div></div>
+            <div type="edition"><div type="textpart" subtype="explicit" xml:lang="gez">
+                <ab>በምድር፡ ወበሰማያት፡ በባሕር፡ ወበቀላያት፡ ለዓለመ፡ ዓለም፡ አሜን።</ab>
+            </div></div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6908MastabqMarIII.xml
+++ b/new/LIT6908MastabqMarIII.xml
@@ -65,6 +65,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <ptr target="bm:Getachew2004Estifanos"/><citedRange>36-38</citedRange>
                     </bibl>
                 </listBibl>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:Bahr2023Litanies"/>
+                    </bibl>
+                </listBibl>
             </div>
             <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
                 <ab>ወካዕበ፡ ናስተበቍዓ፡ ለነቅዐ፡ ሕይወት፡ ለቅድስት፡ ደብተራ፡ ዘወለደት፡ ወአግመረት፡ ጵርስፎራ፡ ይትነከር፡ ዕበየ፡ ክብራ፡ ጊዜ፡ ይትነበብ፡ ተአምራ፡ ጽልሕወ፡ ልብ፡ ብእሲ፡ 


### PR DESCRIPTION
I created three new LIT IDs for Mastabqweʿ za-Māryām and updated LIT4713Liton according  to Leonards requests and information provided by him. I think, the CAe is provided automatically when merged and should be CAe 6906, CAe6907 and CAe 6908 according to the numbers in the LIT IDs.