### PR TITLE
Create LIT7056Qene.xml

### DIFF
--- a/new/LIT7056Qene.xml
+++ b/new/LIT7056Qene.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ለክርስቶስ፡ ጥዑመ፡ ቃል፡ ስቁል፡ ጴጥሮስ፡ በአጽምዖቱ፡</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">La-Krǝstos ṭǝʿuma qāl sǝqul P̣eṭros ba-ʾaṣmǝʿotu (Qǝne of the Śǝllāse-type)</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">La-Krǝstos ṭǝʿuma qāl sǝqul P̣eṭros ba-ʾaṣmǝʿotu (Qǝne of the śǝllāse-type)</title>
                 <title xml:lang="en" corresp="#t1">When Peter listened to the sweet voice of the crucified Christ ...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
@@ -34,7 +34,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Qǝne of the Śǝllāse-type. Type and author are not indicated in the manuscript.</p>
+                <p>Qǝne of the śǝllāse-type. Type and author are not indicated in the manuscript.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -65,7 +65,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="5">መዋቲ፡ መትሩ፡ በሰይፈ፡ ተግሣጽ።</l>
                     <l n="6">ወሰቁለ፡ ሰቀሉ፡ በዕፅ። ።</l>
                 </ab>
-            </div><!---->
+            </div>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT7056Qene" passive="BNFabb145"/>
+                </listRelation>
+            </div>
         </body>
     </text>
 </TEI>

--- a/new/LIT7056Qene.xml
+++ b/new/LIT7056Qene.xml
@@ -60,7 +60,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <ab>
                     <l n="1">ለክርስቶስ፡ ጥዑመ፡ ቃል፡ ስቁል፡ ጴጥሮስ፡ በአጽምዖቱ፡ ወበኀበ፡ ዓለም፡ ጳውሎስ፡ መዋቲ፡ እስከ፡ አፍራስ፡ ዘግብጽ።</l>
                     <l n="2">ሰሐቅዎ፡ ሎቱ፡ ለሞቶሙ፡ ሐፅ።</l>
-                    <l n="3">ወኢንበሎሙ፡ ለ<add place="above">ሰብእ</add><del rend="expunctuated">ግብጽ</del>፡ ዘሮሜ፡ ቀተልት፡ ሕያዋን፡ አብያጽ።</l>
+                    <l n="3">ወኢንበሎሙ፡ ለ<add place="above">ሰብእ</add><del rend="expunctuated">ግብጽ</del>፡ ዘሮሜ፡ ቀተልተ፡ ሕያዋን፡ አብያጽ።</l>
                     <l n="4">ዳእሙ፡ ንብሎሙ፡ ፩ሰብአ፡ ሕ<add place="above">ፀ</add>ፅ።</l>
                     <l n="5">መዋቴ፡ መትሩ፡ በሰይፈ፡ ተግሣጽ።</l>
                     <l n="6">ወስቁለ፡ ሰቀሉ፡ በዕፅ። ።</l>

--- a/new/LIT7056Qene.xml
+++ b/new/LIT7056Qene.xml
@@ -1,0 +1,71 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7056Qene" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">ለክርስቶስ፡ ጥዑመ፡ ቃል፡ ስቁል፡ ጴጥሮስ፡ በአጽምዖቱ፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">La-Krǝstos ṭǝʿuma qāl sǝqul P̣eṭros ba-ʾaṣmǝʿotu (Qǝne of the Śǝllāse-type)</title>
+                <title xml:lang="en" corresp="#t1">When Peter listened to the sweet voice of the crucified Christ ...</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <listWit>
+                    <witness corresp="BNFabb145"/>
+                </listWit>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Qǝne of the Śǝllāse-type. Type and author are not indicated in the manuscript.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Poetry"/>
+                    <term key="Qene"/>
+                    <term key="Sellase"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-08-31">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="edition" xml:lang="gez">
+                <note>This edition is based on <ref type="mss" corresp="BNFabb145"/> on f. 55rc. Division into verses is indicated with
+                    <foreign xml:lang="gez">።</foreign>. The end of the poem is indicated with <foreign xml:lang="gez">። ።</foreign>.</note>
+                <ab>
+                    <l n="1">ለክርስቶስ፡ ጥዑመ፡ ቃል፡ ስቁል፡ ጴጥሮስ፡ በአጽምዖቱ፡ ወበኀበ፡ ዓለም፡ ጳውሎስ፡ መዋቲ፡ እስከ፡ አፍራስ፡ ዘግብጽ።</l>
+                    <l n="2">ሰሐቅዎ፡ ሎቱ፡ ለሞቶሙ፡ ሐፅ።</l>
+                    <l n="3">ወኢንበሎሙ፡ ለ<add place="above">ሰብእ</add><del rend="expunctuated">ግብጽ</del>፡ ዘሮሜ፡ ቀተልት፡ ሕያዋን፡ አብያጽ።</l>
+                    <l n="4">ዳእሙ፡ ንብሎሙ፡ ፩ሰብአ፡ ሕ<add place="above">ፅ</add>ፅ።</l>
+                    <l n="5">መዋቲ፡ መትሩ፡ በሰይፈ፡ ተግሣጽ።</l>
+                    <l n="6">ወሰቁለ፡ ሰቀሉ፡ በዕፅ። ።</l>
+                </ab>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7056Qene.xml
+++ b/new/LIT7056Qene.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ለክርስቶስ፡ ጥዑመ፡ ቃል፡ ስቁል፡ ጴጥሮስ፡ በአጽምዖቱ፡</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">La-Krǝstos ṭǝʿuma qāl sǝqul P̣eṭros ba-ʾaṣmǝʿotu (Qǝne of the śǝllāse-type)</title>
-                <title xml:lang="en" corresp="#t1">When Peter listened to the sweet voice of the crucified Christ ...</title>
+                <title xml:lang="en" corresp="#t1">When Peter listened to the sweet-voiced crucified Christ …</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -61,9 +61,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="1">ለክርስቶስ፡ ጥዑመ፡ ቃል፡ ስቁል፡ ጴጥሮስ፡ በአጽምዖቱ፡ ወበኀበ፡ ዓለም፡ ጳውሎስ፡ መዋቲ፡ እስከ፡ አፍራስ፡ ዘግብጽ።</l>
                     <l n="2">ሰሐቅዎ፡ ሎቱ፡ ለሞቶሙ፡ ሐፅ።</l>
                     <l n="3">ወኢንበሎሙ፡ ለ<add place="above">ሰብእ</add><del rend="expunctuated">ግብጽ</del>፡ ዘሮሜ፡ ቀተልት፡ ሕያዋን፡ አብያጽ።</l>
-                    <l n="4">ዳእሙ፡ ንብሎሙ፡ ፩ሰብአ፡ ሕ<add place="above">ፅ</add>ፅ።</l>
-                    <l n="5">መዋቲ፡ መትሩ፡ በሰይፈ፡ ተግሣጽ።</l>
-                    <l n="6">ወሰቁለ፡ ሰቀሉ፡ በዕፅ። ።</l>
+                    <l n="4">ዳእሙ፡ ንብሎሙ፡ ፩ሰብአ፡ ሕ<add place="above">ፀ</add>ፅ።</l>
+                    <l n="5">መዋቴ፡ መትሩ፡ በሰይፈ፡ ተግሣጽ።</l>
+                    <l n="6">ወስቁለ፡ ሰቀሉ፡ በዕፅ። ።</l>
                 </ab>
             </div>
             <div type="bibliography">


### PR DESCRIPTION
I assume, that it is of the Śǝllāse type, because I counted six verses (I took line 3 as one and did not divide it into two, because the rhyme word ግብጽ is expunctuated (because infact it does not make sense to me in this place) and is not followed by a verse-marker (።) 

I am not sure about the translation of the title, i.e. whether I have put the title words in a sensitive and grammatically correct order.

I have seen, that the Qǝne-type and keyword Śǝllāse is written without a dash on the a i.e. Śǝllase. I think this is incorrect and should be corrected. In Guidi 1901 it is given as ሥላሴ፡

<img width="245" alt="Screenshot 2024_Sellase" src="https://github.com/user-attachments/assets/20b980e2-a81b-46fe-89c4-2ac60ccddd72">
