### PR TITLE
Update LIT1544Gebrah (add chapters as Sub-IDs)

### DIFF
--- a/1001-2000/LIT1544Gebrah.xml
+++ b/1001-2000/LIT1544Gebrah.xml
@@ -47,12 +47,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change who="PL" when="2016-03-21"> Created file from google
-            spreadsheet </change>
-         <change who="ES" when="2016-02-09">CREATED: text record</change>
+         <change when="2016-03-21" who="PL"> Created file from google spreadsheet </change>
+         <change when="2016-02-09" who="ES" >CREATED: text record</change>
          <change when="2016-09-05" who="MV">Added div textparts</change>
-         <change who="DR" when="2017-03-14">Added keywords and t2</change>
+         <change when="2017-03-14" who="DR" >Added keywords and t2</change>
          <change when="2018-04-09" who="ES">Added more div textparts</change>
+         <change when="2024-05-08" who="CH">Added more div textparts</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -69,59 +69,157 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </div>
             <div type="textpart" subtype="chapter" xml:id="PalmSundayGH">
                <label>Palm Sunday</label>
+               <div type="textpart" subtype="chapter" xml:id="PalmSundayMor">
+                  <label>Readings for Palm Sunday morning i.e. first day hour of Palm Sunday</label>
+               </div>
+               <div type="textpart" subtype="chapter" xml:id="PalmSundayProc">
+                  <label>Readings for the procession on Palm Sunday morning</label>
+               </div>
+               <div type="textpart" subtype="chapter" xml:id="PalmSundayMass">
+                  <label>Readings  for the Mass of Palm Sunday</label>
+               </div>
+               <div type="textpart" subtype="chapter" xml:id="PalmSundayElev">
+                  <label>Readings for the 11th day hour on Palm Sunday</label>
+               </div>
             </div>
             <div type="textpart" subtype="chapter" xml:id="Monday">
                <label>Monday</label>
                <div type="textpart" subtype="chapter" xml:id="MondayNight">
                   <label>Monday Night Hours</label>
+                  <div type="textpart" subtype="chapter" xml:id="MondayNightFirst">
+                     <label>Readings for the first night hour on Monday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="MondayNightThird">
+                     <label>Readings for the third night hour on Monday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="MondayNightSixth">
+                     <label>Readings for the sixth night hour on Monday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="MondayNightElev">
+                     <label>Readings for the eleventh night hour on Monday</label>
+                  </div>
                </div>
                <div type="textpart" subtype="chapter" xml:id="MondayDay">
                   <label>Monday Day Hours</label>
-                  <div type="textpart" subtype="chapter" xml:id="AbbaSinodaMoMor">
-                     <label>Admonition by Abba Sinoda for Monday morning</label>
+                  <div type="textpart" subtype="chapter" xml:id="MondayDayDawn" corresp="LIT1546Genesi">
+                     <label>Readings for dawn: Genesis 1:1 to 2:3</label>
                   </div>
-                  <div type="textpart" subtype="chapter" xml:id="JohnMonday">
-                     <label>Homily by John Chrysostom for Monday morning</label>
+                  <div type="textpart" subtype="chapter" xml:id="MondayDayFirst">
+                     <label>Readings for the first day hour on Monday</label>
+                     <div type="textpart" subtype="chapter" xml:id="AbbaSinodaMoMor">
+                        <label>Admonition by Abba Sinoda for Monday morning</label>
+                     </div>
+                     <div type="textpart" subtype="chapter" xml:id="JohnMonday">
+                        <label>Homily by John Chrysostom for Monday morning</label>
+                     </div>
+                     <div type="textpart" subtype="chapter" xml:id="JohnFig" corresp="LIT2122OntheF">
+                        <label>Homily by John Chrysostom on the fig tree for Monday morning</label>
+                     </div>
                   </div>
-                  <div type="textpart" subtype="chapter" xml:id="JohnFig" corresp="LIT2122OntheF">
-                     <label>Homily by John Chrysostom on the fig tree for Monday morning</label>
+                  <div type="textpart" subtype="chapter" xml:id="MondayDayThird">
+                     <label>Readings for the third day hour</label>
                   </div>
-                  <div type="textpart" subtype="chapter" xml:id="MondayNinth">
-                     <label>Homily for the ninth hour of Monday morning (anonymous)</label>
+                  <div type="textpart" subtype="chapter" xml:id="MondayDayNinth">
+                     <label>Readings for the ninth day hour</label>
+                     <div type="textpart" subtype="chapter" xml:id="MondayNinth">
+                        <label>Homily for the ninth hour of Monday morning (anonymous)</label>
+                     </div>
                   </div>
-                  <div type="textpart" subtype="chapter" xml:id="AbbaSinodaMoEve">
-                     <label>Admoninition by Abba Sinoda for the eleventh hour of Monday evening</label>
-                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="MondayDayElev">
+                     <label>Readings for the eleventh day hour</label>
+                     <div type="textpart" subtype="chapter" xml:id="AbbaSinodaMoEve">
+                        <label>Admoninition by ʾAbbā Sinodā for the eleventh hour of Monday evening</label>
+                     </div>
+                  </div>      
                </div>
             </div>
             <div type="textpart" subtype="chapter" xml:id="Tuesday">
                <label>Tuesday</label>               
                <div type="textpart" subtype="chapter" xml:id="TuesdayNight">
                   <label>Tuesday Night Hours</label>
+                  <div type="textpart" subtype="chapter" xml:id="TuesdayNightFirst">
+                     <label>Readings for the first night hour on Tuesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="TuesdayNightThird">
+                     <label>Readings for the third night hour on Tuesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="TuesdayNightSixth">
+                     <label>Readings for the sixth night hour on Tuesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="TuesdayNightNinth">
+                     <label>Readings for the ninth night hour on Tuesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="TuesdayNightElev">
+                     <label>Readings for the eleventh night hour on Tuesday</label>
+                  </div>
                </div>
                <div type="textpart" subtype="chapter" xml:id="TuesdayDay">
                   <label>Tuesday Day Hours</label>
-                  <div type="textpart" subtype="chapter" xml:id="AbbaSinodaTu">
-                     <label>Admonition by Abba Sinoda for Tuesday morning</label>
+                  <div type="textpart" subtype="chapter" xml:id="TuesdayDayFirst">
+                     <label>Readings for the morning (i.e. the first day hour) on Tuesday</label>
+                     <div type="textpart" subtype="chapter" xml:id="AbbaSinodaTu">
+                        <label>Admonition by Abba Sinoda for Tuesday morning</label>
+                     </div>
                   </div>
-                  <div type="textpart" subtype="chapter" xml:id="AnonAdmonTu">
-                     <label>Anonymous Admonition for the ninth day hour on Tuesday</label>
+                  <div type="textpart" subtype="chapter" xml:id="ThuesdayDayThird">
+                     <label>Readings for the third day hour on Tuesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="TuesdayDaySixth">
+                     <label>Readings for the sixth day hour on Tuesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="TuesdayDayNinth">
+                     <label>Readings für the ninth day hour on Tuesday</label>
+                     <div type="textpart" subtype="chapter" xml:id="AnonAdmonTu">
+                        <label>Anonymous Admonition for the ninth day hour on Tuesday</label>
+                     </div>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="TuesdayDayElev">
+                     <label>Readings for the eleventh day hour on Tuesday</label>
                   </div>
                </div>           
             </div>
-            
             <div type="textpart" subtype="chapter" xml:id="Wednesday">
                <label>Wednesday</label>
                <div type="textpart" subtype="chapter" xml:id="WednesdayNight">
                   <label>Wednesday Night Hours</label>
+                  <div type="textpart" subtype="chapter" xml:id="WedNightFirst">
+                     <label>Readings for the first night hour on Wednesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="WedNightThird">
+                     <label>Readings for the third night hour on Wednesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="WedNightSixth">
+                     <label>Readings for the sixth night hour on Wednesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="WedNightNinth">
+                     <label>Readings for the ninth night hour on Wednesday</label>
+                     <div type="textpart" subtype="chapter" xml:id="JohnChrWed">
+                        <label>Admonition by John Chrysostom for the ninth day hour on Wednesday</label>
+                     </div>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="WedNightElev">
+                     <label>Readings for the eleventh night hour on Wednesday</label>
+                     <div type="textpart" subtype="chapter" xml:id="SawirosWed">
+                        <label>Admonition by Severianus of Gabala for the eleventh day hour on Wednesday</label>
+                     </div>
+                  </div>
                </div>
                <div type="textpart" subtype="chapter" xml:id="WednesdayDay">
                   <label>Wednesday Day Hours</label>
-                  <div type="textpart" subtype="chapter" xml:id="JohnChrWed">
-                     <label>Admonition by John Chrysostom for the ninth day hour on Wednesday</label>
+                  <div type="textpart" subtype="chapter" xml:id="WedDayFirst">
+                     <label>Readings for the morning (i.e. for the first day hour) on Wednesday</label>
                   </div>
-                  <div type="textpart" subtype="chapter" xml:id="SawirosWed">
-                     <label>Admonition by Severianus of Gabala for the eleventh day hour on Wednesday</label>
+                  <div type="textpart" subtype="chapter" xml:id="WedDayThird">
+                     <label>Readings for the third day hour on Wednesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="WedDaySixth">
+                     <label>Readings for the sixth day hour on Wednesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="WedDayNinth">
+                     <label>Readings for the ninth day hour on Wednesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="WedDayElev">
+                     <label>Readings for the eleventh day hour</label>
                   </div>
                </div>    
             </div>
@@ -130,14 +228,41 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <label>Thursday</label>
                <div type="textpart" subtype="chapter" xml:id="ThursdayNight">
                   <label>Thursday Night Hours</label>
+                  <div type="textpart" subtype="chapter" xml:id="ThursNightFirst">
+                     <label>Readings for the first night hour on Thursday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="ThursNightThird">
+                     <label>Readings for the third night hour on Thursday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="ThursNightSixth">
+                     <label>Readings for the sixth night hour on Thursday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="ThursNightNinth">
+                     <label>Readings for the ninth night hour on Thursday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="ThursNightElev">
+                     <label>Readings for the eleventh night hour on Thursday</label>
+                  </div>
                </div>
                <div type="textpart" subtype="chapter" xml:id="ThursdayDay">
                   <label>Thursday Day Hours</label>
-                  <div type="textpart" subtype="chapter" xml:id="JohnChrThurMor">
-                     <label>Admonition by John Chrysostom for Thursday morning</label>
+                  <div type="textpart" subtype="chapter" xml:id="ThursDayFirst">
+                     <label>Readings for the first day hour on Thursday</label>
+                     <div type="textpart" subtype="chapter" xml:id="JohnChrThurMor">
+                        <label>Admonition by John Chrysostom for Thursday morning</label>
+                     </div>
                   </div>
-                  <div type="textpart" subtype="chapter" xml:id="JohnChrThurNine">
-                     <label>Admonition by John Chrysostom for the ninth day hour on Thursday</label>
+                  <div type="textpart" subtype="chapter" xml:id="ThursDayThird">
+                     <label>Readings for the third day hour on Thursday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="ThursDaySixth">
+                     <label>Readings for the sixth day hour on Thursday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="ThursDayNinth">
+                     <label>Readings for the ninth day hour on Thursday</label>
+                     <div type="textpart" subtype="chapter" xml:id="JohnChrThurNine">
+                        <label>Admonition by John Chrysostom for the ninth day hour on Thursday</label>
+                     </div>
                   </div>
                   <div type="textpart" subtype="chapter" xml:id="FeetThur">
                      <label>Readings for the Washing of the feet on Thursday</label>
@@ -145,16 +270,32 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <div type="textpart" subtype="chapter" xml:id="MassThur">
                      <label>Readings for the Mass on Thursday</label>
                   </div>
+                  <div type="textpart" subtype="chapter" xml:id="ThursDayElev">
+                     <label>Readings for the eleventh day hour</label>
+                  </div>
                </div>    
             </div>
             <div type="textpart" subtype="chapter" xml:id="Friday">
                <label>Friday</label>
               <div type="textpart" subtype="chapter" xml:id="FridayNight"> 
                   <label>Friday Night Hours</label>
-                 <div type="textpart" subtype="chapter" xml:id="FridaySixthNight"/>
-                 <div type="textpart" subtype="chapter" xml:id="FridayJC" corresp="LIT2142OntheS">
-                    <label>Homily by John [Chrysostom] on Christ when He says “If it be Possible, Let this Cup Pass from Me” </label>
-                  </div>
+                 <div type="textpart" subtype="chapter" xml:id="FriNightFirst">
+                    <label>Readings for the first night hour on Friday</label>
+                 </div>
+                 <div type="textpart" subtype="chapter" xml:id="FriNightThird">
+                    <label>Readings for the third night hour on Friday</label>
+                 </div>
+                 <div type="textpart" subtype="chapter" xml:id="FridaySixthNight">
+                     <label>Readings for the sixth night hour on Friday</label>
+                     <div type="textpart" subtype="chapter" xml:id="FridayJC" corresp="LIT2142OntheS">
+                        <label>Homily by John Chrysostom on Christ when He says “If it be Possible, Let this Cup Pass from Me” on Friday</label>
+                     </div>
+                 <div type="textpart" subtype="chapter" xml:id="FriNightNinth">
+                    <label>Readings for the ninth night hour on Friday</label>
+                 </div>
+                 <div type="textpart" subtype="chapter" xml:id="FriNightElev">
+                    <label>Readings for the eleventh night hour on Friday</label>
+                 </div>
                  <div type="textpart" subtype="chapter" xml:id="Cock" corresp="LIT1922Mashaf">
                      <label>Maṣḥafa dorho</label>
                   </div>
@@ -182,7 +323,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </div>
                   <div type="textpart" subtype="chapter" xml:id="FridaySixth">
                      <label>Readings for the sixth day hour on Friday</label>
-                     <div type="textpart" subtype="chapter" xml:id="JohnChrFrSixth"></div>
+                     <div type="textpart" subtype="chapter" xml:id="JohnChrFrSixth">
+                        <label>Admonition by John Chrysostom for the sixth day hour on Friday</label>
+                     </div>
                   </div>
                   <div type="textpart" subtype="chapter" xml:id="FridayNinth">
                      <label>Readings for the ninth day hour on Friday</label>
@@ -193,6 +336,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                         <label>Admonition by Athanasius for the eleventh day hour on Friday</label>
                      </div>
                   </div>
+                  <div type="textpart" subtype="chapter" xml:id="FriDayTwelth">
+                     <label>Readings for the twelth day hour on Friday</label>
+                  </div>
                </div>
             </div>
             
@@ -200,13 +346,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <label>Saturday</label>
                <div type="textpart" subtype="chapter" xml:id="SaturdayNight">
                   <label>Saturday Night Hours</label>
-                  <div type="textpart" subtype="chapter" xml:id="Revelation" corresp="LIT3179Revela"/>
+                  
                   <div type="textpart" subtype="chapter" xml:id="Mass">
                      <label>Mass</label>
                      <ab>በሰንበተ፡ አይሁድ፡ በጊዜ፡ ቅዳሴ፡ ቍርባን፡</ab>
                   </div>
+                  <div type="textpart" subtype="chapter" xml:id="SaturdayDay">
+                     <label>Readings for Saturday Day</label>
+                     <div type="textpart" subtype="chapter" xml:id="SatDayFirst">
+                        <label>Readings for Saturday morning (i.e. the first day hour)</label>
+                     </div>
+                     <div type="textpart" subtype="chapter" xml:id="SatDaySixth">
+                        <label>Readings for the sixth day hour on Saturday</label>
+                        <div type="textpart" subtype="chapter" xml:id="Revelation" corresp="LIT3179Revela"/>
+                     </div> 
+                  </div>
                   <div type="textpart" subtype="chapter" xml:id="Evening">
-                     <label>Saturday Evening</label>
+                     <label>Readings for Saturday evening</label>
                   </div>
                </div>
 
@@ -224,8 +380,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <div type="textpart" subtype="chapter" xml:id="PrayerMidnight">
                <label>Prayer for midnight during Passion Week</label>
             </div>
+            </div>
          </div>
-            
       </body>
    </text>
 </TEI>

--- a/1001-2000/LIT1544Gebrah.xml
+++ b/1001-2000/LIT1544Gebrah.xml
@@ -63,6 +63,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </div>
             <div type="textpart" subtype="chapter" xml:id="EvePalmSunday">
                <label>Eve of Palm Sunday</label>
+               <div type="textpart" subtype="chapter" xml:id="HomilyEvePalmSun">
+                  <label>Homily by John Chrysostom for Palm Sunday Eve</label>
+               </div>
             </div>
             <div type="textpart" subtype="chapter" xml:id="PalmSundayGH">
                <label>Palm Sunday</label>
@@ -74,6 +77,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:id="MondayDay">
                   <label>Monday Day Hours</label>
+                  <div type="textpart" subtype="chapter" xml:id="AbbaSinodaMoMor">
+                     <label>Admonition by Abba Sinoda for Monday morning</label>
+                  </div>
                   <div type="textpart" subtype="chapter" xml:id="JohnMonday">
                      <label>Homily by John Chrysostom for Monday morning</label>
                   </div>
@@ -82,6 +88,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </div>
                   <div type="textpart" subtype="chapter" xml:id="MondayNinth">
                      <label>Homily for the ninth hour of Monday morning (anonymous)</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="AbbaSinodaMoEve">
+                     <label>Admoninition by Abba Sinoda for the eleventh hour of Monday evening</label>
                   </div>
                </div>
             </div>
@@ -92,6 +101,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:id="TuesdayDay">
                   <label>Tuesday Day Hours</label>
+                  <div type="textpart" subtype="chapter" xml:id="AbbaSinodaTu">
+                     <label>Admonition by Abba Sinoda for Tuesday morning</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="AnonAdmonTu">
+                     <label>Anonymous Admonition for the ninth day hour on Tuesday</label>
+                  </div>
                </div>           
             </div>
             
@@ -102,6 +117,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:id="WednesdayDay">
                   <label>Wednesday Day Hours</label>
+                  <div type="textpart" subtype="chapter" xml:id="JohnChrWed">
+                     <label>Admonition by John Chrysostom for the ninth day hour on Wednesday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="SawirosWed">
+                     <label>Admonition by Severianus of Gabala for the eleventh day hour on Wednesday</label>
+                  </div>
                </div>    
             </div>
                
@@ -112,6 +133,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:id="ThursdayDay">
                   <label>Thursday Day Hours</label>
+                  <div type="textpart" subtype="chapter" xml:id="JohnChrThurMor">
+                     <label>Admonition by John Chrysostom for Thursday morning</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="JohnChrThurNine">
+                     <label>Admonition by John Chrysostom for the ninth day hour on Thursday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="FeetThur">
+                     <label>Readings for the Washing of the feet on Thursday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="MassThur">
+                     <label>Readings for the Mass on Thursday</label>
+                  </div>
                </div>    
             </div>
             <div type="textpart" subtype="chapter" xml:id="Friday">
@@ -129,19 +162,37 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                
                <div type="textpart" subtype="chapter" xml:id="FridayDay">
                   <label>Friday Day Hours</label>  
-                  <div type="textpart" xml:id="Abraham" corresp="LIT1180Baenta">
-                     <label>Homily by Jacob of Serug on Abraham</label>
-                  </div>
                   <div type="textpart" corresp="LIT2362Songof" xml:id="Song">
                      <label>Song of Songs</label>
                   </div>
-                  <div type="textpart" corresp="LIT5807HomilyApostles" xml:id="Teaching"><label>Homily and Teaching of the Apostles regarding the Passion, Crucifixion and Resurrection of Our Lord</label></div>
+                  <div type="textpart" corresp="LIT5807HomilyApostles" xml:id="Teaching"><label>Homily and Teaching of the Apostles 
+                     regarding the Passion, Crucifixion and Resurrection of Our Lord</label></div>
                   <div type="textpart" corresp="LIT5808Selatat" xml:id="Selatat"><label>Petitions in the Passion Week</label></div>
-                  <div type="textpart" subtype="chapter" xml:id="FridayMorning"/>
-                  <div type="textpart" subtype="chapter" xml:id="FridayThird"/>
-                  <div type="textpart" subtype="chapter" xml:id="FridaySixth"/>
-                  <div type="textpart" subtype="chapter" xml:id="FridayNinth"/>
-                  <div type="textpart" subtype="chapter" xml:id="FridayEleventh"/>
+                  <div type="textpart" subtype="chapter" xml:id="FridayMorning">
+                     <label>Readings for Friday morning (i.e. the first day hour)</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="FridayThird">
+                     <label>Readings for the third day hour on Friday</label>
+                     <div type="textpart" xml:id="Abraham" corresp="LIT1180Baenta">
+                        <label>Homily by Jacob of Serug on Abraham</label>
+                     </div>
+                     <div type="textpart" subtype="chapter" xml:id="AthanFrThird">
+                        <label>Homily by Athanasius of Alexandria</label>
+                     </div>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="FridaySixth">
+                     <label>Readings for the sixth day hour on Friday</label>
+                     <div type="textpart" subtype="chapter" xml:id="JohnChrFrSixth"></div>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="FridayNinth">
+                     <label>Readings for the ninth day hour on Friday</label>
+                  </div>
+                  <div type="textpart" subtype="chapter" xml:id="FridayEleventh">
+                     <label>Readings for the eleventh day hour on Friday</label>
+                     <div type="textpart" subtype="chapter" xml:id="AthanFrEleventh">
+                        <label>Admonition by Athanasius for the eleventh day hour on Friday</label>
+                     </div>
+                  </div>
                </div>
             </div>
             
@@ -162,13 +213,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </div>
                <div type="textpart" subtype="chapter" xml:id="Sunday">
                <label>Sunday</label>
-                  <div type="textpart" subtype="chapter" xml:id="Laha" corresp="byLIT1750LahaMa"/>
+                  <div type="textpart" subtype="chapter" xml:id="Laha" corresp="LIT1750LahaMa"/>
                   <div type="textpart" subtype="chapter" xml:id="Mysteries" corresp="LIT2444Temher"/>
 
                </div>
             
             <div type="textpart" subtype="chapter" xml:id="Directives">
                <label>Directives for the Rite of the Passion Week</label>
+            </div>
+            <div type="textpart" subtype="chapter" xml:id="PrayerMidnight">
+               <label>Prayer for midnight during Passion Week</label>
             </div>
          </div>
             


### PR DESCRIPTION
I added some chapters to the record of LIT1544Gebrah as discussed in https://github.com/BetaMasaheft/Documentation/issues/2531. I also added some titles to chapters already existing. However, I saw, that there is no subdivision for each hour of the day or of the night (except for Friday), as it is regularly in manuscripts. If you agree, I would like to add also chapters for the other days of the week, unless the place of some readings may vary in some manuscripts.