### PR TITLE
Updated LIT7016Liton and added reference to it in LIT3188Liton

### DIFF
--- a/3001-4000/LIT3188Liton.xml
+++ b/3001-4000/LIT3188Liton.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
-schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng" 
+<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" type="work" xml:lang="en" xml:id="LIT3188Liton">
    <teiHeader xml:base="https://betamasaheft.eu/">
@@ -26,7 +26,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <sourceDesc>
             <p>Work of the literatures of Ethiopia and Eritrea</p>
          </sourceDesc>
-         
+
       </fileDesc>
       <encodingDesc>
          <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
@@ -38,16 +38,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <profileDesc>
          <abstract>
             <p>General record for a not further identifiable collection of litanies.</p>
-            <ab>Specific litanies that can be in the collection are e.g. <ref type="work" corresp="LIT1806Litonz"/>, <ref type="work" corresp="LIT1808Litonz"/>, <ref type="work" corresp="LIT4713Liton"/>, 
-               <ref type="work" corresp="LIT3571Litonz"/>, the litanies of the week in <ref type="work" corresp="LIT4860Litanies"/>, including 
-               <ref type="work" corresp="LIT1807Litonz"/>, 
-               <ref type="work" corresp="LIT4858Litany"/>, 
-               <ref type="work" corresp="LIT4266Litonz"/>, 
-               <ref type="work" corresp="LIT4264Salota"/>, 
-               <ref type="work" corresp="LIT4268Tazakkar"/>, 
+            <ab>Specific litanies that can be in the collection are e.g. <ref type="work" corresp="LIT1806Litonz"/>, <ref type="work" corresp="LIT1808Litonz"/>, <ref type="work" corresp="LIT4713Liton"/>,
+               <ref type="work" corresp="LIT3571Litonz"/>, the litanies of the week in <ref type="work" corresp="LIT4860Litanies"/>, including
+               <ref type="work" corresp="LIT1807Litonz"/>,
+               <ref type="work" corresp="LIT4858Litany"/>,
+               <ref type="work" corresp="LIT4266Litonz"/>,
+               <ref type="work" corresp="LIT4264Salota"/>,
+               <ref type="work" corresp="LIT4268Tazakkar"/>,
                <ref type="work" corresp="LIT4265Litonz"/>,
-               <ref type="work" corresp="LIT4859Litany"/>         
-            
+               <ref type="work" corresp="LIT4859Litany"/>,
+               <ref type="work" corresp="LIT7016Liton"/>.
             </ab>
          </abstract>
          <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
@@ -64,6 +64,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <change who="PL" when="2016-07-26">Created XML record from Ethio authority google spreadsheet</change>
          <change when="2017-03-09" who="MV">Added title, keywords and bibliography</change>
          <change when="2019-03-27" who="ES">Added abstract</change>
+        <change who="LB" when="2024-09-20">Added reference to LIT7016Liton</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -74,7 +75,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <ptr target="bm:Habtemichael2007EAELitanies"/>
                </bibl>
             </listBibl>
-            
+
          </div>
       </body>
    </text>

--- a/new/LIT7016Liton.xml
+++ b/new/LIT7016Liton.xml
@@ -90,7 +90,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 ምዕራፊነ፡ ኀበ፡ መርሐተነ፡ የማንከ፡ ቅድስት፡ በኢየሱስ፡ ክርስቶስ። ዘቦቱ፡ ለከ፡ ምስሌሁ፡ ወምስለ፡ ቅዱስ፡ መንፈስ፡ ስብሐት፡ ወእኂዝ፡ ወመለኮት፡ ወክብር፡ ይእዜኒ፡ ወዘልፈኒ፡
 ወለዓለመ፡ ዓለም፡ አሜን።
  </ab>
-          </div>    
+          </div>
             </div>
+        </body>
     </text>
 </TEI>

--- a/new/LIT7016Liton.xml
+++ b/new/LIT7016Liton.xml
@@ -90,6 +90,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 ምዕራፊነ፡ ኀበ፡ መርሐተነ፡ የማንከ፡ ቅድስት፡ በኢየሱስ፡ ክርስቶስ። ዘቦቱ፡ ለከ፡ ምስሌሁ፡ ወምስለ፡ ቅዱስ፡ መንፈስ፡ ስብሐት፡ ወእኂዝ፡ ወመለኮት፡ ወክብር፡ ይእዜኒ፡ ወዘልፈኒ፡
 ወለዓለመ፡ ዓለም፡ አሜን።
  </ab>
+          </div>    
             </div>
     </text>
 </TEI>

--- a/new/LIT7016Liton.xml
+++ b/new/LIT7016Liton.xml
@@ -26,7 +26,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <p/>
+              <listWit>
+                  <witness corresp="EMML2109"/>
+              </listWit>
             </sourceDesc>
         </fileDesc>
         <t:encodingDesc xmlns:t="http://www.tei-c.org/ns/1.0">
@@ -56,11 +58,38 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="LB" when="2024-06-16">Created entity</change>
+            <change who="LB" when="2024-09-20">Added text and bibliography relations</change>
         </revisionDesc>
     </teiHeader>
     <text>
-        <t:body xmlns:t="http://www.tei-c.org/ns/1.0">
-            <div type="bibliography"/><!---->
-        </t:body>
+      <body>
+          <div type="bibliography">
+              <listBibl type="secondary">
+                  <bibl><ptr target="bm:Bahr2023Litanies"/></bibl>
+                  <bibl><ptr target="bm:EMML6"/></bibl>
+              </listBibl>
+              <listRelation>
+                  <relation name="saws:formsPartOf" active="LIT7016Liton"
+                      passive="LIT4860Litanies"/>
+                  <relation name="saws:formsPartOf" active="LIT7016Liton"
+                      passive="LIT3188Liton"/>
+              </listRelation>
+          </div>
+        <div type="edition">
+            <note>The text follows <ref type="mss" corresp="EMML2109"/>, fols 87vb18–88va15, but the spelling has been normalised.</note>
+            <div type="textpart">
+                <ab>ሊጦን፡ ዘነግህ፡
+ወካዕበ፡ ናስተበቍዖ፡ ለእግዚአብሔር፡ አቡሁ፡ ለእግዚእነ፡ ወመድኀኒነ፡ ኢየሱስ፡ ክርስቶስ። ንስእለከ፡ ወናስተበቍዐከ፡ አምላክነ፡ እግዚአብሔር፡ ቅዱስ፡ ዘአንተ፡ በሰማይ፡ ወአንተ፡
+በምድር፡ ንስእለከ፡ ወናስተበቍዐከ፡ አቡነ፡ ዘበሰማያት፡ ንጕየይ፡ ወንትመሐፀን፡ ኀቤከ፡ እግዚኦ፡ አንቃዕዶነ፡ ኀቤከ፡ ኢየሱስ፡ ክርስቶስ፡ መራሔ፡ ጽድቅ፡ ወሰላም፡ አንተ፡ አምላክነ፡
+ዘኢትጠፍእ፡ እግዚአብሔር፡ አምላክነ።
+ጸልዩ።
+እወ፡ እግዚኦ፡ አምላክነ፡ መሐረነ፡ ወተሣሀለነ፡ ክድነነ፡ ከመ፡ ዖፍ፡ በጽላሎተ፡ ክነፊከ፡ ከመ፡ ዖፍ፡ እንተ፡ ትከድን፡ እጐሊሃ። አንተ፡ ምስካይነ፡ አእትት፡ አንብዐ፡ እምአዕይንቲነ፡
+ንስግድ፡ ቅድሜከ፡ አርሕቅ፡ ዐውያተ፡ እምአልባቢነ። ንጸርኅ፡ ኀቤከ፡ አሰስል፡ እምላዕሌነ፡ ሕማማተ፡ እንተ፡ ናነክር። ወትብጽሐነ፡ ሣህልከ፡ ወምሕረትከ፡ ወመድኀኒትከ፡ እስመ፡
+መስተዐግሥ፡ አንተ፡ እግዚኦ፡ ወትትዔገሰነ፡ ወትጸውር፡ ለነ፡ ኵሎ፡ ክበደ፡ ኀጢአተነ፡ ወትትመየጠነ፡ ዐይነከ፡ እንተ፡ ምስለ፡ ምሕረት። ወሕሊናከ፡ እንተ፡ ምስለ፡ ሣህል፡ ወየማንከ፡
+እንተ፡ ይእቲ፡ አክሊለ፡ መድኀኒትነ። ወአድኀነነ፡ በከመ፡  አድኀንከ፡ ነነዌ፡ ወኢትዕፅዋ፡ በኵሉ፡ ለነፍስየ። ወንፈኑ፡ ለስምከ፡ ስብሐተ፡ በንጹሕ፡ ልብ፡ ሶበ፡ ነአቱ፡ ውስተ፡
+ምዕራፊነ፡ ኀበ፡ መርሐተነ፡ የማንከ፡ ቅድስት፡ በኢየሱስ፡ ክርስቶስ። ዘቦቱ፡ ለከ፡ ምስሌሁ፡ ወምስለ፡ ቅዱስ፡ መንፈስ፡ ስብሐት፡ ወእኂዝ፡ ወመለኮት፡ ወክብር፡ ይእዜኒ፡ ወዘልፈኒ፡
+ወለዓለመ፡ ዓለም፡ አሜን።
+ </ab>
+            </div>
     </text>
 </TEI>


### PR DESCRIPTION
Hello everyone.

My little project in updating all files with litanies to ensure uniformity and coherence once more faces a new step: 

Since the ID "CAe 7016" has been created a few months ago for a newly discovered litany based on its attestation in EMML 2109 in another issue (see https://github.com/BetaMasaheft/Documentation/issues/2561 and https://betamasaheft.eu/LIT7016Liton), I have now filled that tei/xml file with content like text, literature, and relations. I have also added the prayer to the General record of litanies (see https://betamasaheft.eu/LIT3188Liton). These are the two files which have been changed this time. Last time, the prayer was already added to the record for the seven weekdays (see https://betamasaheft.eu/LIT4860Litanies).

I would be grateful if you could have a look, approve and merge it.

Kind regards

Leo