### PR TITLE
2024 09 27 jk qene effo

### DIFF
--- a/new/LIT7078QeneEffo.xml
+++ b/new/LIT7078QeneEffo.xml
@@ -1,0 +1,61 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7078QeneEffo" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">ʾƎffo ʾayhud ʾazmāda ʾəmməka tadabtarā masqal takalu ba-ʾawda matkaftəka selo ()</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="JK"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Poetry"/>
+                    <term key="Qene"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="JK" when="2024-09-27">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT7078QeneEffo" passive=""/>
+                    <relation name="saws:isAttributedToAuthor" active="LIT7078QeneEffo" passive=""/>
+                </listRelation>
+            </div><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7078QeneEffo.xml
+++ b/new/LIT7078QeneEffo.xml
@@ -5,7 +5,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">ʾƎffo ʾayhud ʾazmāda ʾəmməka tadabtarā masqal takalu ba-ʾawda matkaftəka selo ()</title>
+                <title xml:lang="gez" xml:id="t1">እፎ፡ አይሁድ፡ አዝማደ፡ እምከ፡ ተደብተራ፡ መስቀል፡ ተከሉ፡ በአውደ፡ መትከፍትከ፡ ሴሎ።</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎffo ʾayhud ʾazmāda ʾəmməka dabtarā masqal takalu ba-ʾawda matkaftəka selo (Qǝne of the mawaddəs-type)</title>
+                <title xml:lang="en" corresp="#t1">How (could) the Jews, the relatives of your mother, the Tabernacle, plant the Cross in the courtyard of your shoulders, Selo…</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT7078QeneEffo.xml
+++ b/new/LIT7078QeneEffo.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">እፎ፡ አይሁድ፡ አዝማደ፡ እምከ፡ ተደብተራ፡ መስቀል፡ ተከሉ፡ በአውደ፡ መትከፍትከ፡ ሴሎ።</title>
+                <title xml:lang="gez" xml:id="t1">እፎ፡ አይሁድ፡ አዝማደ፡ እምከ፡ <surplus resp="JK">ተ</surplus>ደብተራ፡ መስቀል፡ ተከሉ፡ በአውደ፡ መትከፍትከ፡ ሴሎ።</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎffo ʾayhud ʾazmāda ʾəmməka dabtarā masqal takalu ba-ʾawda matkaftəka selo (Qǝne of the mawaddəs-type)</title>
                 <title xml:lang="en" corresp="#t1">How (could) the Jews, the relatives of your mother, the Tabernacle, plant the Cross in the courtyard of your shoulders, Selo…</title>
                 <editor role="generalEditor" key="AB"/>
@@ -23,7 +23,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <p/>
+                <listWit>
+                    <witness corresp="UppQ1524o"/>
+                </listWit>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -32,7 +34,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p/>
+                <p><foreign xml:lang="gez">Mawaddəs</foreign>-type <foreign xml:lang="gez">qǝne</foreign> 
+                    attributed to <persName ref="PRS14574GabraLeul" cert="high" corresp="SD">Gabra Ləʿul</persName> 
+                    in the manuscript.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -54,10 +58,27 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <div type="bibliography">
                 <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT7078QeneEffo" passive=""/>
-                    <relation name="saws:isAttributedToAuthor" active="LIT7078QeneEffo" passive=""/>
+                    <relation name="lawd:hasAttestation" active="LIT7078QeneEffo" passive="UppQ1524o"/>
+                    <relation name="saws:isAttributedToAuthor" active="LIT7078QeneEffo" passive="PRS14574GabraLeul"/>
                 </listRelation>
-            </div><!---->
+            </div>
+            <div type="edition" xml:lang="gez">
+                <note>This edition is based on <ref type="mss" corresp="UppQ1524o"/> on fol. 43r
+                    (note that the same <foreign xml:lang="gez">qǝne</foreign> is also attested on fols 30r, 31r. 
+                    Division into verses is indicated with ። .
+                    The end of the poem is indicated with ።። .</note>
+                <ab>
+                    <l n="1">እፎ፡ አይሁድ፡ አዝማደ፡ እምከ፡ <surplus resp="JK">ተ</surplus>ደብተራ፡ መስቀል፡ ተከሉ፡ 
+                        በአውደ፡ መትከፍትከ፡ ሴሎ።</l>
+                    <l n="2">እመቦ፡ <add place="above">በ</add>ርባን፡ ዘይደልዎ፡ ተሰቅሎ።</l>
+                    <l n="3">ወአመተ፡ ጽዮን፡ በጽዮን፡ ነዊሃ፡ ተሰምዮ፡ በኵረ፡ ጽዮን፡ ሐሎ።</l>
+                    <l n="4">ኦዘታሌእሎ፡ ለማይ፡ በክንፈ፡ ደመና፡ ወለደመና፡ በክንፈ፡ አውሎ።</l>
+                    <l n="5">ባሕቱ፡ እመርኢነ፡ ወእመሰማእነ፡ ኵሎ።</l>
+                    <l n="6">ለዘመድ፡ እንበለ፡ ዘመደ፡ አልቦ፡ ዘይቀትሎ።</l>
+                    <l n="7">አቤልሂ፡ ለቃየል፡ እንዘ፡ ወልደ፡ እምየ፡ ይብሎ።</l>
+                    <l n="8">ቃየል፡ ወልደ፡ እሙ፡ ለአቤል፡ ተቀበሎ።።</l>
+                </ab>
+            </div>
         </body>
     </text>
 </TEI>

--- a/new/LIT7078QeneEffo.xml
+++ b/new/LIT7078QeneEffo.xml
@@ -6,8 +6,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">እፎ፡ አይሁድ፡ አዝማደ፡ እምከ፡ <surplus resp="JK">ተ</surplus>ደብተራ፡ መስቀል፡ ተከሉ፡ በአውደ፡ መትከፍትከ፡ ሴሎ።</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎffo ʾayhud ʾazmāda ʾəmməka dabtarā masqal takalu ba-ʾawda matkaftəka selo (Qǝne of the mawaddəs-type)</title>
-                <title xml:lang="en" corresp="#t1">How (could) the Jews, the relatives of your mother, the Tabernacle, plant the Cross in the courtyard of your shoulders, Selo…</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎffo ʾayhud ʾazmāda ʾəmməka dabtarā masqal takalu ba-ʾawda matkaftəka Selo (Qǝne of the mawaddəs-type)</title>
+                <title xml:lang="en" corresp="#t1">How (could) the Jews, the relatives of your mother, the Tabernacle, plant the Cross around your shoulders, Selo…</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -70,7 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     Division into verses is indicated with ። .
                     The end of the poem is indicated with ።። .</note>
                 <ab>
-                    <l n="1">እፎ፡ አይሁድ፡ አዝማደ፡ እምከ፡ <surplus resp="JK">ተ</surplus>ደብተራ፡ መስቀል፡ ተከሉ፡ 
+                    <l n="1">እፎ፡ አይሁድ፡ አዝማደ፡ እምከ፡ <del rend="strikethrough"><surplus resp="JK">ተ</surplus></del>ደብተራ፡ መስቀል፡ ተከሉ፡ 
                         በአውደ፡ መትከፍትከ፡ ሴሎ።</l>
                     <l n="2">እመቦ፡ <add place="above">በ</add>ርባን፡ ዘይደልዎ፡ ተሰቅሎ።</l>
                     <l n="3">ወአመተ፡ ጽዮን፡ በጽዮን፡ ነዊሃ፡ ተሰምዮ፡ በኵረ፡ ጽዮን፡ ሐሎ።</l>

--- a/new/LIT7078QeneEffo.xml
+++ b/new/LIT7078QeneEffo.xml
@@ -24,7 +24,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </publicationStmt>
             <sourceDesc>
                 <listWit>
-                    <witness corresp="UppQ1524o"/>
+                    <witness corresp="UppQ1524o">Uppsala, Q 1524o, fols 30r, 31r</witness>
+                    <witness corresp="UppQ1524o">Uppsala, Q 1524o, fol. 43</witness>
                 </listWit>
             </sourceDesc>
         </fileDesc>
@@ -43,6 +44,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
+                    <term key="Mawaddes"/>
                 </keywords>
             </textClass>
             <langUsage>


### PR DESCRIPTION
Another qene from the Uppsala collection. This is interesting, because it has two attestations in the manuscript: once on a loose leaf and once in the hand of the main scribe (= Kolmodin?). I follow the readings of the loose leaf: https://www.alvin-portal.org/alvin/imageViewer.jsf?dsId=ATTACHMENT-0457&pid=alvin-record:280997

There is a word in the first line that I can't make out, so ideas would be appreciated!