### PR TITLE
Create LIT7103PrayOTprophets

### DIFF
--- a/new/LIT7103PrayOTprophets.xml
+++ b/new/LIT7103PrayOTprophets.xml
@@ -1,0 +1,112 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7103PrayOTprophets" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Collection of prayers of the prophets of the Old Testament (ወሶበ፡ ጸርሐ፡ ስመከ፡ ...)</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <listWit>
+                    <witness corresp="BLorient12859"/>
+                    <witness corresp="BNFabb107"/>
+                    <witness corresp="BNFabb270"/>
+                    <witness corresp="BNFeth320"/>
+                </listWit>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Collection of prayers of the prophets of the Old Testament, each of which are introduced with 
+                    <foreign xml:lang="gez">ወሶበ፡ ጸርሐ፡</foreign> (engl. "When he cried") or 
+                    <foreign xml:lang="gez">ወሶበ፡ ጸርሑ፡</foreign> (engl. "When they cried") and is often continued with 
+                    <foreign xml:lang="gez">ስመከ፡</foreign> (engl. "your name"), possibly related to 
+                    <ref type="work" corresp="LIT1828Mahale"/>, <ref type="work" corresp="LIT2277salotu"/>,
+                    <ref type="work" corresp="LIT2265salota"/> or <ref type="work" corresp="LIT2250salota"/>.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianContent"/>
+                    <term key="OldTestament"/>
+                    <term key="Prayers"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-10-15">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <bibl><ptr target="bm:Strelcyn1949PriereFalacha"/><citedRange unit="page">64-75</citedRange></bibl>
+            </div>
+            <div type="edition">
+                <note>Incipits and order of the prayers are taken from <ref type="mss" corresp="BLorient12859"/></note> 
+                <div type="textpart" xml:id="Moses">
+                    <label>Prayer attributed to Moses</label>
+                    <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ሙሴ፡ ገበርከ፡ እንዘ፡ ይብል፡ ጋዲን፡ ፈሊዖ፡ <gap reason="ellipsis"/></q>
+                </div>
+                <div type="textpart" xml:id="Joshua">
+                    <label>Prayer attributed to Joshua</label>
+                    <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ኢያሱ፡ ወልደ፡ ነዌ፡ ውስተ፡ ሀገረ፡ ገባዖን፡ እንዘ፡ ይብል፡ ደርታን፡</q>
+                </div>
+                <div type="textpart" xml:id="Elijah">
+                    <label>Prayer attributed to Elijah</label>
+                    <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ኤልያስ፡ ስመከ፡ እንዘ፡ ይብል፡ አቅርያኖስ፡</q>
+                </div>
+                <div type="textpart" xml:id="Daniel">
+                    <label>Prayer attributed to Daniel</label>
+                    <q xml:lang="gez">ወሶበ፡ <supplied reason="omitted" resp="PRS8999Strelcyn">ጸርሐ፡ </supplied>ዳንኤል፡ ስመከ፡ እንዘ፡ ይብል፡ 
+                        ዝራኤል፡</q>
+                </div>
+                <div type="textpart" xml:id="Manasseh">
+                    <label>Prayer attributed to Manasseh</label>
+                    <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ምናሴ፡ ስመከ፡ እንዘ፡ ይብል፡ ቀለኤል፡</q>
+                </div>
+                <div type="textpart" xml:id="ThreeChildren">
+                    <label>Prayer attributed to the Three Holy Children in the Furnace (ʾĀnānyā, ʾĀzāryā and Misāʾel)</label>
+                    <q xml:lang="gez">ወሶበ፡ ጸርሑ፡ አናንያ፡ ወአዛርያ፡ ወሚሳኤል፡ እንዘ፡ ይብሉ፡ ዳፋኤል፡</q>
+                </div>
+                <div type="textpart" xml:id="David">
+                    <label>Prayer attributed to David</label>
+                    <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ስመከ፡ ዳዊት፡ እንዘ፡ ይብል፡ በለማዊፒሲል፡</q>
+                </div>
+                <div type="textpart" xml:id="Ezekiel">
+                    <label>Prayer attributed to Ezekiel</label>
+                    <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ሕዝቅያስ፡ ስመከ፡ እንዘ፡ ይብል፡ ወገላውዮስ፡</q>
+                </div>
+                <div type="textpart" xml:id="Jonah">
+                    <label>Prayer attributed to Jonah</label>
+                    <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ስመከ፡ <sic>ዳዊት፡</sic> ዮናስ፡ እንዘ፡ ይብል፡ ዳላዊ፡</q>
+                </div>
+                <div type="textpart" xml:id="Jeremiah">
+                    <label>Prayer attributed to Jeremiah</label>
+                    <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ኤርምያስ፡ ስመከ፡ እንዘ፡ ይብል፡ <gap reason="ellipsis"/> ገደላፊል፡</q>
+                </div>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7103PrayOTprophets.xml
+++ b/new/LIT7103PrayOTprophets.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">Collection of prayers of the prophets of the Old Testament (ወሶበ፡ ጸርሐ፡ ስመከ፡ ...)</title>
+                <title xml:lang="en" xml:id="t1">Collection of prayers of the prophets of the Old Testament (ወሶበ፡ ጸርሐ፡ ስመከ፡ ...)</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -39,14 +39,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <foreign xml:lang="gez">ወሶበ፡ ጸርሐ፡</foreign> (engl. "When he cried") or 
                     <foreign xml:lang="gez">ወሶበ፡ ጸርሑ፡</foreign> (engl. "When they cried") and is often continued with 
                     <foreign xml:lang="gez">ስመከ፡</foreign> (engl. "your name"), possibly related to 
-                    <ref type="work" corresp="LIT1828Mahale"/>, <ref type="work" corresp="LIT2277salotu"/>,
-                    <ref type="work" corresp="LIT2265salota"/> or <ref type="work" corresp="LIT2250salota"/>.</p>
+                    <ref type="work" corresp="LIT1828Mahale"/>.</p>
             </abstract>
             <textClass>
                 <keywords>
                     <term key="ChristianContent"/>
                     <term key="OldTestament"/>
                     <term key="Prayers"/>
+                    <term key="BetaEsraelLiterature"/>
+                    <term key="ChristianLiterature"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -63,47 +64,85 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <div type="bibliography">
                 <bibl><ptr target="bm:Strelcyn1949PriereFalacha"/><citedRange unit="page">64-75</citedRange></bibl>
             </div>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive="LIT1828Mahale"><desc>The entire collection
+                        is possibly related to <ref type="work" corresp="LIT1828Mahale"/> and the single prayers may be related to, or renarrations of, 
+                        the songs of the prophets otherwise contained in <ref type="work" corresp="LIT1828Mahale"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2277salotu"><desc>The prayer attributed
+                        to Moses is possibly related to <ref type="work" corresp=" LIT2277salotu"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2278salota"><desc>The prayer attributed
+                        to Moses is possibly related to <ref type="work" corresp=" LIT2278salota"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2703salota"><desc>The prayer attributed
+                        to Moses is possibly related to <ref type="work" corresp=" LIT2703salota"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2250salota"><desc>The prayer attributed
+                        to the Three Children in the furnace is possibly related to <ref type="work" corresp=" LIT2250salota"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2271salota"><desc>The prayer attributed
+                        to the Three Children in the furnace is possibly related to <ref type="work" corresp=" LIT2271salota"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT1566hababa"><desc>The prayer attributed
+                        to the Three Children in the furnace is possibly related to <ref type="work" corresp=" LIT1566hababa"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2265salota"><desc>The prayer attributed
+                        to Manasseh is possibly related to <ref type="work" corresp=" LIT2265salota"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2258salota"><desc>The prayer attributed
+                        to Hezekiah is possibly related to <ref type="work" corresp=" LIT2258salota"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT1753Lament"><desc>The prayer attributed
+                        to Jeremiah is possibly related to <ref type="work" corresp=" LIT1753Lament"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2274salota"><desc>The prayer attributed
+                        to Jonah is possibly related to <ref type="work" corresp=" LIT2274salota"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2250salota"><desc>The prayer attributed
+                        to Daniel is possibly related to <ref type="work" corresp=" LIT2250salota"/>.</desc></relation>
+                </listRelation>
+            </div>
             <div type="edition">
                 <note>Incipits and order of the prayers are taken from <ref type="mss" corresp="BLorient12859"/></note> 
                 <div type="textpart" xml:id="Moses">
-                    <label>Prayer attributed to Moses</label>
+                    <label>Prayer of Moses</label>
+                    <note>Possibly related to <ref type="work" corresp=" LIT2277salotu"/>, <ref type="work" corresp=" LIT2278salota"/> or
+                        <ref type="work" corresp=" LIT2703salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ሙሴ፡ ገበርከ፡ እንዘ፡ ይብል፡ ጋዲን፡ ፈሊዖ፡ <gap reason="ellipsis"/></q>
                 </div>
                 <div type="textpart" xml:id="Joshua">
-                    <label>Prayer attributed to Joshua</label>
+                    <label>Prayer of Joshua</label>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ኢያሱ፡ ወልደ፡ ነዌ፡ ውስተ፡ ሀገረ፡ ገባዖን፡ እንዘ፡ ይብል፡ ደርታን፡</q>
                 </div>
                 <div type="textpart" xml:id="Elijah">
-                    <label>Prayer attributed to Elijah</label>
+                    <label>Prayer of Elijah</label>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ኤልያስ፡ ስመከ፡ እንዘ፡ ይብል፡ አቅርያኖስ፡</q>
                 </div>
                 <div type="textpart" xml:id="Daniel">
-                    <label>Prayer attributed to Daniel</label>
+                    <label>Prayer of Daniel</label>
+                    <note>Possibly related to <ref type="work" corresp="LIT2250salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ <supplied reason="omitted" resp="PRS8999Strelcyn">ጸርሐ፡ </supplied>ዳንኤል፡ ስመከ፡ እንዘ፡ ይብል፡ 
                         ዝራኤል፡</q>
                 </div>
                 <div type="textpart" xml:id="Manasseh">
-                    <label>Prayer attributed to Manasseh</label>
+                    <label>Prayer of Manasseh</label>
+                    <note>Possibly related to <ref type="work" corresp="LIT2265salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ምናሴ፡ ስመከ፡ እንዘ፡ ይብል፡ ቀለኤል፡</q>
                 </div>
                 <div type="textpart" xml:id="ThreeChildren">
-                    <label>Prayer attributed to the Three Holy Children in the Furnace (ʾĀnānyā, ʾĀzāryā and Misāʾel)</label>
+                    <label>Prayer of the Three Holy Children in the Furnace (ʾĀnānyā, ʾĀzāryā and Misāʾel)</label>
+                    <note>Possibly related to <ref type="work" corresp="LIT2250salota"/>, <ref type="work" corresp="LIT2271salota"/> or
+                        <ref type="work" corresp="LIT1566hababa"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሑ፡ አናንያ፡ ወአዛርያ፡ ወሚሳኤል፡ እንዘ፡ ይብሉ፡ ዳፋኤል፡</q>
                 </div>
                 <div type="textpart" xml:id="David">
-                    <label>Prayer attributed to David</label>
+                    <label>Prayer of David</label>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ስመከ፡ ዳዊት፡ እንዘ፡ ይብል፡ በለማዊፒሲል፡</q>
                 </div>
-                <div type="textpart" xml:id="Ezekiel">
-                    <label>Prayer attributed to Ezekiel</label>
+                <div type="textpart" xml:id="Hezekiah">
+                    <label>Prayer of Hezekiah</label>
+                    <note>Possibly related to <ref type="work" corresp="LIT2258salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ሕዝቅያስ፡ ስመከ፡ እንዘ፡ ይብል፡ ወገላውዮስ፡</q>
                 </div>
                 <div type="textpart" xml:id="Jonah">
-                    <label>Prayer attributed to Jonah</label>
+                    <label>Prayer of Jonah</label>
+                    <note>Possibly related to <ref type="work" corresp="LIT2274salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ስመከ፡ <sic>ዳዊት፡</sic> ዮናስ፡ እንዘ፡ ይብል፡ ዳላዊ፡</q>
                 </div>
                 <div type="textpart" xml:id="Jeremiah">
-                    <label>Prayer attributed to Jeremiah</label>
+                    <label>Prayer of Jeremiah</label>
+                    <note>Possibly an extract from <ref type="work" corresp="LIT1753Lament"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ኤርምያስ፡ ስመከ፡ እንዘ፡ ይብል፡ <gap reason="ellipsis"/> ገደላፊል፡</q>
                 </div>
             </div>

--- a/new/LIT7103PrayOTprophets.xml
+++ b/new/LIT7103PrayOTprophets.xml
@@ -36,9 +36,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <creation/>
             <abstract>
                 <p>Collection of prayers of the prophets of the Old Testament, each of which are introduced with 
-                    <foreign xml:lang="gez">ወሶበ፡ ጸርሐ፡</foreign> (engl. "When he cried") or 
-                    <foreign xml:lang="gez">ወሶበ፡ ጸርሑ፡</foreign> (engl. "When they cried") and is often continued with 
-                    <foreign xml:lang="gez">ስመከ፡</foreign> (engl. "your name"), possibly related to 
+                    <foreign xml:lang="gez">ወሶበ፡ ጸርሐ፡</foreign> "When he cried" or 
+                    <foreign xml:lang="gez">ወሶበ፡ ጸርሑ፡</foreign> "When they cried" and is often continued with 
+                    <foreign xml:lang="gez">ስመከ፡</foreign> "your name", possibly related to 
                     <ref type="work" corresp="LIT1828Mahale"/>.</p>
             </abstract>
             <textClass>
@@ -66,39 +66,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </div>
             <div type="bibliography">
                 <listRelation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive="LIT1828Mahale"><desc>The entire collection
-                        is possibly related to <ref type="work" corresp="LIT1828Mahale"/> and the single prayers may be related to, or renarrations of, 
+                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive="LIT1828Mahale"><desc>Possibly related to 
+                        <ref type="work" corresp="LIT1828Mahale"/> and the single prayers may be related to, or renarrations of, 
                         the songs of the prophets otherwise contained in <ref type="work" corresp="LIT1828Mahale"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2277salotu"><desc>The prayer attributed
-                        to Moses is possibly related to <ref type="work" corresp=" LIT2277salotu"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2278salota"><desc>The prayer attributed
-                        to Moses is possibly related to <ref type="work" corresp=" LIT2278salota"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2703salota"><desc>The prayer attributed
-                        to Moses is possibly related to <ref type="work" corresp=" LIT2703salota"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2250salota"><desc>The prayer attributed
-                        to the Three Children in the furnace is possibly related to <ref type="work" corresp=" LIT2250salota"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2271salota"><desc>The prayer attributed
-                        to the Three Children in the furnace is possibly related to <ref type="work" corresp=" LIT2271salota"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT1566hababa"><desc>The prayer attributed
-                        to the Three Children in the furnace is possibly related to <ref type="work" corresp=" LIT1566hababa"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2265salota"><desc>The prayer attributed
-                        to Manasseh is possibly related to <ref type="work" corresp=" LIT2265salota"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2258salota"><desc>The prayer attributed
-                        to Hezekiah is possibly related to <ref type="work" corresp=" LIT2258salota"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT1753Lament"><desc>The prayer attributed
-                        to Jeremiah is possibly related to <ref type="work" corresp=" LIT1753Lament"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2274salota"><desc>The prayer attributed
-                        to Jonah is possibly related to <ref type="work" corresp=" LIT2274salota"/>.</desc></relation>
-                    <relation name="dc:relation" active="LIT7103PrayOTprophets" passive=" LIT2250salota"><desc>The prayer attributed
-                        to Daniel is possibly related to <ref type="work" corresp=" LIT2250salota"/>.</desc></relation>
                 </listRelation>
             </div>
             <div type="edition">
                 <note>Incipits and order of the prayers are taken from <ref type="mss" corresp="BLorient12859"/></note> 
                 <div type="textpart" xml:id="Moses">
                     <label>Prayer of Moses</label>
-                    <note>Possibly related to <ref type="work" corresp=" LIT2277salotu"/>, <ref type="work" corresp=" LIT2278salota"/> or
-                        <ref type="work" corresp=" LIT2703salota"/>.</note>
+                    <note>Thematically related to <ref type="work" corresp=" LIT2277salotu"/>, <ref type="work" corresp=" LIT2278salota"/> 
+                        and <ref type="work" corresp=" LIT2703salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ሙሴ፡ ገበርከ፡ እንዘ፡ ይብል፡ ጋዲን፡ ፈሊዖ፡ <gap reason="ellipsis"/></q>
                 </div>
                 <div type="textpart" xml:id="Joshua">
@@ -111,18 +89,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </div>
                 <div type="textpart" xml:id="Daniel">
                     <label>Prayer of Daniel</label>
-                    <note>Possibly related to <ref type="work" corresp="LIT2250salota"/>.</note>
+                    <note>Thematically possibly related to <ref type="work" corresp="LIT2250salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ <supplied reason="omitted" resp="PRS8999Strelcyn">ጸርሐ፡ </supplied>ዳንኤል፡ ስመከ፡ እንዘ፡ ይብል፡ 
                         ዝራኤል፡</q>
                 </div>
                 <div type="textpart" xml:id="Manasseh">
                     <label>Prayer of Manasseh</label>
-                    <note>Possibly related to <ref type="work" corresp="LIT2265salota"/>.</note>
+                    <note>Thematically possibly related to <ref type="work" corresp="LIT2265salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ምናሴ፡ ስመከ፡ እንዘ፡ ይብል፡ ቀለኤል፡</q>
                 </div>
                 <div type="textpart" xml:id="ThreeChildren">
                     <label>Prayer of the Three Holy Children in the Furnace (ʾĀnānyā, ʾĀzāryā and Misāʾel)</label>
-                    <note>Possibly related to <ref type="work" corresp="LIT2250salota"/>, <ref type="work" corresp="LIT2271salota"/> or
+                    <note>Thematically possibly related to <ref type="work" corresp="LIT2250salota"/>, <ref type="work" corresp="LIT2271salota"/> or
                         <ref type="work" corresp="LIT1566hababa"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሑ፡ አናንያ፡ ወአዛርያ፡ ወሚሳኤል፡ እንዘ፡ ይብሉ፡ ዳፋኤል፡</q>
                 </div>
@@ -132,17 +110,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </div>
                 <div type="textpart" xml:id="Hezekiah">
                     <label>Prayer of Hezekiah</label>
-                    <note>Possibly related to <ref type="work" corresp="LIT2258salota"/>.</note>
+                    <note>Thematically possibly related to <ref type="work" corresp="LIT2258salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ሕዝቅያስ፡ ስመከ፡ እንዘ፡ ይብል፡ ወገላውዮስ፡</q>
                 </div>
                 <div type="textpart" xml:id="Jonah">
                     <label>Prayer of Jonah</label>
-                    <note>Possibly related to <ref type="work" corresp="LIT2274salota"/>.</note>
+                    <note>Thematically possibly related to <ref type="work" corresp="LIT2274salota"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ስመከ፡ <sic>ዳዊት፡</sic> ዮናስ፡ እንዘ፡ ይብል፡ ዳላዊ፡</q>
                 </div>
                 <div type="textpart" xml:id="Jeremiah">
                     <label>Prayer of Jeremiah</label>
-                    <note>Possibly an extract from <ref type="work" corresp="LIT1753Lament"/>.</note>
+                    <note>Thematically possibly related to <ref type="work" corresp="LIT1753Lament"/>.</note>
                     <q xml:lang="gez">ወሶበ፡ ጸርሐ፡ ኤርምያስ፡ ስመከ፡ እንዘ፡ ይብል፡ <gap reason="ellipsis"/> ገደላፊል፡</q>
                 </div>
             </div>


### PR DESCRIPTION
I created a provisional record for LIT7103PrayOTprophet according to our discussion in https://github.com/BetaMasaheft/Documentation/issues/2647.

According to my investigation, the BnF manuscripts in the listWit do not have any records so far. If I am not mistaken and if they are not processed in any pull requests at the moment, I want to create stubs for them.