### PR TITLE
Smaller corrections of LIT6707 and LIT6708

### DIFF
--- a/6001-7000/LIT6707PPBuryingHearts.xml
+++ b/6001-7000/LIT6707PPBuryingHearts.xml
@@ -59,19 +59,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <div type="edition">
                 <note>The following division and excerpts are taken from <ref type="mss" corresp="BDLaethg32"/>.</note>
                     <div type="textpart" subtype="incipit" xml:lang="gez">
-                        <label>Incipit</label>
                         <ab>አዳታኤል፡ ስምከ፡ ዘያድለቀልቃ፡ ለምድር፡ ሰዱቃኤል፡ ስምከ፡ ዘይስጥቃ፡ ለባሕር፤ ወኤቴኤል፡ ስምከ፡ ዘያቀልጦ፡ ለሰማይ፤ በዝ፡ አስማት፡ ድፍን፡ ልቦሙ፡ ለሰብአ፡ እገሌ፨ ያሙጅጅ፤ ያሙጅብ፤ አልጀባር፡ አልዣባር፤ ገልማላዊ፤ አልሐዲር
                         </ab>
                     </div>
                     <div type="textpart" subtype="explicit" xml:lang="gez">
-                        <label>Explicit</label>
                         <ab>
                             ወያረስኦሙ፡ ምክሮሙ፡ ለመላእክት፤ ፯ ጊዜ፡ ከማሁ፡ አርስዕ፡ ነገሮሙ፤ ወዘርዝር፡ ምክሮሙ፤ ለሰብአ፡ እገሌ፡ እገሌ፡ እገሌ፨
                         </ab>
                     </div>
           
                 <div type="textpart" subtype="directive" xml:lang="am" xml:id="ExplicitDirective">
-                    <label>Directive</label>
                     <ab> በ፯ ጠጠር፡ በ፯ የብረት፡ አር፡ ፵፱ ጊዜ፡ ደግመህ፡ ፬ቱን፡ በ፬ ማዕዘን፡ በትን፤ ፫ቱ፡ ከቤትህ፡ ከ፫ኛው፡ ማገር፡ ስተል፨</ab>
                 </div>
             </div>

--- a/6001-7000/LIT6707PPBuryingHearts.xml
+++ b/6001-7000/LIT6707PPBuryingHearts.xml
@@ -47,6 +47,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="DR" when="2022-09-05">Created entity</change>
+            <change when="2024-09-19" who="CH">Minor corrections</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/6001-7000/LIT6708PPBuryingHearts.xml
+++ b/6001-7000/LIT6708PPBuryingHearts.xml
@@ -46,6 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="DR" when="2022-09-05">Created entity</change>
+            <change when="2024-09-19" who="CH">Minor corrections</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/6001-7000/LIT6708PPBuryingHearts.xml
+++ b/6001-7000/LIT6708PPBuryingHearts.xml
@@ -58,20 +58,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <div type="edition">
                 <note>The following division and excerpts are taken from <ref type="mss" corresp="BDLaethg32"/>.</note>
                 <div type="textpart" subtype="incipit" xml:lang="gez">
-                    <label>Incipit</label>
                     <ab>
                         ጸሎት፡ በእንተ፡ መድፍነ፡ ፀር፤ ገምድድ፤ ፈርድድ፤ <del rend="expunctuated">ረምድድ</del>፤ አምድድ፤ ለምድድ፤ አፈርድድ፤ ረምድድ፤ ለምለሚዎን፤ በኃይለ፡ ዝን<del rend="strikethrough">ዝለ</del>ቱ፡ አስማቲከ፤ ድፍን፡ ልቦሙ፡ ለፀርየ፡ ወለጸላዕትየ፡ ሊተ፡ ለገብርከ
                     </ab>
                 </div>
                 <div type="textpart" subtype="explicit" xml:lang="gez">
-                    <label>Explicit</label>
                     <ab>
                         በሐዋን፡ በዘረጅን፤ በጸረጅን፤ ፯ ጊዜ፤ ዚረፊማኖስ፤ ፫ ጊ፤ ቲቲማኖስ፤ ፫ ጊ፡ አሽድ፤ አልሽድ፤ ፈቀጅ፤ ወከመ፡ ጰዶጸጅ፤ በሰማይ፡ መንበርከ፤ ወበታቦራዊ፡ ስምከ፤ ተማኅፀንኩ፡ ከመ፡ ኢይትናገሩኒ፡ ነገረ፡ ቅሡመ፡ ዘእንበለ፡ <sic>ፍቅፍ፡</sic> ወሰላም፡ ለገብርከ፡
                     </ab>
                 </div>
                 
                 <div type="textpart" subtype="directive" xml:lang="am" xml:id="ExplicitDirective">
-                    <label>Directive</label>
                     <ab>በ፯ ጠጠር፡ ፵፱ ጊዜ፡ ደግመህ፡ ፬ቱን፡ በምሥራቅ፤ በምዕ፤ በሰ፤ በዳቡ፤ በትን፡ ፫ቱን፤ ፀርከ፤ ከሚጠጣው፡ ውሀ፡ ጣለው፨ ለመፍትሔ፡ ሥራይ፡ በ፵፱ ዘቢብ፡ ፯፯ ጊዜ፡ ደግመህ፡ ፯፯ቱን፡ ብላ፡ እስከ፡ ፯ ቀን። ጸሊ፡ በኅቡዕ።</ab>
                 </div>
             </div>


### PR DESCRIPTION
I have seen, that there is a minor problem with the representation on the website having Incipitincipit or Explicitexplicit. I think, this happened, because <label>Incipit</label> was put into the record. I deleted <label> and I hope, that this problem is solved with this change.

<img width="587" alt="Screenshot 2024_Incipitincipit" src="https://github.com/user-attachments/assets/290b2eef-7615-4988-bba2-9fa4490e28bb">
