### PR TITLE
Create LIT7041LordsPrayerAmh

### DIFF
--- a/new/LIT7041LordsPrayerAmh.xml
+++ b/new/LIT7041LordsPrayerAmh.xml
@@ -58,7 +58,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <div type="bibliography">
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LIT7041LordsPrayerAmh" passive="BLorient7946"/>
-                    <relation name="saws:formsPartOf" active="LIT7041LordsPrayerAmh" passive="LIT1558Matthew"/>
                 </listRelation>
             </div><!---->
         </body>

--- a/new/LIT7041LordsPrayerAmh.xml
+++ b/new/LIT7041LordsPrayerAmh.xml
@@ -7,10 +7,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="am" xml:id="t1">የጌታ፡ ጸሎት፡</title>
                 <title xml:lang="am" type="normalized" corresp="#t1">Yagetā ṣalot</title>
-                <title xml:lang="en" corresp="#t1">Lord's prayer</title>
+                <title xml:lang="en" corresp="#t1">The Lord's prayer</title>
                 <title xml:lang="am" xml:id="t2">አባታችን፡ ሆይ፡ በሰማያት፡ የምትኖር፡</title>
-                <title xml:lang="am" type="normalized" corresp="#t2"></title>
-                <title xml:lang="en" corresp="#t2">Our Father, who dwells in heaven</title>
+                <title xml:lang="am" type="normalized" corresp="#t2">ʾabbātāččǝn hoy ba-samāyāt ya-mǝtnor</title>
+                <title xml:lang="en" corresp="#t2">Our Father, who dwells in heaven (...)</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT7041LordsPrayerAmh.xml
+++ b/new/LIT7041LordsPrayerAmh.xml
@@ -9,7 +9,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="am" type="normalized" corresp="#t1">Yagetā ṣalot</title>
                 <title xml:lang="en" corresp="#t1">The Lord's prayer</title>
                 <title xml:lang="am" xml:id="t2">አባታችን፡ ሆይ፡ በሰማያት፡ የምትኖር፡</title>
-                <title xml:lang="am" type="normalized" corresp="#t2">ʾabbātāččǝn hoy ba-samāyāt yammǝtnor</title>
+                <title xml:lang="am" type="normalized" corresp="#t2">ʾabbātāččǝn hoy ba-samāyāt yammǝtǝnor</title>
                 <title xml:lang="en" corresp="#t2">Our Father, who dwells in heaven (...)</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>

--- a/new/LIT7041LordsPrayerAmh.xml
+++ b/new/LIT7041LordsPrayerAmh.xml
@@ -9,7 +9,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="am" type="normalized" corresp="#t1">Yagetā ṣalot</title>
                 <title xml:lang="en" corresp="#t1">The Lord's prayer</title>
                 <title xml:lang="am" xml:id="t2">አባታችን፡ ሆይ፡ በሰማያት፡ የምትኖር፡</title>
-                <title xml:lang="am" type="normalized" corresp="#t2">ʾabbātāččǝn hoy ba-samāyāt ya-mǝtnor</title>
+                <title xml:lang="am" type="normalized" corresp="#t2">ʾabbātāččǝn hoy ba-samāyāt yammǝtnor</title>
                 <title xml:lang="en" corresp="#t2">Our Father, who dwells in heaven (...)</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>

--- a/new/LIT7041LordsPrayerAmh.xml
+++ b/new/LIT7041LordsPrayerAmh.xml
@@ -1,0 +1,66 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7041LordsPrayerAmh" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="am" xml:id="t1">የጌታ፡ ጸሎት፡</title>
+                <title xml:lang="am" type="normalized" corresp="#t1">Yagetā ṣalot</title>
+                <title xml:lang="en" corresp="#t1">Lord's prayer</title>
+                <title xml:lang="am" xml:id="t2">አባታችን፡ ሆይ፡ በሰማያት፡ የምትኖር፡</title>
+                <title xml:lang="am" type="normalized" corresp="#t2"></title>
+                <title xml:lang="en" corresp="#t2">Our Father, who dwells in heaven</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Matthew 6:9-15 in Amharic.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="ChristianContent"/>
+                    <term key="Prayers"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-07-26">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT7041LordsPrayerAmh" passive="BLorient7946"/>
+                    <relation name="saws:formsPartOf" active="LIT7041LordsPrayerAmh" passive="LIT1558Matthew"/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7041LordsPrayerAmh.xml
+++ b/new/LIT7041LordsPrayerAmh.xml
@@ -6,10 +6,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="am" xml:id="t1">የጌታ፡ ጸሎት፡</title>
-                <title xml:lang="am" type="normalized" corresp="#t1">Yagetā ṣalot</title>
+                <title xml:lang="am" type="normalized" corresp="#t1">Ya-getā ṣalot</title>
                 <title xml:lang="en" corresp="#t1">The Lord's prayer</title>
                 <title xml:lang="am" xml:id="t2">አባታችን፡ ሆይ፡ በሰማያት፡ የምትኖር፡</title>
-                <title xml:lang="am" type="normalized" corresp="#t2">ʾabbātāččǝn hoy ba-samāyāt yammǝtǝnor</title>
+                <title xml:lang="am" type="normalized" corresp="#t2">ʾAbbātāččǝn hoy ba-samāyāt yammǝtǝnor</title>
                 <title xml:lang="en" corresp="#t2">Our Father, who dwells in heaven (...)</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>


### PR DESCRIPTION
I created a record for the Lord's Prayer in Amharic as attested in BLorient7946 and following our discussion in 
https://github.com/BetaMasaheft/Documentation/issues/2586. 

I was wondering, whether I should name "Lord's prayer (Amharic)" more prominently in the title, but I decided to use the Amharic title to be consistent with our rule of how to encode prayers in Bm.