### PR TITLE
Created records for Amharic commentaries

### DIFF
--- a/new/LIT7023CommKidanTemHeb.xml
+++ b/new/LIT7023CommKidanTemHeb.xml
@@ -22,7 +22,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </publicationStmt>
             <sourceDesc>
                 <listWit>
-                    <witness corresp="#BLorient11719"/>
+                    <witness corresp="BLorient11719"/>
                 </listWit>
             </sourceDesc>
         </fileDesc>
@@ -56,8 +56,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="dcterms:hasPart" active="LIT7023CommKidanTemHeb" passive="LIT7024CommKidanZaNagh"/>
                     <relation name="dcterms:hasPart" active="LIT7023CommKidanTemHeb" passive="LIT7025CommTemHeb"/>
-                    <relation name="saws:isCommentOn" active="#LIT7023CommKidanTemHeb" passive="LIT1716Kidanz"/>
-                    <relation name="saws:isCommentOn" active="#LIT7023CommKidanTemHeb" passive="LIT2444Temher"/>
+                    <relation name="saws:isCommentOn" active="LIT7023CommKidanTemHeb" passive="LIT1716Kidanz"/>
+                    <relation name="saws:isCommentOn" active="LIT7023CommKidanTemHeb" passive="LIT2444Temher"/>
                 </listRelation>
             </div><!---->
         </body>

--- a/new/LIT7023CommKidanTemHeb.xml
+++ b/new/LIT7023CommKidanTemHeb.xml
@@ -1,0 +1,65 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7023CommKidanTemHeb" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Amharic commentary-introduction to the Kidān za-nagh and Tǝmhǝrta ḫǝbuʾāt</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <listWit>
+                    <witness corresp="#BLorient11719"/>
+                </listWit>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="ChristianContent"/>
+                    <term key="Commentary"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-07-10">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="dcterms:hasPart" active="LIT7023CommKidanTemHeb" passive="LIT7024CommKidanZaNagh"/>
+                    <relation name="dcterms:hasPart" active="LIT7023CommKidanTemHeb" passive="LIT7025CommTemHeb"/>
+                    <relation name="saws:isCommentOn" active="#LIT7023CommKidanTemHeb" passive="LIT1716Kidanz"/>
+                    <relation name="saws:isCommentOn" active="#LIT7023CommKidanTemHeb" passive="LIT2444Temher"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7024CommKidanZaNagh.xml
+++ b/new/LIT7024CommKidanZaNagh.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Amharic commentary on the Kidān za-nagh</title>
+                <title xml:lang="en" xml:id="t1">Amharic commentary on the Kidān za-nagh</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -22,7 +22,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </publicationStmt>
             <sourceDesc>
                 <listWit>
-                    <witness corresp="#BLorient11719"/>
+                    <witness corresp="BLorient11719"/>
                 </listWit>
             </sourceDesc>
         </fileDesc>

--- a/new/LIT7024CommKidanZaNagh.xml
+++ b/new/LIT7024CommKidanZaNagh.xml
@@ -1,0 +1,80 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7024CommKidanZaNagh" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Amharic commentary on the Kidān za-nagh</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <listWit>
+                    <witness corresp="#BLorient11719"/>
+                </listWit>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="ChristianContent"/>
+                    <term key="Commentary"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-07-10">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT7024CommKidanZaNagh" passive="LIT7023CommKidanTemHeb"/>
+                    <relation name="saws:isCommentOn" active="LIT7024CommKidanZaNagh" passive="LIT1716Kidanz"/>
+                </listRelation>
+            </div>
+            <div type="edition">
+                <note>The given text is based on <ref type="mss" corresp="BLorient11719"/> as quoted by 
+                    <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">100</citedRange></bibl>.</note>
+            <div type="edition" subtype="incipit" xml:lang="am">
+                <note>The end is missing.</note>
+                <ab>በስመ፡<gap reason="ellipsis"/> ኪዳን፡ ዘነግሕ፡ ዘነገሮሙ፡ እግዚእነ፡ ለሐዋርያት፡ ጸሎቱ፡ ወበረከቱ፡ ወኃብተ፡ 
+                ረድኤቱ፡ የሀሎ፡ ምስሌነ፡ ለዓለመ፡ ዓለ<corr resp="PRS8999Strelcyn">ም</corr>፡ አ<corr resp="PRS8999Strelcyn">ሜን</corr>። 
+                ጌታ፡ በሕይወተ፡ ሥጋ፡ ሳለ፡ ፫ት፡ ዓመት፡ ከ፫ት፡ ወርኅ፡ ያስተማረው፡ ወንጌል፡ ይባላል፡ ሞቶ፡ ተነስቶ፡ ያስተማረው፡ ኪዳን፡ ይባላል፡ ይሀውም፡ ይታወቅ፡ ዘንድ፡
+                ቅዱስ፡ ጳውሎስ፡ በገላትያ፡ ክታቡ፡ </ab>
+            </div>
+            <div type="edition" subtype="textpart" xml:lang="am">
+                <ab><sic resp="PRS8999Strelcyn">ይትእምርተ፡</sic> ኅቡአትና፡ የከዳን፡ መቅድማቸው፡ አንድ፡ ነው። ከእንግዴህ፡
+                    ወዲህ፡ ትእምርተ፡ ኅቡዓት፡ ቢሉ፡ ወይትእምርተ፡ ኅቡዓት፡ ኪዳን፡ ቢሉ፡ ወይኪዳን፡ ይሔድዋል። ትእምርተ፡ ኅቡዓትም፡ ኪዳንም፡ የጌታ፡ ቃል፡ ስለ 
+                    <pb n="9ra"/>ሆኑ፡ በየፈንታ፡ ይነገራሉ፡ እንጅ፡ እንድ፡ጊዜ፡ አይነግሩም። ነገር፡ ግን፡ ካህን፡ ትእምርተ፡ ኅቡዓት፡ ሳይተረጐም፡ መቅደሱን፡ አይከፍተው፡ ካለ፡ 
+                    ትእምርተ፡ ኅቡዓት፡ ይቅድም።</ab>
+            </div><!---->
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7025CommTemHeb.xml
+++ b/new/LIT7025CommTemHeb.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Amharic commentary on the tǝmhǝrta ḫǝbuʾāt</title>
+                <title xml:lang="en" xml:id="t1">Amharic commentary on the Tǝmhǝrta ḫǝbuʾāt</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -22,7 +22,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </publicationStmt>
             <sourceDesc>
                 <listWit>
-                    <witness corresp="#BLorient11719"/>
+                    <witness corresp="BLorient11719"/>
                 </listWit>
             </sourceDesc>
         </fileDesc>

--- a/new/LIT7025CommTemHeb.xml
+++ b/new/LIT7025CommTemHeb.xml
@@ -1,0 +1,72 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7025CommTemHeb" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Amharic commentary on the tǝmhǝrta ḫǝbuʾāt</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <listWit>
+                    <witness corresp="#BLorient11719"/>
+                </listWit>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="ChristianContent"/>
+                    <term key="Commentary"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-07-10">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT7025CommTemHeb" passive="LIT7023CommKidanTemHeb"/>
+                    <relation name="saws:isCommentOn" active="LIT7025CommTemHeb" passive="LIT2444Temher"/>
+                </listRelation>
+            </div>
+            <div type="edition">
+                <note>The given text is based on <ref type="mss" corresp="BLorient11719"/> as quoted by 
+                    <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">100</citedRange></bibl>.</note>
+                <div type="edition" subtype="incipit" xml:lang="am">
+                    <note>The end is missing.</note>
+                    <ab>በእንተ፡ <sic resp="PRS8999Strelcyn">ትእምርተ፡</sic> ኅቡአት። ኅቡዓትን፡ የመማር፡ ኅቡዓትን፡ የማስተማር፡ ነገር፡ እንዲህ፡ ነው፡ ብሎ፡ አፍዝዞ፡ ተወው። አንድ፡
+                        የኅቡዓትን፡ ዘይቤ፡ ለማውጻት፡ ስለሽሽግ፡ ትእምርት፡ ስል፡ ነው። በአንተን፡ ነገር፡ ሰል፡ ምን፡ ምስክር፡ አለ፡ ቢሉ።</ab>
+                </div>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
Created records for Amharic commentaries on the Kidān za-nagh and the Tǝmhǝrta ḫǝbuʾat as discussed in https://github.com/BetaMasaheft/Documentation/issues/2565.