### PR TITLE
Correct LIT4305Prayer

### DIFF
--- a/4001-5000/LIT4305Prayer.xml
+++ b/4001-5000/LIT4305Prayer.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:lang="en" xml:id="t1">Prayer for obtaining freedom from the enemies</title>
+            <title xml:lang="en" xml:id="t1">Prayer for having children</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
@@ -21,9 +21,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p>Work of the literatures of Ethiopia and Eritrea</p>
-         </sourceDesc>
-         <sourceDesc>
             <listWit>
                <witness corresp="BAVet36#ms_i12"/>
             </listWit>
@@ -37,16 +34,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
+         <abstract>
+            <p>The beginning is missing.</p>
+         </abstract>
+         <textClass>
+            <keywords>
+               <term key="Prayers"/>
+               <term key="ChristianContent"/>
+            </keywords>
+         </textClass>
          <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
       </profileDesc>
       <revisionDesc>
          <change who="MV" when="2017-01-05">Created file</change>
+         <change when="2024-09-19" who="CH">Corrected title; added textClass and abstract.</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <div type="edition">
-            <div type="textpart" subtype="incipit" xml:lang="gez">
+            <div type="textpart" xml:lang="gez">
+               <note>The textpart is taken from <ref type="mss" corresp="BAVet36"/> according to <bibl>
+                  <ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">167</citedRange></bibl>.</note>
                <ab>
                አምላክየ፡ ለዓለመ፡ ዓለም፡ ነጋሢ፡ አሜን፡ ወተዓትብ፡ ገጸከ፡ ሰብዓቱ፡ ጊዜ፡ ጸውዓ፡ ኤልሳዕ፡ ለሰምራዊት፡ ወይቤል፡ ወቆመ፡ ኀበ፡ ሖሕት፡
             </ab>


### PR DESCRIPTION
There are two LIT ID in BAVet36 with the same title:

LIT4304Prayer -> Prayer for obtaining freedom from the enemies LIT4305Prayer -> Prayer for obtaining freedom from the enemies

However, the second one is described as 'Prayer for having children' in the manuscript record of BAVet36. I do not understand from the given text in the incipit and the explicit, what it is about, but I see in the catalogue (GrébautTisserant1935, p. 167), that the latter is correct: 'Precatio ad prolem obtinendam' = "A prayer to obtain a child".

I think the title of the record LIT4305Prayer is wrong because of copy&paste from the previous one. I corrected it. For comparison see the manuscript record of BAVet36#ms_i12:

 ```
 <msItem xml:id="ms_i12">
                     <locus from="115r" to="116r" facs="0130"/>
                     <title type="incomplete" ref="LIT4305Prayer">Prayer for having children</title>
                     <incipit xml:lang="gez">አምላክየ፡ <sic>ለዓለም፡</sic>ዓለም፡ <sic>ነገሢ፡</sic> አሜን፡ ወተዓትብ፡ <sic>ገጽከ፡</sic> ሰብዓቱ፡ ጊዜ፡ <sic>ጸውዕ፡</sic><sic>ኤልሰዕ፡</sic> ለሰምራዊት፡ ወይቤል፡ ወቆመ፡ ኀበ፡ ሖሕት፡  </incipit>
                     <note>The beginning is missing.</note>
                     <explicit xml:lang="gez"> ወእምድሕረ፡ ሰ<gap reason="lost" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/> ወሰከቡ፡ <sic>ኢይትነገሩ፡</sic><gap reason="lost" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/> ወልድ፡ በፈቃደ፡ እግዚ<supplied reason="lost">አብሔ</supplied>ር፨ ሎቱ፡ ይደሉ፡ ስ<supplied reason="lost">ብሐ</supplied>ት፡ ለዓለመ፡ ዓለም፡ <supplied reason="lost">አ</supplied>ሜን፨</explicit>
                  </msItem>
```