### PR TITLE
Update LIT1763Legend.xml

### DIFF
--- a/1001-2000/LIT1763Legend.xml
+++ b/1001-2000/LIT1763Legend.xml
@@ -80,8 +80,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <citedRange unit="page">593-594</citedRange>
                </bibl>
                <bibl>
-                  <ptr target="bm:Worrell1886Zauberwesen"/>
-                  <citedRange unit="page">171-173</citedRange>
+                  <ptr target="bm:Grebaut1937Sousneyos"/>
+                  <citedRange unit="page">177-183</citedRange>
+               </bibl>        
+               <bibl>
+                  <ptr target="bm:Worrell1909Zauberwesen"/>
+                  <citedRange unit="page">165-83</citedRange>
+               </bibl>
+               <bibl>
+                  <ptr target="bm:Worrell1910Zauberwesen"/>
+                  <citedRange unit="page">59-69</citedRange>
                </bibl>
                <bibl>
                   <ptr target="bm:Budge1900Miracles"/>

--- a/1001-2000/LIT1763Legend.xml
+++ b/1001-2000/LIT1763Legend.xml
@@ -76,6 +76,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <div type="bibliography">
             <listBibl type="editions">
                <bibl>
+                  <ptr target="bm:Worrell1909Zauberwesen"/>
+                  <citedRange unit="page">165-83</citedRange>
+               </bibl>
+               <bibl>
                   <ptr target="bm:Budge1928History"/>
                   <citedRange unit="page">593-594</citedRange>
                </bibl>
@@ -83,14 +87,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <ptr target="bm:Grebaut1937Sousneyos"/>
                   <citedRange unit="page">177-183</citedRange>
                </bibl>        
-               <bibl>
-                  <ptr target="bm:Worrell1909Zauberwesen"/>
-                  <citedRange unit="page">165-83</citedRange>
-               </bibl>
-               <bibl>
-                  <ptr target="bm:Worrell1910Zauberwesen"/>
-                  <citedRange unit="page">59-69</citedRange>
-               </bibl>
                <bibl>
                   <ptr target="bm:Budge1900Miracles"/>
                   <citedRange>110</citedRange>
@@ -102,8 +98,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <citedRange unit="page">590-591</citedRange>
                </bibl>
                <bibl>
-                  <ptr target="bm:Worrell1886Zauberwesen"/>
-                  <citedRange unit="page">167-169</citedRange>
+                  <ptr target="bm:Worrell1909Zauberwesen"/>
+                  <citedRange unit="page">165-83</citedRange>
+               </bibl>
+               <bibl>
+                  <ptr target="bm:Worrell1910Zauberwesen"/>
+                  <citedRange unit="page">59-69</citedRange>
                </bibl>
                <bibl>
                   <ptr target="bm:Budge1900Miracles"/>


### PR DESCRIPTION
I updated the bibliography with additional literature, that I found in Strelcyn 1978 for BLorient11602.

However, I have seen, that some of the existing literature in the bibliography was not well displayed, presumably because the tag bm:Worrell1886Zauberwesen does not exist in Zotero. I did not find any publication of 1886 with the name Worrell in KVK, as well. 
For this reason, I think, it was a mistake that I corrected to bm:Worrell1909Zauberwesen and bm:Worrell1910Zauberwesen

<img width="557" alt="Screenshot 2024_Worrell" src="https://github.com/user-attachments/assets/9ac5b4ba-3b1a-43f8-9968-5797b9819b6d">


Worrells publication of 1909 has both edited texts and translations, while Worrell 1910 contains only translated texts from various mss.