### PR TITLE
Create LIT7125QeneRufael (Qene from BNFabb145, no. 10)

### DIFF
--- a/new/LIT7070Qene.xml
+++ b/new/LIT7070Qene.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">">ተሠይጠ፡ ዮሴፍ፡ በምሳሌከ፡ አባግዓ፡ ያዕቆብ፡ ይርአይ፡ መንገለ፡ ወፈረ፡ ሐቅለ።</title>
+                <title xml:lang="gez" xml:id="t1">ተሠይጠ፡ ዮሴፍ፡ በምሳሌከ፡ አባግዓ፡ ያዕቆብ፡ ይርአይ፡ መንገለ፡ ወፈረ፡ ሐቅለ።</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">Taśayṭa Yosef ba-mǝssāleka ʾabāgʿā Yāʿqob yǝrʾay mangala wafara ḥaqla (Qǝne of the kʷǝllǝkǝmu-type)</title>
                 <title xml:lang="en" corresp="#t1">Joseph was sold in your likeness, where he went out to the desert to tend Jacob's sheep …</title>
                 <editor role="generalEditor" key="AB"/>
@@ -34,7 +34,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Qǝne of the kʷǝllǝkǝmu-type. Type and author are not indicated in the manuscript.</p>
+                <p>Qǝne of the kʷǝllǝkǝmu-type according to the classification in 
+                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl>. 
+                    Type and author are not indicated in the manuscript.</p>
             </abstract>
             <textClass>
                 <keywords>

--- a/new/LIT7125QeneRufael.xml
+++ b/new/LIT7125QeneRufael.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ሩፋኤል፡ ላዕከ፡ ተሰብኦ፡ ባሕረ፡ ተሰብኦ፡ አመ፡ ጸበተ።</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">Rufāʾel lāʿka tasabʾo bāḥra tasabʾo ʾama ṣabata... (Qǝne possibly of śǝllāse type)</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Rufāʾel lāʿka tasabʾo bāḥra tasabʾo ʾama ṣabata... (Qǝne of śǝllāse type)</title>
                 <title xml:lang="en" corresp="#t1">Rufael, the servant of incarnation, when he swam in the sea of the incarnation...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
@@ -34,7 +34,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Qǝne possibly of the śǝllāse type according to the classification in 
+                <p>Qǝne of the śǝllāse type according to the classification in 
                     <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl>, with a long verse at the 
                     beginning, erroneously divided into two by an incorrect verse marker (።). The type and author are not given in the manuscript.</p>
             </abstract>
@@ -51,7 +51,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2024-10-30">Created entity with the help of Nafisa Valieva.</change>
+            <change who="CH" when="2024-10-30">Created entity.</change>
+            <change who="CH" when="2024-10-30">Updated edition with several readings supplied by Nafisa Valieva.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT7125QeneRufael.xml
+++ b/new/LIT7125QeneRufael.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ሩፋኤል፡ ላዕከ፡ ተሰብኦ፡ ባሕረ፡ ተሰብኦ፡ አመ፡ ጸበተ።</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">Rufāʾel lāʿka tasabʾo bāḥra tasabʾo ʾama ṣabata... (Qǝne possibly of śǝllāse type)</title>
-                <title xml:lang="en" corresp="#t1">Rufael being a human, send the sea, being a human, as long as he swam (?)…</title>
+                <title xml:lang="en" corresp="#t1">Rufael, the servant of incarnation, when he swam in the see of the incarnation...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -51,7 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2024-10-30">Created entity</change>
+            <change who="CH" when="2024-10-30">Created entity with the help of Nafisa Valieva.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT7125QeneRufael.xml
+++ b/new/LIT7125QeneRufael.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ሩፋኤል፡ ላዕከ፡ ተሰብኦ፡ ባሕረ፡ ተሰብኦ፡ አመ፡ ጸበተ።</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">Rufāʾel lāʿka tasabʾo bāḥra tasabʾo ʾama ṣabata... (Qǝne possibly of =sǝllāse type)</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Rufāʾel lāʿka tasabʾo bāḥra tasabʾo ʾama ṣabata... (Qǝne possibly of śǝllāse type)</title>
                 <title xml:lang="en" corresp="#t1">Rufael being a human, send the sea, being a human, as long as he swam (?)…</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
@@ -58,17 +58,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <div type="edition" xml:lang="gez">
                 <note>This edition is based on <ref type="mss" corresp="BNFabb145"/> on f. 55vb to 55vc. Division into verses is indicated with ። . 
-                    The end of the poem is indicated with ። ። . One or two characters at the end of each line in column 55vc are not recognizable in the 
-                    digital reproduction due to tight binding..</note>
+                    The end of the poem is indicated with ። ። .</note>
                 <ab>
                     <l n="1">ሩፋኤል፡ ላዕከ፡ ተሰብኦ፡ ባሕረ፡ ተሰብኦ፡ አመ፡ ጸበተ። እንዘ፡ ይነሥእ፡ እምቈጽል፡ አርአያ፡ ወእምአኅማር፡ አምሳለ፡ 
                         <del rend="strikethrough">፩</del>።</l>
                     <l n="2">ለባሕረ፡ ሥጋዊ፡ ዲቤሁ፡ ጸለለ።</l>
-                    <l n="3">ፍጻሚ፡ ዕመቁሰ፡ ይር<cb n="55vc"/>አይ፡ ፈጣሪ፡ እስመ፡ 
-                        በእንቲአ<unclear>ነ</unclear><supplied resp="CH" reason="undefined">፡ ብ</supplied>ህለ።</l>
-                    <l n="4">ወረደ፡ ታሕተ፡ ወተቈል<supplied reason="undefined" resp="CH">ቈለ።</supplied></l>
-                    <l n="5">ወከመ፡ እምዕከል፡ ኢዓርገ፡ <unclear>ወ</unclear><supplied reason="undefined" resp="CH">ለ</supplied>ተለዓለ።</l>
-                    <l n="6">አርአያነ፡ ኆፃሁ፡ መ<unclear>ሰ</unclear>ለ። ።</l>
+                    <l n="3">ፍጻሚ፡ ዕመቁሰ፡ ይር<cb n="55vc"/>አይ፡ ፈጣሪ፡ እስመ፡ በእንቲአነ፡ ክህለ።</l>
+                    <l n="4">ወረደ፡ ታሕተ፡ ወተቈልቈለ።</l>
+                    <l n="5">ወከመ፡ እምዕከል፡ ኢዓርገ፡ ወኢተለዓለ።</l>
+                    <l n="6">አርአያነ፡ ኆፃሁ፡ መስቀለ። ።</l>
                 </ab>
             </div>
         </body>

--- a/new/LIT7125QeneRufael.xml
+++ b/new/LIT7125QeneRufael.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ሩፋኤል፡ ላዕከ፡ ተሰብኦ፡ ባሕረ፡ ተሰብኦ፡ አመ፡ ጸበተ።</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">Rufāʾel lāʿka tasabʾo bāḥra tasabʾo ʾama ṣabata... (Qǝne possibly of śǝllāse type)</title>
-                <title xml:lang="en" corresp="#t1">Rufael, the servant of incarnation, when he swam in the see of the incarnation...</title>
+                <title xml:lang="en" corresp="#t1">Rufael, the servant of incarnation, when he swam in the sea of the incarnation...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT7125QeneRufael.xml
+++ b/new/LIT7125QeneRufael.xml
@@ -1,0 +1,76 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7125QeneRufael" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">ሩፋኤል፡ ላዕከ፡ ተሰብኦ፡ ባሕረ፡ ተሰብኦ፡ አመ፡ ጸበተ።</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Rufāʾel lāʿka tasabʾo bāḥra tasabʾo ʾama ṣabata... (Qǝne possibly of =sǝllāse type)</title>
+                <title xml:lang="en" corresp="#t1">Rufael being a human, send the sea, being a human, as long as he swam (?)…</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <listWit>
+                    <witness corresp="BNFabb145"/>
+                </listWit>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Qǝne possibly of the śǝllāse type according to the classification in 
+                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl>, with a long verse at the 
+                    beginning, erroneously divided into two by an incorrect verse marker (።). The type and author are not given in the manuscript.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Poetry"/>
+                    <term key="Qene"/>
+                    <term key="Wazema"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2024-10-30">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="edition" xml:lang="gez">
+                <note>This edition is based on <ref type="mss" corresp="BNFabb145"/> on f. 55vb to 55vc. Division into verses is indicated with ። . 
+                    The end of the poem is indicated with ። ። . One or two characters at the end of each line in column 55vc are not recognizable in the 
+                    digital reproduction due to tight binding..</note>
+                <ab>
+                    <l n="1">ሩፋኤል፡ ላዕከ፡ ተሰብኦ፡ ባሕረ፡ ተሰብኦ፡ አመ፡ ጸበተ። እንዘ፡ ይነሥእ፡ እምቈጽል፡ አርአያ፡ ወእምአኅማር፡ አምሳለ፡ 
+                        <del rend="strikethrough">፩</del>።</l>
+                    <l n="2">ለባሕረ፡ ሥጋዊ፡ ዲቤሁ፡ ጸለለ።</l>
+                    <l n="3">ፍጻሚ፡ ዕመቁሰ፡ ይር<cb n="55vc"/>አይ፡ ፈጣሪ፡ እስመ፡ 
+                        በእንቲአ<unclear>ነ</unclear><supplied resp="CH" reason="undefined">፡ ብ</supplied>ህለ።</l>
+                    <l n="4">ወረደ፡ ታሕተ፡ ወተቈል<supplied reason="undefined" resp="CH">ቈለ።</supplied></l>
+                    <l n="5">ወከመ፡ እምዕከል፡ ኢዓርገ፡ <unclear>ወ</unclear><supplied reason="undefined" resp="CH">ለ</supplied>ተለዓለ።</l>
+                    <l n="6">አርአያነ፡ ኆፃሁ፡ መ<unclear>ሰ</unclear>ለ። ።</l>
+                </ab>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created a record for the Qene of folio 55vb-c. I was challenged by the translation of the first line, whose content I do not understand. I am wondering, whether twice ተሰብኦ might be a dittography.

Furthermore, I have problems in determining the type. The poem is divided with verse markers (።) into six or seven verses depending on the emendation in line 4. However, the rhyme in ለ indicates, that the first verse break must be a mistake, because otherwise the first verse would end in ጸበተ and would not match to the rhyme in ለ (accepting the crossing out of ፩ at the end of the first line. Otherwise, there could be also a rhyme in ጸበተ and  ፩ (= ʾaḥatta), what is difficult to accept, because a change in the rhyme from ተ to ለ is not common in qene, as far as I know.) Another option could be to define two very long verses ending in ብህለ (if this emendation is correct) and መሰለ and a ʾač̣ǝr kwǝllǝkomu or gubāʾe qānā type respectively.

![grafik](https://github.com/user-attachments/assets/19f01cd0-83d2-4477-a001-8b0dcd07bf2a)
![grafik](https://github.com/user-attachments/assets/fc934444-fa1a-45e0-ad44-23675ce02f68)
