### PR TITLE
Malkəʾa ʿālam

### DIFF
--- a/new/LIT6911MalkeaAlam.xml
+++ b/new/LIT6911MalkeaAlam.xml
@@ -74,7 +74,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <div type="textpart" subtype="explicit">
                     <ab>
                         <lg type="stanza" n="55">
-                            <l n="1"><!--lacuna, to be filled in the edition--> ፍቅርትየ፡ በአምኃ፡ ጕሕሉት፡ አማኅኩኪ፨</l>
+                            <l n="1"><space reason="rubrication" unit="chars" quantity="2"/> ፍቅርትየ፡ በአምኃ፡ ጕሕሉት፡ አማኅኩኪ፨</l>
                             <l n="2">አምሳለ፡ ይሁዳ፡ ረድእኪ፨</l>
                             <l n="3">ወቃለ፡ ዘለፋ፡ ቶሳሕኩ፡ በውስቴቱ፡ እንዘ፡ እጌሥጽ፡ ኪያኪ፨</l>
                             <l n="4">እመ፡ ኢነሳ|ሕኪሰ፡ ወታጸንዒ፡ ልበኪ፨</l>

--- a/new/LIT6911MalkeaAlam.xml
+++ b/new/LIT6911MalkeaAlam.xml
@@ -39,7 +39,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
-                    <term key="Chants"/>
+                    <term key="Poetry"/>
                     <term key="ChristianLiterature"/>
                     <term key="Liturgy"/>
                     <term key="MonasticLiterature"/>

--- a/new/LIT6911MalkeaAlam.xml
+++ b/new/LIT6911MalkeaAlam.xml
@@ -59,18 +59,30 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <div type="bibliography"/>
 
             <div type="edition">
-            <div type="textpart" subtype="incipit">
-              <ab>
-                <lg>
-                  <l n="1">ናሁ፡ ለልብየ፡ አስተናሥኦ፡ ዘመኑ፨</l>
-                  <l n="2">ዜና፡ መልክእኪ፡ ዓለም፡ ከመ፡ እጽሐፍ፡ ዘበበ፡ በይኑ፨</l>
-                  <l n="3">ባሕቱ፡ ሐሰተ፡ ከመ፡ ኢይቶስሕ፡ ውስተ፡ ድርሳኑ፨</l>
-                  <l n="4">ኢየሱስ፡ ክርስቶስ፡ ለእግዚአብሔር፡ የማኑ፨</l>
-                  <l n="5">ጸጋ፡ መንፈስ፡ ቅዱስ፡ ላዕሌየ፡ ይፈኑ፨</l>
-                </lg>
-              </ab>
+                <div type="textpart" subtype="incipit">
+                    <ab>
+                        <lg type="stanza" n="1">
+                            <l n="1">ናሁ፡ ለልብየ፡ አስተናሥኦ፡ ዘመኑ፨</l>
+                            <l n="2">ዜና፡ መልክእኪ፡ ዓለም፡ ከመ፡ እጽሐፍ፡ ዘበበ፡ በይኑ፨</l>
+                            <l n="3">ባሕቱ፡ ሐሰተ፡ ከመ፡ ኢይቶስሕ፡ ውስተ፡ ድርሳኑ፨</l>
+                            <l n="4">ኢየሱስ፡ ክርስቶስ፡ ለእግዚአብሔር፡ የማኑ፨</l>
+                            <l n="5">ጸጋ፡ መንፈስ፡ ቅዱስ፡ ላዕሌየ፡ ይፈኑ፨</l>
+                        </lg>
+                    </ab>
+                </div>
+
+                <div type="textpart" subtype="explicit">
+                    <ab>
+                        <lg type="stanza" n="55">
+                            <l n="1"><space reason="rubrication" unit="chars" quantity="2-3"/> ፍቅርትየ፡ በአምኃ፡ ጕሕሉት፡ አማኅኩኪ፨</l>
+                            <l n="2">አምሳለ፡ ይሁዳ፡ ረድእኪ፨</l>
+                            <l n="3">ወቃለ፡ ዘለፋ፡ ቶሳሕኩ፡ በውስቴቱ፡ እንዘ፡ እጌሥጽ፡ ኪያኪ፨</l>
+                            <l n="4">እመ፡ ኢነሳ|ሕኪሰ፡ ወታጸንዒ፡ ልበኪ፨</l>
+                            <l n="5">መቅሠፍተ፡ ወኵነኔ፡ ትዘግቢ፡ ለኪ፨</l>
+                        </lg>
+                    </ab>
+                </div>
             </div>
-          </div>
         </body>
     </text>
 </TEI>

--- a/new/LIT6911MalkeaAlam.xml
+++ b/new/LIT6911MalkeaAlam.xml
@@ -74,7 +74,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <div type="textpart" subtype="explicit">
                     <ab>
                         <lg type="stanza" n="55">
-                            <l n="1"><space reason="rubrication" unit="chars" quantity="2-3"/> ፍቅርትየ፡ በአምኃ፡ ጕሕሉት፡ አማኅኩኪ፨</l>
+                            <l n="1"><!--lacuna, to be filled in the edition--> ፍቅርትየ፡ በአምኃ፡ ጕሕሉት፡ አማኅኩኪ፨</l>
                             <l n="2">አምሳለ፡ ይሁዳ፡ ረድእኪ፨</l>
                             <l n="3">ወቃለ፡ ዘለፋ፡ ቶሳሕኩ፡ በውስቴቱ፡ እንዘ፡ እጌሥጽ፡ ኪያኪ፨</l>
                             <l n="4">እመ፡ ኢነሳ|ሕኪሰ፡ ወታጸንዒ፡ ልበኪ፨</l>

--- a/new/LIT6911MalkeaAlam.xml
+++ b/new/LIT6911MalkeaAlam.xml
@@ -5,7 +5,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Malkəʾa ʾālam</title>
+                <title xml:lang="gez" xml:id="t1">መልክአ፡ ዓለም፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Malkəʾa ʿālam</title>
+                <title xml:lang="en" corresp="#t1">Image of the World</title>
+                
                 <editor role="generalEditor" key="AB"/>
                 <editor key="AD"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -21,7 +24,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <p/>
+                <listWit>
+                    <witness corresp="EMML6993" xml:id="A"></witness>
+                </listWit>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -51,7 +56,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text>
         <body>
-            <div type="bibliography"/><!---->
+            <div type="bibliography"/>
+
+            <div type="edition">
+            <div type="textpart" subtype="incipit">
+              <ab>
+                <lg>
+                  <l n="1">ናሁ፡ ለልብየ፡ አስተናሥኦ፡ ዘመኑ፨</l>
+                  <l n="2">ዜና፡ መልክእኪ፡ ዓለም፡ ከመ፡ እጽሐፍ፡ ዘበበ፡ በይኑ፨</l>
+                  <l n="3">ባሕቱ፡ ሐሰተ፡ ከመ፡ ኢይቶስሕ፡ ውስተ፡ ድርሳኑ፨</l>
+                  <l n="4">ኢየሱስ፡ ክርስቶስ፡ ለእግዚአብሔር፡ የማኑ፨</l>
+                  <l n="5">ጸጋ፡ መንፈስ፡ ቅዱስ፡ ላዕሌየ፡ ይፈኑ፨</l>
+                </lg>
+              </ab>
+            </div>
+          </div>
         </body>
     </text>
 </TEI>

--- a/new/LIT6911MalkeaAlam.xml
+++ b/new/LIT6911MalkeaAlam.xml
@@ -1,0 +1,57 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6911LIT6910MalkeaAlam" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Malkəʾa ʾālam</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="AD"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Chants"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Liturgy"/>
+                    <term key="MonasticLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="AD" when="2024-01-11">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
This is to add the hymn መልክአ፡ ዓለም፡ to the clavis. Michael Hensley and I will present the text soon and intend to publish it with a translation as soon as possible. There will be more to add in the future, but for now this is a start.

The Monastic literature tag is due to the hymn being, essentially, a praise of monasticism and clearly intended for — and produced within — a monastic audience.