### PR TITLE
2024 10 14 jk qene amharic

### DIFF
--- a/new/LIT7101QeneAmh.xml
+++ b/new/LIT7101QeneAmh.xml
@@ -73,12 +73,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="1"><choice><sic>ኢ</sic><corr resp="HSM">እየ</corr></choice>ደ<choice><sic>ርስበ</sic><corr resp="HSM">ረስበ</corr></choice>ኝ፡ 
                         ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ 
                         <choice><sic>ኢ</sic><corr resp="HSM">እ</corr></choice>ያሉ፡ አዝማሪ፤</l>
-                    <l n="2">እስኪ፡ <sic resp="JK">ያመዘከራት፡</sic> ነፍሴት፡ የጌታ፡ ወቀሰ፡ ወራሪ፤</l>
-                    <l n="3">ወዘማዊትተ፡ ሕግ፡ ልቡናዬ፡ ይሻልሽ፡ ነበሬ፡ ጌታሽን፡ ብትፈሪ፤</l><pb n="46r"/>
+                    
+                    <l n="2">እስኪ፡ <sic resp="JK">ያመዘከራት፡</sic> 
+                        ነፍሴ<choice><sic>ት</sic><corr resp="HSM">ን</corr></choice>፡ የጌታ፡ 
+                        ወ<choice><sic>ቀሰ</sic><corr resp="HSM">ቃሽ</corr></choice>፡ ወራሪ፤</l>
+                    
+                    <l n="3">ወዘማዊ<choice><sic>ት</sic><corr>ተ</corr></choice>፡ ሕ<choice><sic>ግ</sic><corr resp="HSM">ገ</corr></choice>፡ ልቡናዬ፡ ይሻልሽ፡ 
+                        ነበ<choice><sic>ሬ</sic><corr resp="HSM">ረ</corr></choice>፡ ጌታሽን፡ ብትፈሪ፤</l><pb n="46r"/>
+                    
                     <l n="4">የቁጣ፡ ፊቱን፡ ባነሳ፡ ጊዜ፡ የለውምና፡ ምንምን፡ ወደርሱ፡ ቀርቦ፡ መካሪ፤</l>
-                    <l n="5">አንዶበትሂ፡ ነገረ፡ ጽድቅ፡ ተዪ፡ ተናገሪ፤</l>
-                    <l n="6">እንግዳ፡ ህማም፡ ብመጣ፡ ጊዜ፡ በሰንሰለት፡ ሞት፡ ሳትታስሪ፤</l>
-                    <l n="7">አያድንምና፡ ወንድም፡ ጋሻ፡ ጣር፡ ይዘ፡ ፊፈካሪ፤</l>
+                    
+                    <l n="5">አን<choice><sic>ዶ</sic><corr resp="HSM">ደ</corr></choice>በትሂ፡ ነገረ፡ ጽድቅ፡ ተዪ፡ ተናገሪ፤</l>
+                    
+                    <l n="6">እንግዳ፡ ህማም፡ <choice><sic>ብ</sic><corr resp="HSM">በ</corr></choice>መጣ፡ ጊዜ፡ በሰንሰለት፡ ሞት፡ 
+                        ሳትታዶ<choice><sic>ስ</sic><corr resp="HSM">ሰ</corr></choice>ሪ፤</l>
+                    
+                    <l n="7">አያድንምና፡ ወንድም፡ ጋሻ፡ <choice><sic>ጣ</sic><corr resp="HSM">ጦ</corr></choice>ር፡ 
+                        <choice><sic>ይ</sic><corr resp="HSM">የያ</corr></choice>ዘ፡ 
+                        <choice><sic>ፊ</sic><corr>ፈ</corr></choice>ካሪ፤</l>
+                    
                     <l n="8">በትር፡ ወንጌሉን፡ ባነሳ፡ ጊዜ፡ ኃይለኛ፡ ቃሉ፡ ፈጣሪ።</l>
                 </ab>
             </div>

--- a/new/LIT7101QeneAmh.xml
+++ b/new/LIT7101QeneAmh.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="am" xml:id="t1">እየደረስብኝ፡ ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ እያሉ፡ አዝማሪ፤</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎyyadarrasabbəññ naw ba-sane farasaññāw mot (Qǝne possibly of the mawaddǝs-type)</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎyyadarrasabbəññ naw ba-sane farasaññāw mot (Amharic "qǝne-style" poem)</title>
                 <title xml:lang="en" corresp="#t1">The galloping death is reaching me in Sane, without me having benefitted my soul. Oh my woes, say the people and the ʾazmāri…</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="JK"/>

--- a/new/LIT7101QeneAmh.xml
+++ b/new/LIT7101QeneAmh.xml
@@ -54,7 +54,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="JK" when="2024-10-14">Created entity with the help of Nafisa Valieva</change>
+            <change who="JK" when="2024-10-14">Created entity with the help of Hewan Semon Marye and Nafisa Valieva</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -70,8 +70,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     Division into verses is indicated with ፤ .
                     The end of the poem is indicated with ። .</note>
                 <ab>
-                    <l n="1">ኢደርስበኝ፡ ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ ኢያሉ፡ አዝማሪ፤</l>
-                    <l n="2">እስኪ፡ ያመዘከራት፡ ነፍሴት፡ የጌታ፡ ወቀሰ፡ ወራሪ፤</l>
+                    <l n="1"><choice><sic>ኢ</sic><corr resp="HSM">እየ</corr></choice>ደ<choice><sic>ርስበ</sic><corr resp="HSM">ረስበ</corr></choice>ኝ፡ 
+                        ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ 
+                        <choice><sic>ኢ</sic><corr resp="HSM">እ</corr></choice>ያሉ፡ አዝማሪ፤</l>
+                    <l n="2">እስኪ፡ <sic resp="JK">ያመዘከራት፡</sic> ነፍሴት፡ የጌታ፡ ወቀሰ፡ ወራሪ፤</l>
                     <l n="3">ወዘማዊትተ፡ ሕግ፡ ልቡናዬ፡ ይሻልሽ፡ ነበሬ፡ ጌታሽን፡ ብትፈሪ፤</l><pb n="46r"/>
                     <l n="4">የቁጣ፡ ፊቱን፡ ባነሳ፡ ጊዜ፡ የለውምና፡ ምንምን፡ ወደርሱ፡ ቀርቦ፡ መካሪ፤</l>
                     <l n="5">አንዶበትሂ፡ ነገረ፡ ጽድቅ፡ ተዪ፡ ተናገሪ፤</l>

--- a/new/LIT7101QeneAmh.xml
+++ b/new/LIT7101QeneAmh.xml
@@ -5,8 +5,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="am" xml:id="t1"></title>
-                <title xml:lang="gez" corresp="#t1" type="normalized"></title>
+                <title xml:lang="am" xml:id="t1">እየደረስብኝ፡ ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ እያሉ፡ አዝማሪ፤</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎyyadarasabbəññ naw ba-sane farasaññāw mot (Qǝne possibly of the mawaddǝs-type)</title>
                 <title xml:lang="en" corresp="#t1"></title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="JK"/>
@@ -70,7 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     Division into verses is indicated with ፤ .
                     The end of the poem is indicated with ። .</note>
                 <ab>
-                    <l n="1"><choice><sic>ኢ</sic><corr resp="HSM">እየ</corr></choice>ደ<choice><sic>ርስበ</sic><corr resp="HSM">ረስበ</corr></choice>ኝ፡ 
+                    <l n="1"><choice><sic>ኢ</sic><corr resp="HSM">እየ</corr></choice>ደ<choice><sic>ርስበ</sic><corr resp="HSM">ረሰብ</corr></choice>ኝ፡ 
                         ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ 
                         <choice><sic>ኢ</sic><corr resp="HSM">እ</corr></choice>ያሉ፡ አዝማሪ፤</l>
                     

--- a/new/LIT7101QeneAmh.xml
+++ b/new/LIT7101QeneAmh.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="am" xml:id="t1">እየደረስብኝ፡ ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ እያሉ፡ አዝማሪ፤</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎyyadarrasabbəññ naw ba-sane farasaññāw mot (Qǝne possibly of the mawaddǝs-type)</title>
-                <title xml:lang="en" corresp="#t1">The galloping death is reaching me in Sane, without me having benefitted my soul. Oh my woes, the ʾazmāri says…</title>
+                <title xml:lang="en" corresp="#t1">The galloping death is reaching me in Sane, without me having benefitted my soul. Oh my woes, say the people and the ʾazmāri…</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -34,11 +34,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
                 <abstract>
-                    <p>Amharic <foreign xml:lang="gez">qǝne</foreign> without type indication in the manuscript. It has eight lines, meaning
-                        that it can be classified as a <foreign xml:lang="gez">mawaddəs qəne</foreign> according to
+                    <p>Amharic "<foreign xml:lang="gez">qǝne</foreign>-style" poem without type indication in the manuscript.
+                        It has eight lines, meaning
+                        that it can be compared to the <foreign xml:lang="gez">mawaddəs qəne</foreign> according to
+                        the classification in
                         <bibl><ptr target="bm:Guidi1900Qene"/></bibl>.
-                        It is attributed to <persName ref="PRS14574GabraLeul" cert="high" corresp="SD">Gabra Ləʿul</persName> 
-                        in the manuscript.</p>
+                        In the manuscript, it is attributed to the <foreign xml:lang="gez">qǝne</foreign> collection 
+                        of <persName ref="PRS14574GabraLeul" cert="high" corresp="SD">Gabra Ləʿul</persName>.</p>
                 </abstract>
             <textClass>
                 <keywords>
@@ -62,7 +64,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <div type="bibliography">
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LIT7101QeneAmh" passive="UppQ1524o"/>
-                    <relation name="saws:isAttributedToAuthor" active="LIT7101QeneAmh" passive="PRS14574GabraLeul"/>
+                    <relation name="saws:isAttributedToAuthor" active="LIT7101QeneAmh" passive="PRS14574GabraLeul" cert="low"/>
                 </listRelation>
             </div>
             <div type="edition" xml:lang="am">
@@ -71,7 +73,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     The end of the poem is indicated with ። .</note>
                 <ab>
                     <l n="1"><choice><sic>ኢ</sic><corr resp="HSM">እየ</corr></choice>ደ<choice><sic>ርስበ</sic><corr resp="HSM">ረሰብ</corr></choice>ኝ፡ 
-                        ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ 
+                        ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ <sic resp="JK">ነፍሴት፡</sic> ሳልጠቅማት፡ ወየው፡ ሰዎች፡ 
                         <choice><sic>ኢ</sic><corr resp="HSM">እ</corr></choice>ያሉ፡ አዝማሪ፤</l>
                     
                     <l n="2">እስኪ፡ <sic resp="JK">ያመዘከራት፡</sic> 

--- a/new/LIT7101QeneAmh.xml
+++ b/new/LIT7101QeneAmh.xml
@@ -80,7 +80,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         ነፍሴ<choice><sic>ት</sic><corr resp="HSM">ን</corr></choice>፡ የጌታ፡ 
                         ወቀሰ፡ ወራሪ፤</l>
                     
-                    <l n="3">ወዘማዊ<choice><sic>ት</sic><corr>ተ</corr></choice>፡ ሕ<choice><sic>ግ</sic><corr resp="HSM">ገ</corr></choice>፡ ልቡናዬ፡ ይሻልሽ፡ 
+                    <l n="3">ወ<supplied reason="omitted" resp="JK">ይ</supplied>ዘማዊ<choice><sic>ት</sic><corr>ተ</corr></choice>፡ ሕግ፡ ልቡናዬ፡ ይሻልሽ፡ 
                         ነበ<choice><sic>ሬ</sic><corr resp="HSM">ረ</corr></choice>፡ ጌታሽን፡ ብትፈሪ፤</l><pb n="46r"/>
                     
                     <l n="4">የቁጣ፡ ፊቱን፡ ባነሳ፡ ጊዜ፡ የለውምና፡ ምንምን፡ ወደርሱ፡ ቀርቦ፡ መካሪ፤</l>

--- a/new/LIT7101QeneAmh.xml
+++ b/new/LIT7101QeneAmh.xml
@@ -1,0 +1,85 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7101QeneAmh" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="am" xml:id="t1"></title>
+                <title xml:lang="gez" corresp="#t1" type="normalized"></title>
+                <title xml:lang="en" corresp="#t1"></title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="JK"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <listWit>
+                    <witness corresp="UppQ1524o"/>
+                </listWit>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+                <abstract>
+                    <p>Amharic <foreign xml:lang="gez">qǝne</foreign> without type indication in the manuscript. It has eight lines, meaning
+                        that it can be classified as a <foreign xml:lang="gez">mawaddəs qəne</foreign> according to
+                        <bibl><ptr target="bm:Guidi1900Qene"/></bibl>.
+                        It is attributed to <persName ref="PRS14574GabraLeul" cert="high" corresp="SD">Gabra Ləʿul</persName> 
+                        in the manuscript.</p>
+                </abstract>
+            <textClass>
+                <keywords>
+                    <term key="AmharicLiterature"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Poetry"/>
+                    <term key="Qene"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="JK" when="2024-10-14">Created entity with the help of Nafisa Valieva</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT7101QeneAmh" passive="UppQ1524o"/>
+                    <relation name="saws:isAttributedToAuthor" active="LIT7101QeneAmh" passive="PRS14574GabraLeul"/>
+                </listRelation>
+            </div>
+            <div type="edition" xml:lang="am">
+                <note>This edition is based on <ref type="mss" corresp="UppQ1524o"/> on fols 45r, 46r.
+                    Division into verses is indicated with ፤ .
+                    The end of the poem is indicated with ። .</note>
+                <ab>
+                    <l n="1">ኢደርስበኝ፡ ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ ኢያሉ፡ አዝማሪ፤</l>
+                    <l n="2">እስኪ፡ ያመዘከራት፡ ነፍሴት፡ የጌታ፡ ወቀሰ፡ ወራሪ፤</l>
+                    <l n="3">ወዘማዊትተ፡ ሕግ፡ ልቡናዬ፡ ይሻልሽ፡ ነበሬ፡ ጌታሽን፡ ብትፈሪ፤</l><pb n="46r"/>
+                    <l n="4">የቁጣ፡ ፊቱን፡ ባነሳ፡ ጊዜ፡ የለውምና፡ ምንምን፡ ወደርሱ፡ ቀርቦ፡ መካሪ፤</l>
+                    <l n="5">አንዶበትሂ፡ ነገረ፡ ጽድቅ፡ ተዪ፡ ተናገሪ፤</l>
+                    <l n="6">እንግዳ፡ ህማም፡ ብመጣ፡ ጊዜ፡ በሰንሰለት፡ ሞት፡ ሳትታስሪ፤</l>
+                    <l n="7">አያድንምና፡ ወንድም፡ ጋሻ፡ ጣር፡ ይዘ፡ ፊፈካሪ፤</l>
+                    <l n="8">በትር፡ ወንጌሉን፡ ባነሳ፡ ጊዜ፡ ኃይለኛ፡ ቃሉ፡ ፈጣሪ።</l>
+                </ab>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7101QeneAmh.xml
+++ b/new/LIT7101QeneAmh.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="am" xml:id="t1">እየደረስብኝ፡ ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ እያሉ፡ አዝማሪ፤</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎyyadarasabbəññ naw ba-sane farasaññāw mot (Qǝne possibly of the mawaddǝs-type)</title>
-                <title xml:lang="en" corresp="#t1"></title>
+                <title xml:lang="en" corresp="#t1">The galloping death is reaching me in Sane, without me having benefitted my soul. Oh my woes, the ʾazmāri says…</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="JK"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT7101QeneAmh.xml
+++ b/new/LIT7101QeneAmh.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="am" xml:id="t1">እየደረስብኝ፡ ነው፡ በሰኔ፡ ፈረሰኛው፡ ሞት፡ ነፍሴን፡ ሳልጠቅማት፡ ወየው፡ ሰዎች፡ እያሉ፡ አዝማሪ፤</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎyyadarasabbəññ naw ba-sane farasaññāw mot (Qǝne possibly of the mawaddǝs-type)</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">ʾƎyyadarrasabbəññ naw ba-sane farasaññāw mot (Qǝne possibly of the mawaddǝs-type)</title>
                 <title xml:lang="en" corresp="#t1">The galloping death is reaching me in Sane, without me having benefitted my soul. Oh my woes, the ʾazmāri says…</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="JK"/>
@@ -76,7 +76,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     
                     <l n="2">እስኪ፡ <sic resp="JK">ያመዘከራት፡</sic> 
                         ነፍሴ<choice><sic>ት</sic><corr resp="HSM">ን</corr></choice>፡ የጌታ፡ 
-                        ወ<choice><sic>ቀሰ</sic><corr resp="HSM">ቃሽ</corr></choice>፡ ወራሪ፤</l>
+                        ወቀሰ፡ ወራሪ፤</l>
                     
                     <l n="3">ወዘማዊ<choice><sic>ት</sic><corr>ተ</corr></choice>፡ ሕ<choice><sic>ግ</sic><corr resp="HSM">ገ</corr></choice>፡ ልቡናዬ፡ ይሻልሽ፡ 
                         ነበ<choice><sic>ሬ</sic><corr resp="HSM">ረ</corr></choice>፡ ጌታሽን፡ ብትፈሪ፤</l><pb n="46r"/>
@@ -86,7 +86,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="5">አን<choice><sic>ዶ</sic><corr resp="HSM">ደ</corr></choice>በትሂ፡ ነገረ፡ ጽድቅ፡ ተዪ፡ ተናገሪ፤</l>
                     
                     <l n="6">እንግዳ፡ ህማም፡ <choice><sic>ብ</sic><corr resp="HSM">በ</corr></choice>መጣ፡ ጊዜ፡ በሰንሰለት፡ ሞት፡ 
-                        ሳትታዶ<choice><sic>ስ</sic><corr resp="HSM">ሰ</corr></choice>ሪ፤</l>
+                        ሳትታ<choice><sic>ስ</sic><corr resp="HSM">ሰ</corr></choice>ሪ፤</l>
                     
                     <l n="7">አያድንምና፡ ወንድም፡ ጋሻ፡ <choice><sic>ጣ</sic><corr resp="HSM">ጦ</corr></choice>ር፡ 
                         <choice><sic>ይ</sic><corr resp="HSM">የያ</corr></choice>ዘ፡ 


### PR DESCRIPTION
An Amharic qene from the manuscript in Uppsala. Images are available here: https://www.alvin-portal.org/alvin/imageViewer.jsf?dsId=ATTACHMENT-0463&pid=alvin-record:280997

Nafisa and especially Hewan helped me greatly with this one.