### PR TITLE
Create Octateuch books (Amharic)

### DIFF
--- a/new/LIT6921BibleAmharic.xml
+++ b/new/LIT6921BibleAmharic.xml
@@ -1,0 +1,66 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6921BibleAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Bible (Amharic)</title>
+                <title xml:lang="am" xml:id="t2">መጽሐፍ፡ ቅዱስ፡</title>
+                <title corresp="#t2" xml:lang="am" type="normalized">Maṣḥaf qǝddus</title>
+                <title xml:lang="am" xml:id="t3">የብሉይና፡ የሐዲስ፡ ኪዳን፡ መጻሕፍት፡</title>
+                <title corresp="#t3" xml:lang="am" type="normalized">Ya-bǝluy-nā ya-ḥaddis kidān maṣāḥǝft</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the Bible</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6921BibleAmharic" passive="LIT1219Bible"/>
+                    <relation name="saws:contains" active="LIT6921BibleAmharic" passive="LIT6922OldTesAmharic"/>
+                    <relation name="saws:contains" active="LIT6921BibleAmharic" passive="LIT6923NewTesAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6921BibleAmharic.xml
+++ b/new/LIT6921BibleAmharic.xml
@@ -9,7 +9,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="am" xml:id="t2">መጽሐፍ፡ ቅዱስ፡</title>
                 <title corresp="#t2" xml:lang="am" type="normalized">Maṣḥaf qǝddus</title>
                 <title xml:lang="am" xml:id="t3">የብሉይና፡ የሐዲስ፡ ኪዳን፡ መጻሕፍት፡</title>
-                <title corresp="#t3" xml:lang="am" type="normalized">Ya-bǝluy-nā ya-ḥaddis kidān maṣāḥǝft</title>
+                <title corresp="#t3" xml:lang="am" type="normalized">Ya-bǝluy-ǝnnā ya-ḥaddis kidān maṣāḥǝft</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT6922OldTesAmharic.xml
+++ b/new/LIT6922OldTesAmharic.xml
@@ -1,0 +1,73 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6922OldTesAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Old Testament (Amharic)</title>
+                <title xml:lang="am" xml:id="t2">ብሉይ፡ ኪዳን፡</title>
+                <title corresp="#t2" xml:lang="am" type="normalized">Bǝluy kidān</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the Old Testament</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6922OldTesAmharic" passive="LIT3530OldTes"/>
+                    <relation name="saws:formsPartOf" active="LIT6922OldTesAmharic" passive="LIT6921BibleAmharic"/>
+                    <relation name="saws:contains" active="LIT6922OldTesAmharic" passive="LIT6924OctateAmharic"/>
+                    <relation name="saws:contains" active="LIT6922OldTesAmharic" passive="LIT6926GenesiAmharic"/>
+                    <relation name="saws:contains" active="LIT6922OldTesAmharic" passive="LIT6927ExodusAmharic"/>
+                    <relation name="saws:contains" active="LIT6922OldTesAmharic" passive="LIT6928LevitiAmharic"/>
+                    <relation name="saws:contains" active="LIT6922OldTesAmharic" passive="LIT6929NumberAmharic"/>
+                    <relation name="saws:contains" active="LIT6922OldTesAmharic" passive="LIT6930DeuteroAmharic"/>
+                    <relation name="saws:contains" active="LIT6922OldTesAmharic" passive="LIT6931JoshuaAmharic"/>
+                    <relation name="saws:contains" active="LIT6922OldTesAmharic" passive="LIT6932JudgesAmharic"/>
+                    <relation name="saws:contains" active="LIT6922OldTesAmharic" passive="LIT6933RuthAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6923NewTesAmharic.xml
+++ b/new/LIT6923NewTesAmharic.xml
@@ -1,0 +1,64 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6923NewTesAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">New Testament (Amharic)</title>
+                <title xml:lang="am" xml:id="t2">አዲስ፡ ኪዳን፡</title>
+                <title corresp="#t2" xml:lang="am" type="normalized">ʾAddis kidān</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the New Testament</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="NewTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6923NewTesAmharic" passive="LIT2072NewTes"/>
+                    <relation name="saws:formsPartOf" active="LIT6923NewTesAmharic" passive="LIT6921BibleAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6924OctateAmharic.xml
+++ b/new/LIT6924OctateAmharic.xml
@@ -1,0 +1,73 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6924OctateAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Octateuch (Amharic)</title>
+                <title xml:lang="am" xml:id="t2">ኦሪት፡</title>
+                <title corresp="#t2" xml:lang="am" type="normalized">ʾOrit</title>
+                <title xml:lang="en" xml:id="t3">Eight Books of Moses</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic Version of the eight books of Moses.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6924OctateAmharic" passive="LIT6922OldTesAmharic"/>
+                    <relation name="saws:containsTextInLanguage" active="LIT6924OctateAmharic" passive="LIT2083Octate"/>
+                    <relation name="saws:contains" active="LIT6924OctateAmharic" passive="LIT6926GenesiAmharic"/>
+                    <relation name="saws:contains" active="LIT6924OctateAmharic" passive="LIT6927ExodusAmharic"/>
+                    <relation name="saws:contains" active="LIT6924OctateAmharic" passive="LIT6928LevitiAmharic"/>
+                    <relation name="saws:contains" active="LIT6924OctateAmharic" passive="LIT6929NumberAmharic"/>
+                    <relation name="saws:contains" active="LIT6924OctateAmharic" passive="LIT6930DeuteroAmharic"/>
+                    <relation name="saws:contains" active="LIT6924OctateAmharic" passive="LIT6931JoshuaAmharic"/>
+                    <relation name="saws:contains" active="LIT6924OctateAmharic" passive="LIT6932JudgesAmharic"/>
+                    <relation name="saws:contains" active="LIT6924OctateAmharic" passive="LIT6933RuthAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6925EnumerationOTAm.xml
+++ b/new/LIT6925EnumerationOTAm.xml
@@ -1,0 +1,63 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6925EnumerationOTAm" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Enumeration of the Books of the Old Testament</title>
+                <title xml:lang="am" xml:id="t2">የብሉይ፡ ኪዳን፡ መጻሕፍት፡ እሊህ፡ ናቸው።</title>
+                <title corresp="#t2" xml:lang="am" type="normalized">Ya-bǝluy kidān maṣāḥǝft ʾǝllih nāččaw</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6925EnumerationOTAm" passive="LIT6924OctateAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6926GenesiAmharic.xml
+++ b/new/LIT6926GenesiAmharic.xml
@@ -1,0 +1,66 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6926GenesiAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Genesis (Amharic)</title>
+                <title type="short">Gen.</title>
+                <title xml:lang="am" xml:id="t2">ኦሪት፡ ዘፍጥረት፡</title>
+                <title corresp="#t2" xml:lang="am" type="normalized">ʾOrit za-fǝṭrat</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the first book of Moses</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6926GenesiAmharic" passive="LIT1546Genesi"/>
+                    <relation name="saws:formsPartOf" active="LIT6926GenesiAmharic" passive="LIT6922OldTesAmharic"/>
+                    <relation name="saws:formsPartOf" active="LIT6926GenesiAmharic" passive="LIT6924OctateAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6927ExodusAmharic.xml
+++ b/new/LIT6927ExodusAmharic.xml
@@ -1,0 +1,68 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6927ExodusAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Exodus (Amharic)</title>
+                <title type="short">Ex.</title>
+                <title xml:lang="am" xml:id="t2">ኦሪት፡ ዘፀአት፡</title>
+                <title xml:lang="am" corresp="#t2" type="normalized">ʾOrit za-ḍaʾāt</title>
+                <title xml:lang="am" xml:id="t3">ኦሪት፡ ዘፀዓት፡</title>
+                <title xml:lang="am" corresp="#t3" type="normalized">ʾOrit za-ḍaʿāt</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the second book of Moses.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6927ExodusAmharic" passive="LIT1367Exodus"/>
+                    <relation name="saws:formsPartOf" active="LIT6927ExodusAmharic" passive="LIT6922OldTesAmharic"/>
+                    <relation name="saws:formsPartOf" active="LIT6927ExodusAmharic" passive="LIT6924OctateAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6928LevitiAmharic.xml
+++ b/new/LIT6928LevitiAmharic.xml
@@ -1,0 +1,66 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6928LevitiAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Leviticus (Amharic)</title>
+                <title type="short">Lev.</title>
+                <title xml:lang="am" xml:id="t2">ኦሪት፡ ዘሌዋውያን፡</title>
+                <title xml:lang="am" corresp="#t2" type="normalized">ʾOrit za-lewāwǝyān</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the third book of Moses.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6928LevitiAmharic" passive="LIT1793Leviti"/>
+                    <relation name="saws:formsPartOf" active="LIT6928LevitiAmharic" passive="LIT6922OldTesAmharic"/>
+                    <relation name="saws:formsPartOf" active="LIT6928LevitiAmharic" passive="LIT6924OctateAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6929NumberAmharic.xml
+++ b/new/LIT6929NumberAmharic.xml
@@ -1,0 +1,66 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6929NumberAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Book of Numbers (Amharic)</title>
+                <title type="short">Num.</title>
+                <title xml:lang="am" xml:id="t2">ኦሪት፡ ዘኍልቍ፡</title>
+                <title xml:lang="am" corresp="#t2" type="normalized">ʾOrit za-ḫʷǝlqʷ</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the fourth book of Moses.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6929NumberAmharic" passive="LIT2075Number"/>
+                    <relation name="saws:formsPartOf" active="LIT6929NumberAmharic" passive="LIT6922OldTesAmharic"/>
+                    <relation name="saws:formsPartOf" active="LIT6929NumberAmharic" passive="LIT6924OctateAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6930DeuteroAmharic.xml
+++ b/new/LIT6930DeuteroAmharic.xml
@@ -1,0 +1,66 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6930DeuteroAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Deuteronomy (Amharic)</title>
+                <title type="short">Deut.</title>
+                <title xml:lang="am" xml:id="t2">ኦሪት፡ ዘዳግም፡</title>
+                <title xml:lang="am" corresp="#t2" type="normalized">ʾOrit za-dāgǝm</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the fifth book of Moses.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6930DeuteroAmharic" passive="LIT2637Deuteronomy"/>
+                    <relation name="saws:formsPartOf" active="LIT6930DeuteroAmharic" passive="LIT6922OldTesAmharic"/>
+                    <relation name="saws:formsPartOf" active="LIT6930DeuteroAmharic" passive="LIT6924OctateAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6931JoshuaAmharic.xml
+++ b/new/LIT6931JoshuaAmharic.xml
@@ -1,0 +1,66 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6931JoshuaAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Book of Joshua (Amharic)</title>
+                <title type="short">Jos.</title>
+                <title xml:lang="am" xml:id="t2">መጽሐፈ፡ ኢያሱ፡</title>
+                <title xml:lang="am" corresp="#t2" type="normalized">Maṣḥafa ʾIyāsu</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic Version of the biblical Book of Joshua.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6931JoshuaAmharic" passive="LIT1696Joshua"/>
+                    <relation name="saws:formsPartOf" active="LIT6931JoshuaAmharic" passive="LIT6922OldTesAmharic"/>
+                    <relation name="saws:formsPartOf" active="LIT6931JoshuaAmharic" passive="LIT6924OctateAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6932JudgesAmharic.xml
+++ b/new/LIT6932JudgesAmharic.xml
@@ -1,0 +1,66 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6932JudgesAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Book of Judges (Amharic)</title>
+                <title type="short">Jud.</title>
+                <title xml:lang="am" xml:id="t2">መጽሐፈ፡ መሳፍንት፡</title>
+                <title xml:lang="am" corresp="#t2" type="normalized">Maṣḥafa masāfǝnt</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the biblical Book of Judges.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6932JudgesAmharic" passive="LIT1700Judges"/>
+                    <relation name="saws:formsPartOf" active="LIT6932JudgesAmharic" passive="LIT6922OldTesAmharic"/>
+                    <relation name="saws:formsPartOf" active="LIT6932JudgesAmharic" passive="LIT6924OctateAmharic"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6933RuthAmharic.xml
+++ b/new/LIT6933RuthAmharic.xml
@@ -1,0 +1,62 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT6933RuthAmharic" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Book of Ruth (Amharic)</title>
+                <title type="short">Ruth</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Amharic version of the biblical Book of Ruth.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="Bible"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="OldTestament"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-02-14">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isVersionInAnotherLanguageOf" active="LIT6933RuthAmharic" passive="LIT2229RuthBo"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT6933RuthAmharic.xml
+++ b/new/LIT6933RuthAmharic.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Book of Ruth (Amharic)</title>
+                <title xml:lang="en" xml:id="t1">Book of Ruth (Amharic)</title>
                 <title type="short">Ruth</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>


### PR DESCRIPTION
I created records for the eight Octateuch books plus a record for a short enumeration of OT-books, that is extant in BLorient12125 and umbrella records for Octateuch, New Testament, Old Testament and Bible (Amharic) as discussed in https://github.com/BetaMasaheft/Documentation/issues/2476.