### PR TITLE
Texts in bavet121

### DIFF
--- a/1001-2000/LIT1295Dersan.xml
+++ b/1001-2000/LIT1295Dersan.xml
@@ -39,12 +39,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <witness corresp="EMML44"/>
                <witness corresp="BNFet346"/>
                <witness corresp="BAVet82"/>
+               <witness corresp="BAVet21"/>
                <!--create mini ms-->
             </listWit>
             <!-- list from ESam004 
             <listBibl type="mss">
                <bibl>BritMus Orient. 4849 (17th-18th cent.), <locus from="37r" to="108v">37r-108v</locus> (StrBritLib 94, n<locus target="#58">58</locus>);</bibl>
                <bibl>VatLib Aeth. 82 (19th cent.), <locus from="15" to="83">15-83</locus> (GréTisVat I, 298-307);</bibl>
+                <bibl>VatLib Aeth. 121 (19th cent.),   <locus from="5r" to="89r">52-89r</locus> (GréTisVat I, 488-491);</bibl>
                <bibl>EMML n° 424 (19th-20th cent.), <locus from="1a" to="124b">1a-124b</locus> (EMML II, 143);</bibl>
                <bibl>EMML n°301 (20th cent.), <locus from="2a" to="138a">2a-138a</locus> (EMML II, 1);</bibl>
                <bibl>EMML n°44 (20th cent.), <locus from="2a" to="15a">2a-15a</locus>, 31b-53b, 64a-83a (EMML I, 48);</bibl>
@@ -152,7 +154,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                
                <div type="textpart" subtype="Introduction">
-<label>Introduction</label>               </div>
+                  <label>Introduction</label>             
+               </div>
             </div>
             
             <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="Hedar">
@@ -167,9 +170,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="IntroductionMiracles">
                   <label xml:lang="en">Introduction to the miracles performed by St Michael</label>
+                  <!-- This introduction is transmitted in the section for Ḫǝdār in BAVet82, but in the section for Maskaram in BAVet121 (instead of the miracle)  -->
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleHedar">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ḫǝdār</foreign> on the Egyptian sailors saved by St Michael</label>
+                  <!-- This miracle is transmitted in the section for Ḫǝdār in BAVet82, but in the section for Hamle in BAVet121  -->
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeHedar">
                   <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Ḫǝdār</foreign>
@@ -194,6 +199,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleTahsas">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Tāḫśāś</foreign> on the poor peasant who found a treasure</label>
+                  <!-- This miracle is transmitted in the section for Tāḫśāś in BAVet82, but in the section for Gǝnbot in BAVet121  -->
+               </div>
+               <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="ThreeYouths">
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Tāḫśāś</foreign> of the three youths in the furnace</label>
+                  <!-- This miracle is inserted here after BAVet121; GrebTiss p. 489 give no incipt of other info, it does not correspond to "MiracleTahsas". -->
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeTahsas">
                   <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Tāḫśāś</foreign>
@@ -215,10 +225,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      <relation name="saws:isAttributedToAuthor" active="LIT1295Dersan#HomilyTerr" passive="PRS3828Epiphani"/>
                   </listRelation>
                   <label xml:lang="en">Homily for <foreign xml:lang="gez">Ṭǝrr</foreign> by <persName ref="PRS3828Epiphani"/>
+                     <!-- This homily is transmitted in the section for Ṭǝrr in BAVet82, but in the section for Miyāzyā in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleTerr">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ṭǝrr</foreign>
+                     <!-- This miracle is transmitted in the section for Ṭǝrr in BAVet82, but in the section for Miyāzyā in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeTerr">
@@ -248,6 +260,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleYakkatit">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Yakkātit</foreign>
+                     <!-- This miracle is transmitted in the section for Yakkātit in BAVet82, but in the section for Naḥase in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeYakkatit">
@@ -284,7 +297,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            and <bibl>
                               <ptr target="bm:budge1894stmichael"/>
                            </bibl> as <persName ref="PRS8790Severus"/>. His name is often omitted,
-                           leaving only his title "patriarch of Antioch". Occassionally it is also attributed to other authors.
+                           leaving only his title "patriarch of Antioch". Occasionally it is also attributed to other authors.
                         </desc>
                      </relation>
                   </listRelation>
@@ -292,6 +305,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleMaggabit">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Maggābit</foreign>
+                     <!-- This miracle is transmitted in the section for Maggābit in BAVet82, but in the section for Yakkātit in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeMaggabit">
@@ -311,7 +325,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </label>
                
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="HomilyMiyazya">
-                  
+                  <!-- This homily is within the section for Miyāzyā in BAVet82, but in the section for Tāḫśāś in BAVet121 (here attributed to PRS10425Yohanne) -->
                   <listRelation>
                      <relation name="saws:isAttributedToAuthor" active="LIT1295Dersan#HomilyMiyazya" passive="PRS10425Yohanne">
                         <desc>The Homily for <foreign xml:lang="gez">Miyāzyā</foreign> is attributed in
@@ -331,6 +345,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleMiyazya">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Miyāzyā</foreign>
+                     <!-- This homily is transmitted in the section for Miyāzyā in BAVet82, but in the section for Ṭǝrr in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeMiyazya">
@@ -367,6 +382,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleGenbot">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Gǝnbot</foreign>
+                     <!-- This miracle is within the section for Gǝnbot in BAVet82, but in the section for Ḫǝdār in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeGenbot">
@@ -422,6 +438,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleHamle">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ḥamle</foreign>
+                     <!-- This miracle is within the section for Ḥamle in BAVet82, but in the section for Tāḫśāś in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeHamle">
@@ -445,6 +462,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleNahase">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Naḥase</foreign>
+                     <!-- This miracle is transmitted in the section for Naḥase in BAVet82, but in the section for Ṭǝqǝmt in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeNahase">
@@ -496,6 +514,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleTeqemt">
                   <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ṭǝqǝmt</foreign>
+                     <!-- This miracle is transmitted in the section for Ṭǝqǝmt in BAVet82, but in the section for Maggābit in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeTeqemt">

--- a/1001-2000/LIT1295Dersan.xml
+++ b/1001-2000/LIT1295Dersan.xml
@@ -94,6 +94,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="MV" when="2017-05-17">Added textpart</change>
          <change who="DR" when="2018-04-25">Added xml:lang to label</change>
          <change when="2019-03-26" who="ES">bits of data from ESam004 added + relation</change>
+         <change who="MV" when="2024-11-04">Updated labels of the textparts</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -303,7 +304,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleMaggabit">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Maggābit</foreign> on the the woman suffering from elephantiasis
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Maggābit</foreign> on the woman suffering from elephantiasis
                      <!-- This miracle is transmitted in the section for Maggābit in BAVet82, but in the section for Yakkātit in BAVet121  -->
                   </label>
                </div>

--- a/1001-2000/LIT1295Dersan.xml
+++ b/1001-2000/LIT1295Dersan.xml
@@ -170,14 +170,16 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="IntroductionMiracles">
                   <label xml:lang="en">Introduction to the miracles performed by St Michael</label>
-                  <!-- This introduction is transmitted in the section for Ḫǝdār in BAVet82, but in the section for Maskaram in BAVet121 (instead of the miracle)  -->
+                  <!-- This introduction is transmitted in the section for Ḫǝdār in BAVet82, but in the section for Maskaram in BAVet121 (instead of the miracle). -->
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleHedar">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ḫǝdār</foreign> on the Egyptian sailors saved by St Michael</label>
-                  <!-- This miracle is transmitted in the section for Ḫǝdār in BAVet82, but in the section for Hamle in BAVet121  -->
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ḫǝdār</foreign> on the Egyptian sailors whose boat was troubled by a strong wind</label>
+                  <!-- This miracle is transmitted in the section for Ḫǝdār in BAVet82, but in the section for Hamle in BAVet121.
+                  The indication of the month should be removed from the title in order to avoid confusion in the MSS descriptions where it is not transmitted in Ḫǝdār.
+                  -->
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeHedar">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Ḫǝdār</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Ḫǝdār</foreign> on St Michael's appearance to Joshua  
                   </label>
                </div>
                
@@ -198,15 +200,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleTahsas">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Tāḫśāś</foreign> on the poor peasant who found a treasure</label>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Tāḫśāś</foreign> on the poor peasant who found a treasure in a fish</label>
                   <!-- This miracle is transmitted in the section for Tāḫśāś in BAVet82, but in the section for Gǝnbot in BAVet121  -->
                </div>
-               <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="ThreeYouths">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Tāḫśāś</foreign> of the three youths in the furnace</label>
-                  <!-- This miracle is inserted here after BAVet121; GrebTiss p. 489 give no incipt of other info, it does not correspond to "MiracleTahsas". -->
-               </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeTahsas">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Tāḫśāś</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Tāḫśāś</foreign> about the three youths in the furnace
+                     <!-- This is indicated as a miracle by GrebTiss about BAVet82 and BAVet121-->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamTahsas">
@@ -229,12 +228,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleTerr">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ṭǝrr</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ṭǝrr</foreign> about the rich man who became poor
                      <!-- This miracle is transmitted in the section for Ṭǝrr in BAVet82, but in the section for Miyāzyā in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeTerr">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Ṭǝrr</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Ṭǝrr</foreign> on St Michael's appearance to Jacob
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamTerr">
@@ -259,12 +258,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </listBibl>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleYakkatit">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Yakkātit</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Yakkātit</foreign> on the poor who sent the money to the church custodian inside a fish <!-- check this content; it is given after GrebTiss's Latin title -->
                      <!-- This miracle is transmitted in the section for Yakkātit in BAVet82, but in the section for Naḥase in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeYakkatit">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Yakkātit</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Yakkātit</foreign> on St Michael's appearance to Samson
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamYakkatit">
@@ -304,12 +303,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleMaggabit">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Maggābit</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Maggābit</foreign> on the the woman suffering from elephantiasis
                      <!-- This miracle is transmitted in the section for Maggābit in BAVet82, but in the section for Yakkātit in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeMaggabit">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Maggābit</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Maggābit</foreign> on St Michael's appearance to Balaam
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamMaggabit">
@@ -344,12 +343,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </div>
                
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleMiyazya">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Miyāzyā</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Miyāzyā</foreign> on the Christian whose hand had become dry and on the conversion of a pagan
                      <!-- This homily is transmitted in the section for Miyāzyā in BAVet82, but in the section for Ṭǝrr in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeMiyazya">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Miyāzyā</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Miyāzyā</foreign> on Jeremiah freed by St Michael's
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamMiyazya">
@@ -381,12 +380,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <label>Homily Concerning John (Yoḥannǝs), Metropolitan of Aksum, for the 12th day of Gǝnbot</label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleGenbot">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Gǝnbot</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Gǝnbot</foreign> on the sterile woman
                      <!-- This miracle is within the section for Gǝnbot in BAVet82, but in the section for Ḫǝdār in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeGenbot">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Gǝnbot</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Gǝnbot</foreign> on St Michael's appearance to Habakkuk
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamGenbot">
@@ -410,11 +409,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <label>Homily of John (Yoḥannǝs), Metropolitan of Aksum, for the 12th day of Sane</label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleSane">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Sane</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Sane</foreign> on the healing of the leprous Jew
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeSane">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Sane</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Sane</foreign> on the conversion of the temple in Alexandria into a church dedicated to St Michael
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamSane" corresp="LIT6631SalMikMahari">
@@ -437,12 +436,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <label>Homily of John (Yoḥannǝs), Bishop of Aksum, for the 12th day of Ḥamle</label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleHamle">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ḥamle</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ḥamle</foreign> on a man freed from an evil spirit
                      <!-- This miracle is within the section for Ḥamle in BAVet82, but in the section for Tāḫśāś in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeHamle">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Ḥamle</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Ḥamle</foreign> on St Michael's intervention against King Sennacherib 
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamHamle">
@@ -461,12 +460,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleNahase">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Naḥase</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Naḥase</foreign> on the healing of a blind man
                      <!-- This miracle is transmitted in the section for Naḥase in BAVet82, but in the section for Ṭǝqǝmt in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeNahase">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Naḥase</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Naḥase</foreign> on St Michael's appearance to King Constantine
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamNahase">
@@ -485,11 +484,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleMaskaram">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Maskaram</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Maskaram</foreign> on Dorotheus and Theopista, who found a treasure in the belly of a fish
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeMaskaram">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Maskaram</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Maskaram</foreign> on St Michael's appearance to Isaiah
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamMaskaram">
@@ -513,12 +512,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="MiracleTeqemt">
-                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ṭǝqǝmt</foreign>
+                  <label xml:lang="en">Miracle for <foreign xml:lang="gez">Ṭǝqǝmt</foreign> on the healing of the paralytic
                      <!-- This miracle is transmitted in the section for Ṭǝqǝmt in BAVet82, but in the section for Maggābit in BAVet121  -->
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="CommemorativeTeqemt">
-                  <label xml:lang="en">Commemorative Notice for <foreign xml:lang="gez">Ṭǝqǝmt</foreign>
+                  <label xml:lang="en">Commemorative notice for <foreign xml:lang="gez">Ṭǝqǝmt</foreign> on St Michael's appearance to Samuel
                   </label>
                </div>
                <div type="textpart" subtype="chapter" xml:lang="gez" xml:id="SalamTeqemt">

--- a/2001-3000/LIT2835RepCh119.xml
+++ b/2001-3000/LIT2835RepCh119.xml
@@ -29,7 +29,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <listWit>
                <witness corresp="DSEthiop10"/>
                <witness corresp="BNFet346"/>
-               <witness corresp="VATet82"/>
+               <witness corresp="BAVet82"/>
                <witness corresp="EMML301"/>
                <witness corresp="BLorient13270"/>
                         </listWit>
@@ -56,6 +56,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <change who="PL" when="2016-07-26">Created XML record from Ethio authority google spreadsheet</change>
          <change who="MV" when="2017-05-05">Added keywords and incipit</change>
          <change who="DR" when="2022-03-07">Transferred information from deleted LIT1860Malkea</change>
+         <change who="MV" when="2024-10-31">Corrected listWit</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -80,6 +81,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <!-- <listBibl type="mss">
                   <bibl>BN éth. 346 (20th cent.), <locus from="237v" to="242v">237v-242v</locus>: “Malke´e à l´archange Michel” (GrébGriaule I–III, 46-47, n<locus target="#42">42</locus>);</bibl>
                   <bibl>VatLib Aeth. 82 (19th cent.), <locus from="199v" to="211v">199v-211v</locus>: “Malkʾ in honorem s. Michahelis” (GréTisVat I, 316);</bibl>
+                  <bibl>VatLib Aeth. 121 (19th cent.), <locus from="89r" to="93v">89v-93v</locus>: “Invocatio rhythmica seu malkʾ, s. Michahelis” (GréTisVat I, 490);</bibl>
                   <bibl>EMML n°301 (20th cent.), <locus from="158a" to="166b">158a-166b</locus>: “Image of St Michael the Archangel” (EMML II, 1).</bibl>
                </listBibl> -->
          <listRelation>

--- a/2001-3000/LIT2835RepCh119.xml
+++ b/2001-3000/LIT2835RepCh119.xml
@@ -19,9 +19,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
-                  <p>
+                 
                                     This file is licensed under the Creative Commons
-                                    Attribution-ShareAlike 4.0. </p>
+                                    Attribution-ShareAlike 4.0. 
                </licence>
             </availability>
          </publicationStmt>
@@ -57,6 +57,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <change who="MV" when="2017-05-05">Added keywords and incipit</change>
          <change who="DR" when="2022-03-07">Transferred information from deleted LIT1860Malkea</change>
          <change who="MV" when="2024-10-31">Corrected listWit</change>
+         <change when="2024-11-04" who="ES">added text and bibl from Augustine Dickinson's database</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -67,26 +68,66 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                   <ptr target="bm:Chaine1913Rep"/>
                   <citedRange unit="item">119</citedRange>
                </bibl>
+               <bibl><ptr target="bm:MgWebsite"/></bibl>
+               <bibl><ptr target="bm:Malkea2020Am"/></bibl>
+               <bibl><ptr target="bm:MalkaGubae1974"/></bibl>
+               <bibl><ptr target="bm:ZekraAbaw"/></bibl>
             </listBibl>
          </div>
-         <div type="edition">
-      
-            <div type="textpart" subtype="incipit">
-               <ab>መልክአ፡ ሚካኤል። ሰላም፡ ለዝክረ፡ ስምከ፡ ምስለ፡ ስመ፡ ልዑል፡ ዘተሳተፈ፡ ወልደ፡ ያሬድ፡ ሔኖክ፡ በከመ፡ ጸሐፈ፡ ሶበ፡ እጼውዕ፡ ስመከ፡ ከሢትየ፡ አፈ፡ ራዳኤ፡ ምንዱባን፡ ሚካኤል፡ በከመ፡ ታለምድ፡ ዘልፈ።</ab>
+         <div type="edition" xml:lang="gez">
+            <div type="textpart" xml:id="masgabiya">
+               <lg type="stanza" n="1">
+                  <l n="1">በስመ፡ እግዚአብሔር፡ ዘይነብር፡ ማኔ፨</l>
+                  <l n="2">ወበስመ፡ እግዚአብሔር፡ ወልድ፡ ሥጋ፡ ማርያም፡ ተከዳኔ፨</l>
+                  <l n="3">ወበስመ፡ እግዚአብሔር፡ መንፈስ፡ ቅዱስ፡ ዘይሥዕር፡ ግማኔ፨</l>
+                  <l n="4">እወጥን፡ ዝክረ፡ ውዳሴከ፡ በሐዳስ፡ ኵርጓኔ፨</l>
+                  <l n="5">ቤዝወኒ፡ ሚካኤል፡ እምሲኦል፡ ኵነኔ፨</l>
+               </lg>
             </div>
-            <div type="textpart" subtype="explicit">
-               <ab>ሰላም፡ ለከ፡ ቅድመ፡ እግዚእከ፡ ስግድ፡ ዘበአድንኖ፡ ሰአሎ፡ ከመ፡ ይባርከነ፡ ሰፊሆ፡ የማኖ። አምላከ፡ ቅዱስ፡ ዕቀበኒ፡ ወአድኅነኒ፡ እምካራ፡ ሥጋ፡ ወነፍስ፡ ለገብርከ፡ ለዓለመ፡ ዓለም፡ አሜን።</ab>
+            <div type="textpart" xml:id="malke">
+               <lg type="stanza" n="1">
+                  <l n="1">ሰላም፡ ለዝክረ፡ ስምከ፡ ምስለ፡ ስመ፡ ልዑል፡ ዘተሳተፈ፨</l>
+                  <l n="2">ወልደ፡ ያሬድ፡ ሄኖክ፡ በከመ፡ ጸሐፈ፨</l>
+                  <l n="3">ሶበ፡ እጼውዕ፡ ስመከ፡ ከሢትየ፡ አፈ፨</l>
+                  <l n="4">ራዳኤ፡ ምንዱባን፡ ሚካኤል፡ በከመ፡ ታለምድ፡ ዘልፈ፨</l>
+                  <l n="5">ለረዲኦትየ፡ ነዓ፡ ሰፊሐከ፡ ክንፈ፨</l>
+               </lg>
+               <lg type="stanza" n="2">
+                  <l n="1">ሰላም፡ ለሥዕርተ፡ ርእስከ፡ ዘኢይጤየቅ፡ ግዕዛ፨</l>
+                  <l n="2">ሚካኤል፡ ካህን፡ አጸንሓሔ፡ ሠናይ፡ ጼና፡ መዐዛ፨</l>
+                  <l n="3">በጺሐከ፡ ግብተ፡ ለነፍስየ፡ አመ፡ ትካዛ፨</l>
+                  <l n="4">ለልበ፡ ዚአየ፡ በትንባሌከ፡ ናዝዛ፨</l>
+                  <l n="5">እንበለ፡ ጊዜ፡ ወላሕ፡ ኢይርሳዕ፡ ወሬዛ፨</l>
+               </lg>
+               <lg type="stanza" n="44">
+                  <l n="1">ሰላም፡ ለቆምከ፡ ዘአሕመልመለ፡ ከመ፡ ዘግባ፨</l>
+                  <l n="2">ለጽርሐ፡ አርያም፡ በዐውደ፡ መርኅባ፨</l>
+                  <l n="3">ሚካኤል፡ የዋህ፡ ለገነተ፡ ሰማይ፡ ርግባ፨</l>
+                  <l n="4">ከመ፡ ይዜውራኒ፡ ለመርቄ፡ ኀጢአት፡ እምላህባ፨</l>
+                  <l n="5">አክናፊከ፡ ክልኤ፡ ዲቤየ፡ ይርብባ፨</l>
+               </lg>
+               <lg type="stanza" n="45">
+                  <l n="1">ሰላም፡ ሰላም፡ ለመላክኢከ፡ ኵሎን፨</l>
+                  <l n="2">በበ፡ አስማቲሆን፨</l>
+                  <l n="3">ሚካኤል፡ ካህን፡ ሥርግወ፡ ብርሃን፨</l>
+                  <l n="4">ሠናይ፡ ተዐርኮትከ፡ በኵሉ፡ ዘመን፨</l>
+                  <l n="5">ሰራዬ፡ ኀጢአት፡ አንተ፡ ዐርከ፡ ነፍስ፡ ምእመን፨</l>
+               </lg>
+               <lg type="stanza" n="46">
+                  <l n="1">አምኃ፡ ሰላም፡ አቅረብኩ፡ ለመላክኢከ፡ ኵሉ፨</l>
+                  <l n="2">ለለ፡ አሐዱ፡ አሐዱ፡ ዘበበ፡ ክፍሉ፨</l>
+                  <l n="3">ሚካኤል፡ ብኩር፡ ለልዑል፡ መልአከ፡ ኀይሉ፨</l>
+                  <l n="4">ተወኪፈከ፡ አምኃየ፡ እምኑኀ፡ ሰማያት፡ ዘላዕሉ፨</l>
+                  <l n="5">ዕሤተ፡ ጸሎትየ፡ ፈኑ፡ ወዐስብየ፡ ድሉ፨</l>
+               </lg>
             </div>
          </div>
-         <!-- <listBibl type="mss">
-                  <bibl>BN éth. 346 (20th cent.), <locus from="237v" to="242v">237v-242v</locus>: “Malke´e à l´archange Michel” (GrébGriaule I–III, 46-47, n<locus target="#42">42</locus>);</bibl>
-                  <bibl>VatLib Aeth. 82 (19th cent.), <locus from="199v" to="211v">199v-211v</locus>: “Malkʾ in honorem s. Michahelis” (GréTisVat I, 316);</bibl>
-                  <bibl>VatLib Aeth. 121 (19th cent.), <locus from="89r" to="93v">89v-93v</locus>: “Invocatio rhythmica seu malkʾ, s. Michahelis” (GréTisVat I, 490);</bibl>
-                  <bibl>EMML n°301 (20th cent.), <locus from="158a" to="166b">158a-166b</locus>: “Image of St Michael the Archangel” (EMML II, 1).</bibl>
-               </listBibl> -->
+
+      
          <listRelation>
             <relation name="ecrm:P129_is_about" active="LIT2835RepCh119" passive="PRS7049Michael"/>
             <relation name="betmas:formerlyAlsoListedAs" active="LIT2835RepCh119" passive="LIT1860Malkea"/>
+            <relation name="skos:exactMatch" active="LIT2835RepCh119" passive="https://w3id.org/malke/2835/"></relation>
          </listRelation>
       </body>
    </text>

--- a/new/LIT7112Asmat.xml
+++ b/new/LIT7112Asmat.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1"><foreign xml:lang="gez">ʾAsmāt</foreign>-names of St Michael</title>
+                <title xml:lang="en" xml:id="t1">Names of the Archangel Michael</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT7112Asmat.xml
+++ b/new/LIT7112Asmat.xml
@@ -1,0 +1,79 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7112Asmat" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1"><foreign xml:lang="gez">ʾAsmāt</foreign>-names of St Michael</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2024-10-31">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT7112Asmat" passive="BAVet121"/>
+                </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>
+                        The following incipit is taken from <ref type="mss" corresp="BAVet121"/> according to
+                        <bibl><ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">490</citedRange></bibl>.</note>
+                    <ab>
+                        በስመ፡ አብ፡ <gap reason="ellipsis" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/>ኅቡዓት፡ አስማቲሁ፡ ለቅዱስ፡ ሚካኤል፡ ሊቀ፤ 
+                        መላእክት፡ ኤኮስ፡ አስሌ፤ ኤፓ፤ ኤፓስ፡ ኤንካ፡ ኤንኪ፤
+                    </ab>
+                </div>       
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>The following explicit is taken from <ref type="mss" corresp="BAVet121"/> according to
+                        <bibl><ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">490-491</citedRange></bibl>.</note>
+                    <ab>
+                        ወይርኃቁ፨ እምኔነ፡ ሠራዊተ፡ ዲያብሎስ፤ ወአጋንንቲሁ፡ ዘመዓልት፡ ወዘሌሊት፡ ዘቀትር፡ ወዘምሴት፤ እለ፡ ያደነግፁ፤ ነፍሰ፡ ወሥጋ፡ 
+                        <sic resp="PRS4805Grebaut PRS9530Tisseran">ይዘረው፡</sic> ከመ፡ ጢስ፤ በነፋስ፡ <gap reason="ellipsis" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/> 
+                        ዕቀበኒ፡ ወአድኅነኒ፤ እመከራ፤ ሥጋ፡ ወነፍስ፡ ለገብርከ፨
+                    </ab>
+                </div>       
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7126Asmat.xml
+++ b/new/LIT7126Asmat.xml
@@ -1,0 +1,78 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7126Asmat" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1"><foreign xml:lang="gez">ʾAsmāt</foreign>-names of God found by St Michael</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2024-10-31">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LIT7126Asmat" passive="BAVet121"/>
+                </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>
+                        The following incipit is taken from <ref type="mss" corresp="BAVet121"/> according to
+                        <bibl><ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">491</citedRange></bibl>.</note>
+                    <ab>
+                        ያኮስ፡ አሜእ፡ ሌኬ፡ ኤንካዕ፡ ከዜዕ፤ ኮርናዕ፤ ክዮን፤ ኤፔካ፡ ኤሎ፤
+                    </ab>
+                </div>       
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>The following explicit is taken from <ref type="mss" corresp="BAVet121"/> according to
+                        <bibl><ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">491</citedRange></bibl>.</note>
+                    <ab>
+                        እሉ፡ ኩብራት፡ ወኅቡዓት፨ አስማቲ<supplied reason="omitted">ሁ፡</supplied> ለእግዚእነ፡ ዘተረክቡ፤ በእደ፡ ቅዱስ፡ ሊቀ፡ መላእክት፡ ሚካኤል፡ መግረሬ፡ 
+                        ፀር፡ ወጸላእት፡ ወከማሁ፡ አግርር፡ ሊተ፡ ለገብርከ፡ ገብረ፡ <space reason="unknown" extent="unknown"/> ይትባረክ፡ እግዚአብሔር፡ ዘአፈጸመኒ፡ በዳኅና፡ 
+                        ወበሰላም፨
+                    </ab>
+                </div>       
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7126Asmat.xml
+++ b/new/LIT7126Asmat.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1"><foreign xml:lang="gez">ʾAsmāt</foreign>-names of God found by St Michael</title>
+                <title xml:lang="en" xml:id="t1">Names of God found by the Archangel Michael</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>


### PR DESCRIPTION
Dear all,
two new records from BAVet121 and some additional information in LIT1295Dersan concerning the titles of the miracles and commemorative notices, as well as some comments on the distribution of the textparts in BAVet82 and BAVet121. No incipits/explicits because as far as I understood BMLacq776 is possibly a better manuscript. I think a deep check of the entire tradition on DM, with all specific work records, requires a separate branch