### PR TITLE
Update records concerning prayers against stomach pain

### DIFF
--- a/4001-5000/LIT4624Prayer.xml
+++ b/4001-5000/LIT4624Prayer.xml
@@ -27,6 +27,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <listWit>
                     <witness corresp="BAVet77#ms_i7"/>
                     <witness corresp="BAVet98#ms_i7"/>
+                    <witness corresp="BLorient12959#ms_i4"/>
                 </listWit>
             </sourceDesc>
         </fileDesc>

--- a/4001-5000/LIT4624Prayer.xml
+++ b/4001-5000/LIT4624Prayer.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ጸሎት፡ በእንተ፡ ሕማመ፡ ውጋት፡</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">Ṣalot baʾǝnta ḥǝmāma wǝgāt</title>
-                <title xml:lang="en" corresp="#t1">Protective prayer against the pain</title>
+                <title xml:lang="en" corresp="#t1">Prayer against stomachache</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -41,7 +41,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Protective prayer ayer against the pain</p>
+                <p>Magic prayer against stomach pain or chest pain. Thematically similar and with identical text as 
+                    <ref type="work" corresp="LIT6716PPWegat"/>, but without any <foreign xml:lang="gez">ʾasmāt</foreign>.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -58,11 +59,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
         <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="dc:relation" active="LIT4624Prayer" passive="LIT6716PPWegat"><desc>Thematically similar and with
+                        identical text as <ref type="work" corresp="LIT6716PPWegat"/>, but without any <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
+                </listRelation>
+            </div>
             <div type="edition">
                 <div type="textpart" subtype="incipit" xml:lang="gez" xml:id="Incipit">
                     <ab>
                         ጸሎት፡ በእንተ፡ ሕማመ፡ ውጋት፡ ምድምያስ፡ ምድምያስ፡
-                        <!-- Cp. LIT4625Prayer and LIT4705Prayer with the same title (በእንተ፡ ሕማመ፡ ውግ[ዓ]ት፡) but different incipit-->
                     </ab>
                 </div>
             </div>

--- a/4001-5000/LIT4624Prayer.xml
+++ b/4001-5000/LIT4624Prayer.xml
@@ -43,7 +43,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <creation/>
             <abstract>
                 <p>Magic prayer against stomach pain or chest pain. Thematically similar and with identical text as 
-                    <ref type="work" corresp="LIT6716PPWegat"/>, but without any <foreign xml:lang="gez">ʾasmāt</foreign>.</p>
+                    <ref type="work" corresp="LIT6716PPWegat"/>, but without any <foreign xml:lang="gez">ʾasmāt</foreign>
+                    and thematically similar to <ref type="work" corresp="LIT4625Prayer"/> and <ref type="work" corresp="LIT4705MagicPr"/>.
+                </p>
             </abstract>
             <textClass>
                 <keywords>
@@ -63,7 +65,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <div type="bibliography">
                 <listRelation>
                     <relation name="dc:relation" active="LIT4624Prayer" passive="LIT6716PPWegat"><desc>Thematically similar and with
-                        identical text as <ref type="work" corresp="LIT6716PPWegat"/>, but without any <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
+                        identical text as <ref type="work" corresp="LIT6716PPWegat"/>, 
+                        but without any <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
+                    <relation name="dc:relation" active="LIT4624Prayer" passive="LIT4705MagicPr"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4705MagicPr"/>, but without any <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
+                    <relation name="dc:relation" active="LIT4624Prayer" passive="LIT4625Prayer"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4625Prayer"/>, but without any <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
                 </listRelation>
             </div>
             <div type="edition">

--- a/4001-5000/LIT4625Prayer.xml
+++ b/4001-5000/LIT4625Prayer.xml
@@ -40,7 +40,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Protective prayer ayer against the pain</p>
+                <p>Magic prayer against stomach pain or chest pain, which is thematically similar to 
+                    <ref type="work" corresp="LIT4624Prayer"/>, but with some <foreign xml:lang="gez">ʾasmāt</foreign> added, but 
+                    different from <ref type="work" corresp="LIT6716PPWegat"/> and <ref type="work" corresp="LIT4705MagicPr"/>.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -65,11 +67,22 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                     </bibl>
                 </listBibl>
             </div>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="dc:relation" active="LIT4625Prayer" passive="LIT4705MagicPr"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4705MagicPr"/>, but with another set of
+                        <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
+                    <relation name="dc:relation" active="LIT4625Prayer" passive="LIT6716PPWegat"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT6716PPWegat"/>, but with another set of
+                        <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
+                    <relation name="dc:relation" active="LIT4625Prayer" passive="LIT4624Prayer"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4624Prayer"/>, but with <foreign xml:lang="gez">ʾasmāt</foreign> added.</desc></relation>
+                </listRelation>
+            </div>
             <div type="edition">
                 <div type="textpart" subtype="incipit" xml:lang="gez" xml:id="Incipit">
                     <ab>
                         ጸሎት፡ በእንተ፡ ሕማመ፡ ውጋት፡ ሰላም፡ ለገቦከ፡ ኵናተ፡ ለንጊኖስ፡ ዘወግዖ፡
-                        <!-- Cp. LIT4624Prayer and LIT4705Prayer with the same title (በእንተ፡ ሕማመ፡ ውግ[ዓ]ት፡) but different incipit-->
                     </ab>
                 </div>
             </div>

--- a/4001-5000/LIT4705MagicPr.xml
+++ b/4001-5000/LIT4705MagicPr.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ጸሎት፡ በእንተ፡ ሕማመ፡ ውግዓት፡</title>
                 <title xml:lang="gez" corresp="#t1" type="normalized">Ṣalot baʾǝnta ḥǝmāma wǝgʿāt</title>
-                <title xml:lang="en" corresp="#t1">Protective prayer against the pain</title>
+                <title xml:lang="en" corresp="#t1">Protective prayer against stomach pain</title>
                 <title xml:lang="en" xml:id="t2">Magic Prayer</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
@@ -41,7 +41,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <profileDesc>
             <creation/>
             <abstract>
-                <p/>
+                <p>Magic prayer against stomach pain or chest pain, which is thematically similar to 
+                    <ref type="work" corresp="LIT4624Prayer"/>, but with some <foreign xml:lang="gez">ʾasmāt</foreign> added, but 
+                    different from <ref type="work" corresp="LIT6716PPWegat"/> and <ref type="work" corresp="LIT4625Prayer"/>.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -58,6 +60,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
         <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="dc:relation" active="LIT4705MagicPr" passive="LIT4625Prayer"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4625Prayer"/>, but with another set of
+                        <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
+                    <relation name="dc:relation" active="LIT4705MagicPr" passive="LIT6716PPWegat"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT6716PPWegat"/>, but with another set of
+                        <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
+                    <relation name="dc:relation" active="LIT4705MagicPr" passive="LIT4624Prayer"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4624Prayer"/>, but with <foreign xml:lang="gez">ʾasmāt</foreign> added.</desc></relation>
+                </listRelation>
+            </div>
             <div type="edition">
                 <div type="textpart" subtype="incipit" xml:lang="gez" xml:id="Incipit">
                     <ab>

--- a/6001-7000/LIT6716PPWegat.xml
+++ b/6001-7000/LIT6716PPWegat.xml
@@ -33,7 +33,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <creation/>
             <abstract>
                 <p>Magic prayer against stomach pain or chest pain, which is essentially the same prayer as 
-                    <ref type="work" corresp="LIT4624Prayer"/>, but with some <foreign xml:lang="gez">ʾasmāt</foreign> added.</p>
+                    <ref type="work" corresp="LIT4624Prayer"/>, but with some <foreign xml:lang="gez">ʾasmāt</foreign> added
+                    and thematically similar to <ref type="work" corresp="LIT4625Prayer"/> and <ref type="work" corresp="LIT4705MagicPr"/>.
+                </p>
             </abstract>
             <textClass>
                 <keywords>
@@ -58,6 +60,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <listRelation>
                     <relation name="dc:relation" active="LIT6716PPWegat" passive="LIT4624Prayer"><desc>It is essentially the same prayer as 
                         <ref type="work" corresp="LIT4624Prayer"/>, but with <foreign xml:lang="gez">ʾasmāt</foreign> added.</desc></relation>
+                    <relation name="dc:relation" active="LIT6716PPWegat" passive="LIT4705MagicPr"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4705MagicPr"/>, but with another set of
+                        <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
+                    <relation name="dc:relation" active="LIT6716PPWegat" passive="LIT4625Prayer"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4625Prayer"/>, but with another set of
+                        <foreign xml:lang="gez">ʾasmāt</foreign>.</desc></relation>
               </listRelation>
             </div>
             <div type="edition">

--- a/6001-7000/LIT6716PPWegat.xml
+++ b/6001-7000/LIT6716PPWegat.xml
@@ -21,7 +21,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <p/>
+                <listWit>
+                    <witness corresp="BDLaethg45"/>
+                </listWit>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -30,13 +32,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p/>
+                <p>Magic prayer against stomach pain or chest pain, which is essentially the same prayer as 
+                    <ref type="work" corresp="LIT4624Prayer"/>, but with some <foreign xml:lang="gez">ʾasmāt</foreign> added.</p>
             </abstract>
             <textClass>
                 <keywords>
                     <term key="ChristianLiterature"/>
                     <term key="Magic"/>
                     <term key="Prayers"/>
+                    <term key="Asmat"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -52,8 +56,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <div type="bibliography">
                 <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT6716PPWegat" passive="BDLaethg45"/>
-                </listRelation>
+                    <relation name="dc:relation" active="LIT6716PPWegat" passive="LIT4624Prayer"><desc>It is essentially the same prayer as 
+                        <ref type="work" corresp="LIT4624Prayer"/>, but with <foreign xml:lang="gez">ʾasmāt</foreign> added.</desc></relation>
+              </listRelation>
             </div>
             <div type="edition">
                 <note>The following is the complete text of the prayer, taken from <ref type="mss" corresp="BDLaethg45"/>.</note>


### PR DESCRIPTION
I have seen that LIT4624Prayer and LIT6716PPWegat are essentially the same prayer with the only difference, that LIT6716PPWegat contains ʾasmat. I wanted to indicate this relationship by adding relation in body and by updating the abstracts. 

I do not know, what happened to LIT4705Prayer, which was mentioned in line 65 of LIT4624Prayer. LIT4705Prayer is not in the app. I think, this note can be deleted.