### PR TITLE
Update records on Mastabqʷǝʿān according Leonards requests

### DIFF
--- a/4001-5000/LIT4711Mastabqwe.xml
+++ b/4001-5000/LIT4711Mastabqwe.xml
@@ -42,8 +42,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <creation/>
             <abstract>
                 <p>
-                    The office contains prayers for the sick, the pilgrims, the rain, the fruits of the earth, the water of the rivers, the king, the sleepers, the offerers, the
-                    catechumens, the peace, the Church.
+                    The office contains prayers for the sick, the pilgrims, the rain, the fruits of the earth, the water of the rivers, the king, the sleepers, 
+                    the offerers, the catechumens, the peace, the Church. Optionally, other Mastabqʷǝʿān (like the Marian prayers or that of the cross)
+                    appear with the core of Mastabqʷǝʿān.
                     This record serves as a general record for any collection of liturgical supplications.
                 </p>
             </abstract>
@@ -247,7 +248,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </div>
                 </div>
                     
-                <div type="textpart" subtype="supplication" xml:id="SupplicationMaryam" corresp="LIT1960Mashaf#Maryam">
+                <div type="textpart" subtype="supplication" xml:id="SupplicationMaryam" corresp="LIT6906MastabqMar">
                <label>መስተበቍዕ፡ ዘግዝእትነ፡ ማርያም፡</label>
                     <note>
                         <bibl>
@@ -267,7 +268,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </ab>
             </div>
 
-                <div type="textpart" subtype="supplication" xml:id="SupplicationMaryam2" corresp="LIT1960Mashaf#Maryam2">
+                <div type="textpart" subtype="supplication" xml:id="SupplicationMaryam2" corresp="LIT6907MastabqMar">
                     <label>ዓዲ፡</label>
                <ab>
                     ወካዕበ፡ ናስተበቍዓ፡ ለንግሥተ፡ ኵልነ፡ ማርያም፡ እምነ፡ ወእሙ፡ ለእግዚእነ፡ ወመድኃኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ንስእል፡ ወነኃሥሥ፡ ናስተበቍዕ፡ ወንቄድስ፡ ዕበየ፡ ተአምሪሃ፡ ብዙኃ፡ ለእመ፡ ጸባዖት፡ ንጉሥ፡ እለ፡ ትነብሩ፡ ተንሥኡ፡ ወእለ፡ ታረምሙ፡ አውሥኡ፡ ማርያምሃ፡ በቃለ፡ ስብሐት፡ ጸውዑ፡ ቁሙ፡ ወአጽምዑ፡ ተአምረ፡ ድንግል፡ ከመ፡ ትስምዑ። 
@@ -275,6 +276,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     ይ፡ ሕ፡ ቡርክት፡ አንቲ፡ ማርያም፡ ቡርክት፡ አንቲ፡ ማርያም፡ ሠናይት፡ አንቲ፡ ማርያም፡ ወቡሩክ፡ ፍሬ፡ ከርሥኪ፡ መድኃኔ፡ ኵሉ፡ ዓለም። 
                     ይ፡ ካ፡ ንዑ፡ ንስግድ፡ ወንግነይ፡ ላቲ፡ ንዑ፡ ንትፈሣሕ፡ ወንትኀሠይ፡ ባቲ፡ እስመ፡ እመ፡ አምላክ፡ ይእቲ፡ ድንግልናቲሃ፡ ፪ቲ፡ ዛቲ፡ ይእቲ፡ ትንቢቶሙ፡ ለነቢያት፡ ሞገሰ፡ ስብከቶሙ፡ ለሐዋርያት፡ እሞሙ፡ ለሰማዕት፡ ወእኅቶሙ፡ ለመላእክት፡ ላቲ፡ ይደሉ፡ ክብር፡ ወስብሐት፡ ወለወልዳ፡ አምልኮ፡ ወስግደት፡ በምድር፡ ወበሰማያት፡ በባሕር፡ ወበቀላያት፡ ለዓለመ፡ ዓለም፡ አሜን። 
                </ab>                    
+                </div>
+                
+                <div type="textpart" subtype="supplication" xml:id="SupplicationMaryam3" corresp="LIT6908MastabqMarIII">
+                    <label>ናስተበቍዓ፡ ለነቅዐ፡</label>
+                    <ab>
+                        ወካዕበ፡ ናስተበቍዓ፡ ለነቅዐ፡ ሕይወት፡ ለቅድስት፡ ደብተራ፡ ዘወለደት፡ ወአግመረት፡ ጵርስፎራ፡ ይትነከር፡ ዕበየ፡ ክብራ፡ ጊዜ፡ ይትነበብ፡ ተአምራ፡ ጽልሕወ፡ ልብ፡ ብእሲ፡ ሥጋ፡ 
+                        ቢጹ፡ ዘበልዐ፡ ስመ፡ ማርያም፡ ዘጸውዐ፡ በሕፍነ፡ ማይ፡ ቈሪር፡ መንግሥተ፡ ሰማያት፡ ቦአ፡ ሰሚዐክሙ፡ አንክሩ፡ ዜና፡ ዝክራ፡ አፍቅሩ፡ መንግሥተ፡ ዚአሃ፡ ተዘከሩ፡ ዘኵሎ፡ ታድኅን፡ 
+                        እግዝእትነ፡ ማርያም። ንዑ፡ ንስግድ፡ ወንግነይ፡ ለንግሣ፡ ዘጾረት፡ ወአግመረት፡ በከርሣ፡ እግዚአ፡ ሰማያት፡ ወምድር፡ መስተስርየ፡ ኀጢአት፡ ወአበሳ። እንዘ፡ ኢትሌሊ፡ ባዕላየ፡ 
+                        ወኢትሜንን፡ ነዳየ። ማርያምሰ፡ ታፈቅር፡ ዘይገብር፡ ሠናየ። ዛቲ፡ ይእቲ፡ እኅተ፡ መላእክት፡ ትጉሃን። ወለተ፡ ኄራን፡ ነቢያት፡ ብዕሎሙ፡ ለሐዋርያት፡ ሞገሰ፡ ጻድቃን፡ ወሰማዕት፡ 
+                        ላቲ፡ ይደሉ፡ ክብር፡ ወስብሐት፡ ዘምስለ፡ ወልዳ፡ አምልኮ፡ ወስግደት፡ በምድር፡ ወበሰማያት፡ በባሕር፡ ወበቀላያት፡ ለዓለመ፡ ዓለም፡ አሜን።
+                    </ab>                    
                 </div>
                 
             <div type="textpart" subtype="supplication" xml:id="SupplicationMasqal" corresp="LIT1960Mashaf#SuppMasqal">

--- a/4001-5000/LIT4711Mastabqwe.xml
+++ b/4001-5000/LIT4711Mastabqwe.xml
@@ -43,7 +43,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p>
                     The office contains prayers for the sick, the pilgrims, the rain, the fruits of the earth, the water of the rivers, the king, the sleepers, 
-                    the offerers, the catechumens, the peace, the Church. Optionally, other Mastabqʷǝʿān (like the Marian prayers or that of the cross)
+                    the offerers, the catechumens, the peace, the Church. Optionally, other Mastabqʷǝʿān 
+                    (like <ref type="work" corresp="LIT6906MastabqMar"/>, <ref type="work" corresp="LIT6907MastabqMar"/>,
+                    <ref type="work" corresp="LIT6908MastabqMarIII"/> or <ref type="work" corresp="LIT1960Mashaf#SuppMasqal"/>)
                     appear with the core of Mastabqʷǝʿān.
                     This record serves as a general record for any collection of liturgical supplications.
                 </p>

--- a/4001-5000/LIT4711Mastabqwe.xml
+++ b/4001-5000/LIT4711Mastabqwe.xml
@@ -251,7 +251,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </div>
                     
                 <div type="textpart" subtype="supplication" xml:id="SupplicationMaryam" corresp="LIT6906MastabqMar">
-               <label>መስተበቍዕ፡ ዘግዝእትነ፡ ማርያም፡</label>
+                    <label>መስተብቍዕ፡ ዘእግዝእትነ፡ ማርያም፡</label>
                     <note>
                         <bibl>
                             <ptr target="bm:MashafaSalotaKidan1960"/>
@@ -281,7 +281,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </div>
                 
                 <div type="textpart" subtype="supplication" xml:id="SupplicationMaryam3" corresp="LIT6908MastabqMarIII">
-                    <label>ናስተበቍዓ፡ ለነቅዐ፡</label>
+                    <label>ወካዕበ፡ ናስተበቍዓ፡ ለነቅዐ፡ ሕይወት፡</label>
                     <ab>
                         ወካዕበ፡ ናስተበቍዓ፡ ለነቅዐ፡ ሕይወት፡ ለቅድስት፡ ደብተራ፡ ዘወለደት፡ ወአግመረት፡ ጵርስፎራ፡ ይትነከር፡ ዕበየ፡ ክብራ፡ ጊዜ፡ ይትነበብ፡ ተአምራ፡ ጽልሕወ፡ ልብ፡ ብእሲ፡ ሥጋ፡ 
                         ቢጹ፡ ዘበልዐ፡ ስመ፡ ማርያም፡ ዘጸውዐ፡ በሕፍነ፡ ማይ፡ ቈሪር፡ መንግሥተ፡ ሰማያት፡ ቦአ፡ ሰሚዐክሙ፡ አንክሩ፡ ዜና፡ ዝክራ፡ አፍቅሩ፡ መንግሥተ፡ ዚአሃ፡ ተዘከሩ፡ ዘኵሎ፡ ታድኅን፡ 

--- a/new/LIT6906MastabqMar.xml
+++ b/new/LIT6906MastabqMar.xml
@@ -42,7 +42,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p/>
+                <p>This Mastabqʷǝʿ for Mary often optionally appears together with the core of 
+                    <ref type="work" corresp="LIT4711Mastabqwe">Mastabqʷǝʿān</ref>, but also individually in some manuscripts.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -67,6 +68,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <ptr target="bm:Bahr2023Litanies"/>
                 </bibl>
             </listBibl>
+            <listRelation>
+                <relation name="saws:formsPartOf" active="LIT6906MastabqMar" passive="LIT4711Mastabqwe"/>
+            </listRelation>
             <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
                 <ab>እግዚአብሔር፡ እግዚኦ፡ ኢየሱስ፡ ክርስቶስ፡ አምላክነ፡ ዘትቤሎ፡ ለፍቁርከ፡ ዮሐንስ፡ እንዘ፡ ሀሎከ፡ ዲበ፡ 
                     ዕፀ፡ መስቀል፡ ቅዱስ፡ ወትቤላ፡ ለማርያም፡ ነዋ፡ ወልድኪ፡ ወለረድእከኒ፡ ነያ፡ እምከ፡</ab>

--- a/new/LIT6907MastabqMar.xml
+++ b/new/LIT6907MastabqMar.xml
@@ -42,7 +42,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p/>
+                <p>This Mastabqʷǝʿ for Mary often optionally appears together with the core of 
+                    <ref type="work" corresp="LIT4711Mastabqwe">Mastabqʷǝʿān</ref>, but also individually in some manuscripts.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -67,6 +68,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <ptr target="bm:Bahr2023Litanies"/>
                 </bibl>
             </listBibl>
+            <listRelation>
+                <relation name="saws:formsPartOf" active="LIT6907MastabqMar" passive="LIT4711Mastabqwe"/>
+            </listRelation>
             <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
                 <ab>ወካዕበ፡ ናስተበቍዓ፡ ለንግሥተ፡ ኵልነ፡ ማርያም፡ እምነ፡ ወእሙ፡ ለእግዚእነ፡ ወመድኀኒነ፡ ኢየሱስ፡ ክርስቶስ፡ ንስእል፡ ወነኀሥሥ፡ ናስተበቍዕ፡ ወንዌድስ፡ ዕበየ፡ 
                     ተአምሪሃ፡ ብዙኀ፡ ለእመ፡ ጸባኦት፡ ንጉሥ፡</ab>

--- a/new/LIT6908MastabqMarIII.xml
+++ b/new/LIT6908MastabqMarIII.xml
@@ -38,7 +38,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p/>
+                <p>This Mastabqʷǝʿ for Mary often optionally appears together with the core of 
+                    <ref type="work" corresp="LIT4711Mastabqwe">Mastabqʷǝʿān</ref>, but also individually in some manuscripts.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -69,6 +70,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <ptr target="bm:Bahr2023Litanies"/>
                     </bibl>
                 </listBibl>
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT6907MastabqMar" passive="LIT4711Mastabqwe"/>
+                </listRelation>
             </div>
             <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">
                 <ab>ወካዕበ፡ ናስተበቍዓ፡ ለነቅዐ፡ ሕይወት፡ ለቅድስት፡ ደብተራ፡ ዘወለደት፡ ወአግመረት፡ ጵርስፎራ፡ ይትነከር፡ ዕበየ፡ ክብራ፡ ጊዜ፡ ይትነበብ፡ ተአምራ፡ ጽልሕወ፡ ልብ፡ ብእሲ፡ 

--- a/new/LIT6908MastabqMarIII.xml
+++ b/new/LIT6908MastabqMarIII.xml
@@ -71,7 +71,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </bibl>
                 </listBibl>
                 <listRelation>
-                    <relation name="saws:formsPartOf" active="LIT6907MastabqMar" passive="LIT4711Mastabqwe"/>
+                    <relation name="saws:formsPartOf" active="LIT6908MastabqMarIII" passive="LIT4711Mastabqwe"/>
                 </listRelation>
             </div>
             <div type="edition"><div type="textpart" subtype="incipit" xml:lang="gez">


### PR DESCRIPTION
I updated the three records on Mastabqʷǝʿān, that I created recently according to Leonards request in November 2023 (cf. https://github.com/BetaMasaheft/Works/pull/1033) and the general record LIT4711Mastabqwe according to Leonards new request from june 2024 (cf. https://github.com/BetaMasaheft/Documentation/issues/2552).

Alas, I had problems to connect the sub-IDs in LIT4711Mastabqwe with the newly created individual LIT IDs. The oxygen accepted just only one corresp for any sub-ID, so I needed to delete the references to LIT1960Mashaf (LIT1960Mashaf#Maryam, LIT1960Mashaf#Maryam2). Does anybody know, how to add a LIT ID without deleting the previous one?