### PR TITLE
Create records for the Maṣḥafa falāsfā ṭabibān

### DIFF
--- a/1001-2000/LIT1925Mashaf.xml
+++ b/1001-2000/LIT1925Mashaf.xml
@@ -58,7 +58,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                Collection of sentences and sayings of Greek philosophers, Fathers of the Church and biblical figures. Some apophthegms are anonymous.
                The work was translated from the Arabic <foreign xml:lang="ar">Kitāb al-bustān wa-qāʿidat al-ḥukamāʾ wa-šams al-ʾādāb</foreign> between
                1510 and 1522 by <persName role="translator" ref="PRS7077Mikael"/> and enjoyed much popularity given the high number of manuscripts.
-               There exist a short and a long recension of the work. The <ref type="work" corresp="LIT7144MFTabiban">short recension</ref> generally
+               There is a short and a long recension of the work. The <ref type="work" corresp="LIT7144MFTabiban">short recension</ref> generally
                preserves the Arabic text. The <ref type="work" corresp="LIT7145MFTabiban">long recension</ref> includes additional sayings of the Church Fathers
                and other stories, especially of <persName ref="PRS1499Ahiqar"/>.</p>
             <p>

--- a/1001-2000/LIT1925Mashaf.xml
+++ b/1001-2000/LIT1925Mashaf.xml
@@ -48,11 +48,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language><language ident="ar">Arabic</language><language ident="gez">Gǝʿǝz</language></langUsage>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="ar">Arabic</language>
+            <language ident="gez">Gǝʿǝz</language>
+         </langUsage>
          <abstract>
-            <p>There exist a short and a long recension of the <foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>. The short recension generally
-            preserves the Arabic text. To the long recension, sayings of the Church fathers and other stories,
-            especially of <persName ref="PRS1499Ahiqar"/>, have been added.</p>
+            <p>
+               Collection of sentences and sayings of Greek philosophers, Fathers of the Church and biblical figures. Some apophthegms are anonymous.
+               The work was translated from the Arabic <foreign xml:lang="ar">Kitāb al-bustān wa-qāʿidat al-ḥukamāʾ wa-šams al-ʾādāb</foreign> between
+               1510 and 1522 by <persName role="translator" ref="PRS7077Mikael"/> and enjoyed much popularity given the high number of manuscripts.
+               There exist a short and a long recension of the work. The <ref type="work" corresp="LIT7144MFTabiban">short recension</ref> generally
+               preserves the Arabic text. The <ref type="work" corresp="LIT7145MFTabiban">long recension</ref> includes additional sayings of the Church Fathers
+               and other stories, especially of <persName ref="PRS1499Ahiqar"/>.</p>
             <p>
                <listBibl type="secondary">
                   <bibl>
@@ -79,6 +87,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="DR" when="2016-11-15">Updated title and added bibliography</change>
          <change who="DR" when="2017-03-21">Added keywords</change>
          <change who="DR" when="2017-03-17">Added keywords</change>
+         <change who="MV" when="2024-11-15">Expanded abstract, added relations</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -86,7 +95,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <listRelation>
             <relation name="saws:isVersionInAnotherLanguageOf" active="LIT1925Mashaf#t1" passive="LIT1925Mashaf#t2arabic"/>
             <relation name="saws:isAttributedToAuthor" active="LIT1925Mashaf#t2arabic" passive="PRS7509Nasralla">
-               <desc>It is not clear whether <persName ref="PRS7509Nasralla"/>, who is otherwise unknown, is the compiler or author.
+               <desc>It is not clear whether <persName ref="PRS7509Nasralla"/>, who is otherwise unknown, is the compiler or author of the Arabic work.
                   <bibl>
                      <ptr target="bm:Pietruschka2005EAEFalasfa"/>
                   </bibl>
@@ -121,7 +130,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </bibl>
             </listBibl>
 
-       
          </div>
       </body>
    </text>

--- a/new/LIT7144MFTabiban.xml
+++ b/new/LIT7144MFTabiban.xml
@@ -33,7 +33,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <creation/>
             <abstract>
                 <p>
-                    This is the short recension of the <foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>.
+                    This is the short recension of the <ref type="work" corresp="LIT1925Mashaf">Maṣḥafa falāsfā ṭabibān</ref>.
+                    This recension is different from <ref type="work" corresp="LIT7145MFTabiban"/>,
+                    especially in the second part of the work ((see <bibl>
+                        <ptr target="bm:Zotenberg1877Catalogue"/>
+                        <citedRange unit="page">260-261</citedRange>.
+                    </bibl>).
                 </p>
             </abstract>
             <textClass>

--- a/new/LIT7144MFTabiban.xml
+++ b/new/LIT7144MFTabiban.xml
@@ -6,8 +6,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">Maṣḥafa falāsfā ṭabibān (short recension)</title>
-                <title xml:lang="en" corresp="#t1">The book of the wise philosophers</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Maṣḥafa falāsfā ṭabibān</title>
+                <title xml:lang="en" corresp="#t1">The book of the wise philosophers (short recension)</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -33,7 +33,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <creation/>
             <abstract>
                 <p>
-                    <!-- Add abstract -->
+                    This is the short recension of the <foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>.
                 </p>
             </abstract>
             <textClass>
@@ -57,16 +57,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listRelation>
-               <!--  
-                <relation name="saws:isVersionInAnotherLanguageOf" active="LIT1925Mashaf#t1" passive="LIT1925Mashaf#t2arabic"/>
-                <relation name="saws:isAttributedToAuthor" active="LIT1925Mashaf#t2arabic" passive="PRS7509Nasralla">
-                    <desc>It is not clear whether <persName ref="PRS7509Nasralla"/>, who is otherwise unknown, is the compiler or author.-->
-                        <bibl>
-                            <ptr target="bm:Pietruschka2005EAEFalasfa"/>
-                        </bibl>
-                    </desc>
-                </relation>
-                <relation name="saws:isAttributedToAuthor" active="LIT1925Mashaf#t1" passive="PRS7077Mikael"/>
+                <listRelation>
+                    <relation name="saws:isVersionOf" active="LIT7144MFTabiban" passive="LIT1925Mashaf"/>
+                    <relation name="saws:isDifferentTo" active="LIT7144MFTabiban" passive="LIT7145MFTabiban"/>
+                </listRelation>
             </listRelation>
             <div type="bibliography">
                 <listBibl type="secondary">
@@ -91,33 +85,36 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <div type="edition">
                     <div type="textpart" subtype="incipit" xml:lang="gez">
                         <note>
-                            The following incipit is taken from <ref type="mss" corresp="BAVet118#i3"/></note>
+                            The following incipit is taken from <ref type="mss" corresp="BNFet157#ms_i3"/> according to <bibl><ptr target="bm:Zotenberg1877Catalogue"/>
+                                <citedRange unit="page">260</citedRange></bibl>. It corresponds to <bibl>
+                                    <ptr target="bm:Dillmann1866Chrestomathia"/>
+                                    <citedRange unit="page">40</citedRange>
+                                </bibl>.
+                        </note>
                         <ab>
-                            በስመ፡ እግዚአብሔር፡ መሐሪ፡ ወመስተሣህል፡ ንወጥን፡ በጽሒፈ፡ መጽሐፈ፡ ጠቢባን፡ ዘተናገሩ፡ ቦቱ፡ 
-                            ለለ፩፩እምኔሆሙ፡ በአምጣነ፡ ክሂሎቶሙ፡ ይቤ፡ ጠቢብ፡ ወሬዛ፡ ጠቢብ፡ ይኄይስ፡ እምአረጋዊ፡ አብድ፡
-                            <!-- Continuare qui per mostrare differenza con la recensione lunga -->
+                            በስመ፡ እግዚአብሔር፡ መሓሪ፡
+                            ወመስተሣህል፡ ወላዕሌሁ፡ ትውክልትነ፡ ወረድኤትነ፡ ዘውእቱ፡ ይሁብ፡ መክፈልተ፡ ሀብታት፡ በከመ፡ ፈቀደ፤
+                            ውእቱ፡ ይጼጉ፡ ወውእቱ፡ ያስተነቢ፡ ወይሁብ፡ መንፈሶ፡ ለኵሉ፡ <gap reason="omitted" extent="unknown" resp="PRS10747Zotenbe"/>
+                            ንዌጥን፡ በረድኤተ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ በጽሒፈ፡ መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡ ዘተናገሩ፡ ባቲ፡ ለለ፡ ፩፡
+                            እምኔሆሙ፡ በአምጣነ፡ ክሂሎቱ፤
                         </ab>
-                    </div>       
-                    <div type="textpart" subtype="explicit" xml:lang="gez">
-                        <note>The following explicit is taken from <ref type="mss" corresp="BAVet118#i3"/> </note>
+                    </div>      
+                    <div type="textpart" subtype="sentence" xml:id="MainText">
+                        <note>
+                            The following incipit is taken from <ref type="mss" corresp="BNFet157#ms_i3"/> according to <bibl><ptr target="bm:Zotenberg1877Catalogue"/>
+                                <citedRange unit="page">260</citedRange></bibl>.
+                        </note>
                         <ab>
-                            ይቤ፡ ስቅራጥስ፡ ለአርዳኢሁ፡ ኩኑ፡ ድልዋነ፡ ለሞት፡ ለተዘክሮ፡ ከመ፡ ይፈድፍድ፡ <supplied reason="omitted">ሕ</supplied>ይወትክሙ፡ 
-                            ወዓዲ፡ ይቤሎሙ፡ ለእመ፡ ፈቀድክሙ፡ 
-                            <sic>ትሕየው፡</sic>
-                            በሠናይ፡ አኅፅፁ፡ አጥርዮ፡ 
-                            ከመ፡ ይኅፅፅ፡ ትካዝክሙ፡ <del rend="expunctuated">ሰ</del>ዘሰ፡ <choice>
-                                <sic>ትውኀበ፡</sic>
-                                <corr resp="PRS4805Grebaut PRS9530Tisseran">ተውኅበ፡</corr>
-                            </choice> 
-                            <sic>ጥብብ፡</sic>
-                            ኢይኅዝን፡ በእንተ፡ ኃጢአ፡ ወርቅ፡ ወብሩር፡ 
-                            አማኅፀንኩክሙ፡ ፍርህዎ፡ ለእግዚአብሔር፡ ወዕቀቡ፡ ትእዛዞ፡ ተፈጸመ፡ መጽሐፈ፡ ጥበብ፡ ስብሐት፡ 
-                            ለእግዚአብሔር፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን።
+                            ይቤ፡ ጠቢብ፡ ወሬዛ፡ ጠቢብ፡ ይኄይስ፡ እምነ፡ አረጋዊ፡ አብድ። ተብህለ፡ እስመ፡ ተግሣጽሰ፡ ይከብር፡ እምነ፡ አዕናቍ፡ ክቡራት፡
+                            ወያከብር፡ ዘመደ፡ ኅሡራን፡ ወያቀውሞሙ፡ ውስተ፡ ምቅዋመ፡ ክቡራን፡ ወያከብር፡ እንበለ፡ ተባይጾ፡ ወያብዝኅ፡ ረድኤተ፡ እንዘ፡ አልቦቱ፡ ዘርእ። ተብህለ፡
+                            እስመ፡ ጥበብሰ፡ ይጸንዕ፡ እምነ፡ ዘመድ፡ ብዙኃን፡ ወአእምሮሂ፡ ይከብር፡ እምነ፡ ዘመድ፡ ክቡራን። ተብህለ፡ ግዕዝ፡ ሠናይ፡ ይኄይስ፡
+                            እምነ፡ ቢጽ፡ ሠናይ፡ ወመጽሐፍሂ፡ ናዛዚሁ፡ ለትኩዝ፡ ውእቱ። ተብህለ፡ ሕስዋ፡ ለጥበብ፡ እስመ፡ ይእቲ፡ ተውሳከ፡ ልቡና፡ ወመራኂተ፡
+                            ፍኖት፡ ይእቲ፡ ወዓርክ፡ ይእቲ፡ በውስተ፡ ተአንግዶ፡ ወሞገስ፡ ይእቲ፡ በውስተ፡ ጉባኤ። ተብህለ፡ መቅድመ፡ ኵሉ፡ ዘይፈቅድ፡ ባቲ፡
+                            ሰብእ፡ ልቡና፡ ወተግሣጽ፡ ወጽድቅ፡ ወትዕግሥት፡ ወጥበብ፡ ወንጽሕና፡ ወተገድሎ፡ ወአእኵቶ፡ ወጸልዮ፡ ጸሎታት፡ እንተ፡ ይእቲ፡ መሠረተ፡ ሃይማኖት፡ ዘታበጽሕ፡ ኀበ፡
+                            ፈጣሪ፡ ሎቱ፡ ስብሐት። ወጽድቀ፡ ቃል፡ ወዜና፡ ወርኂቅ፡ እመሐላ፡ በሐሰት፡ ወተቀብሎ፡ በገጽ፡ ፍሡሕ፤ ወአክብሮ፡ አናግድ፡ ወአሠንዮ፡ ለኵሉ፡ ወዓዊበ፡ ጎር፡
                         </ab>
-                    </div>       
+                    </div>
                 </div>
-                
-                
             </div>
         </body>
     </text>

--- a/new/LIT7144MFTabiban.xml
+++ b/new/LIT7144MFTabiban.xml
@@ -1,0 +1,124 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7144MFTabiban" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Maṣḥafa falāsfā ṭabibān (short recension)</title>
+                <title xml:lang="en" corresp="#t1">The book of the wise philosophers</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>
+                    <!-- Add abstract -->
+                </p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Philosophy"/>
+                    <term key="Theology"/>
+                    <term key="Translation"/>
+                    <term key="Paks2"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2024-11-13">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listRelation>
+               <!--  
+                <relation name="saws:isVersionInAnotherLanguageOf" active="LIT1925Mashaf#t1" passive="LIT1925Mashaf#t2arabic"/>
+                <relation name="saws:isAttributedToAuthor" active="LIT1925Mashaf#t2arabic" passive="PRS7509Nasralla">
+                    <desc>It is not clear whether <persName ref="PRS7509Nasralla"/>, who is otherwise unknown, is the compiler or author.-->
+                        <bibl>
+                            <ptr target="bm:Pietruschka2005EAEFalasfa"/>
+                        </bibl>
+                    </desc>
+                </relation>
+                <relation name="saws:isAttributedToAuthor" active="LIT1925Mashaf#t1" passive="PRS7077Mikael"/>
+            </listRelation>
+            <div type="bibliography">
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:Pietruschka2005EAEFalasfa"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Cornill1875Falasfa"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Euringer1941Lehrsprueche"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Pietruschka2002Falasfa"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Goldschmidt1893Bibliotheca"/>
+                        <citedRange unit="page">20-21</citedRange>
+                    </bibl>
+                </listBibl>
+                
+                <div type="edition">
+                    <div type="textpart" subtype="incipit" xml:lang="gez">
+                        <note>
+                            The following incipit is taken from <ref type="mss" corresp="BAVet118#i3"/></note>
+                        <ab>
+                            በስመ፡ እግዚአብሔር፡ መሐሪ፡ ወመስተሣህል፡ ንወጥን፡ በጽሒፈ፡ መጽሐፈ፡ ጠቢባን፡ ዘተናገሩ፡ ቦቱ፡ 
+                            ለለ፩፩እምኔሆሙ፡ በአምጣነ፡ ክሂሎቶሙ፡ ይቤ፡ ጠቢብ፡ ወሬዛ፡ ጠቢብ፡ ይኄይስ፡ እምአረጋዊ፡ አብድ፡
+                            <!-- Continuare qui per mostrare differenza con la recensione lunga -->
+                        </ab>
+                    </div>       
+                    <div type="textpart" subtype="explicit" xml:lang="gez">
+                        <note>The following explicit is taken from <ref type="mss" corresp="BAVet118#i3"/> </note>
+                        <ab>
+                            ይቤ፡ ስቅራጥስ፡ ለአርዳኢሁ፡ ኩኑ፡ ድልዋነ፡ ለሞት፡ ለተዘክሮ፡ ከመ፡ ይፈድፍድ፡ <supplied reason="omitted">ሕ</supplied>ይወትክሙ፡ 
+                            ወዓዲ፡ ይቤሎሙ፡ ለእመ፡ ፈቀድክሙ፡ 
+                            <sic>ትሕየው፡</sic>
+                            በሠናይ፡ አኅፅፁ፡ አጥርዮ፡ 
+                            ከመ፡ ይኅፅፅ፡ ትካዝክሙ፡ <del rend="expunctuated">ሰ</del>ዘሰ፡ <choice>
+                                <sic>ትውኀበ፡</sic>
+                                <corr resp="PRS4805Grebaut PRS9530Tisseran">ተውኅበ፡</corr>
+                            </choice> 
+                            <sic>ጥብብ፡</sic>
+                            ኢይኅዝን፡ በእንተ፡ ኃጢአ፡ ወርቅ፡ ወብሩር፡ 
+                            አማኅፀንኩክሙ፡ ፍርህዎ፡ ለእግዚአብሔር፡ ወዕቀቡ፡ ትእዛዞ፡ ተፈጸመ፡ መጽሐፈ፡ ጥበብ፡ ስብሐት፡ 
+                            ለእግዚአብሔር፡ ለዓለመ፡ ዓለም፡ አሜን፡ ወአሜን።
+                        </ab>
+                    </div>       
+                </div>
+                
+                
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7145MFTabiban.xml
+++ b/new/LIT7145MFTabiban.xml
@@ -32,7 +32,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <creation/>
                 <abstract>
                     <p>
-                        This is the long recension of the <foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>, containing additional sayings of the Church Fathers
+                        This is the long recension of the <ref type="work" corresp="LIT1925Mashaf">Maṣḥafa falāsfā ṭabibān</ref>, containing additional sayings of the Church Fathers
                         and other stories, especially of <persName ref="PRS1499Ahiqar"/>. 
                         This recension is different from <ref type="work" corresp="LIT7144MFTabiban"/>,
                         especially in the second part of the work. Several sentences are missing, others are more developed or followed by a commentary. 

--- a/new/LIT7145MFTabiban.xml
+++ b/new/LIT7145MFTabiban.xml
@@ -1,0 +1,141 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7145MFTabiban" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Maṣḥafa falāsfā ṭabibān (long recension)</title>
+                <title xml:lang="en" corresp="#t1">The book of the wise philosophers</title>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>
+                    <!-- Add abstract -->
+                </p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Philosophy"/>
+                    <term key="Theology"/>
+                    <term key="Translation"/>
+                    <term key="Paks2"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2024-11-13">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listRelation>
+                <!--  
+                <relation name="saws:isVersionInAnotherLanguageOf" active="LIT1925Mashaf#t1" passive="LIT1925Mashaf#t2arabic"/>
+                <relation name="saws:isAttributedToAuthor" active="LIT1925Mashaf#t2arabic" passive="PRS7509Nasralla">
+                    <desc>It is not clear whether <persName ref="PRS7509Nasralla"/>, who is otherwise unknown, is the compiler or author.-->
+                <bibl>
+                    <ptr target="bm:Pietruschka2005EAEFalasfa"/>
+                </bibl>
+                </desc>
+                </relation>
+                <relation name="saws:isAttributedToAuthor" active="LIT1925Mashaf#t1" passive="PRS7077Mikael"/>
+            </listRelation>
+            <div type="bibliography">
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:Pietruschka2005EAEFalasfa"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Cornill1875Falasfa"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Euringer1941Lehrsprueche"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Pietruschka2002Falasfa"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Goldschmidt1893Bibliotheca"/>
+                        <citedRange unit="page">20-21</citedRange>
+                    </bibl>
+                </listBibl>
+                
+                <div type="edition">
+                    <div type="textpart" subtype="incipit" xml:lang="gez">
+                        <note>
+                            The following incipit is taken from <ref type="mss" corresp="BAVet118#i2"/></note>
+                        <ab>
+                            ንዌጥን፡ በረድኤተ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ በጽሒፈ፡ መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡ ዘተናገሩ፡ 
+                            ባቲ፡ ለለ፩፩፡ እምኔሆሙ፡ በአምጣነ፡ ክሂሎቶሙ፡ ወናሁ፡ አስተጋብኡ፡ ውስቴታ፡ ነገረ፡ ምዕዳን፡ 
+                            ብዙኃ<supplied reason="omitted">ት</supplied>፡ <choice>
+                                <sic>ወተገሣጸ፡</sic>
+                                <corr resp="PRS4805Grebaut PRS9530Tisseran">ወተግሣጽ፡</corr>
+                            </choice> ሠናያት፡ ወዜና፡ ቅሥምተ፡ ከመ፡ ፄው፡ <gap reason="omitted" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/> 
+                            <locus target="#32r"/> ይቤ፡ እንከ፡ እስመ፡ 
+                            ዘያነብብ፡ <supplied reason="omitted">ለ</supplied>ዛቲ፡ መጽሐፍ፡ አምላካዊት፡ ዘልፈ፡ 
+                            ይረክብ፡ ረባሐ፡ እስመ፡ መጽሕፍትሰ፡ መካነ፡ መዝገበ፡ አእምሮ፡ ወጥበብ፡ እሙንቱ፡ <gap reason="omitted" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/> ይቤ፡ ልዎ፡ ለመነኮስ፡ በእንተ፡ ምንትኑ፡ ኀደገ፡ 
+                            ዓለመ፡ ይቤ፡ ጠየቁ፡ አነ፡ ከመ፡ አነ፡ እመጽእ፡ ምስሌሃ፡ እንበለ፡ ፈቃድከ፡ ወካዕበ፡ ይቤልዎ፡ 
+                            ለመነኮስ፡ መኑ፡ ውእቱ፡ ኃዳጌ፡ ዓለም፡ ወመናኔ፡ ዓለም፡ ይቤ፡ ዘያመዘግን፡ በንዋይ፡ በኅዳጥ፡ እምነ፡ 
+                            ሲሳይ፡ ወዘድልው፡ ዘልፈ፡ ለመዊት፡ ወይቤሎ፡ ለምንትኑ፡ ትለብስ፡ ሠቀ፡ ይቤ፡ ከመ፡ እትመሰሎሙ፡ 
+                            ለሰብእ፡ ምኩራን፨
+                        </ab>
+                    </div>       
+                    <div type="textpart" subtype="explicit" xml:lang="gez">
+                        <note>The following explicit is taken from <ref type="mss" corresp="BAVet118#i2"/> </note>
+                        <ab>
+                            ይቤ፡ ጠቢብ፡ ፩እምጠቢባን፡ ሐመ፡ ደዌ፡ ጽኑዓ፡ በሕማመ፡ ከርሥ፡ ወሶበ፡ ቀርበ፡ ዕለተ፡ ሞቱ፡ 
+                            ይቤልዎ፡ <choice>
+                                <sic>አርዳዊሁ፡</sic>
+                                <corr resp="PRS4805Grebaut PRS9530Tisseran">አርዳኢሁ፡</corr>
+                            </choice> እስመ፡ ጠቢብ፡ አንተ፡ ዘትሁብ፡ ፈውሰ፡ ለኵሉ፡ እፎ፡ ዘይትፌወስ፡ ርእሰከ፡ ወእምዝ፡ 
+                            አውጽአ፡ ማየ፡ ዘድልወቱ፡ ፻፡ 
+                            <sic>ልጥረ፡</sic>
+                            <sic>ወወድየ፡</sic>
+                            ውስቴቱ፡ ፩፡ 
+                            <sic>ድኅርመ፡</sic>
+                            መድኃኒት፡ ወአይበሶ፡ ወኮነ፡ ከመ፡ ዕብን፡ 
+                            ኢትሬእዩኑ፡ ዘከመ፡ አይበስኩ፡ 
+                            <sic>በ፩ድሕርመ፡</sic>
+                            መድኃኒት፡ ፻፡ <add place="above">ል</add>ጥረ፡ 
+                            ማይ፡ ወእምይእዜሰ፡ በላዕኩ፡ <gap reason="illegible"/>ጥረ፡ 
+                            <sic>መድኃኒት፡</sic>
+                            ዘአይበሰ፡ ፩ልጥረ፡ ማይ፡ ወናሁ፡ ስዕ<supplied reason="omitted">ን</supplied>ኩ፡ ፈውሶ፡ ሕማመ፡ 
+                            ከርሥየ፡ በውእቱ፡ መድኃኒት፡ ወሶበ፡ በጽሐ፡ ለሰብእ፡ ጽኑዕ፡ ደዌ፡ 
+                            <sic>ወኢቀረበ፡</sic>
+                            ዕለተ፡ ሞቱ፡ ይክል፡ ፈውሶቶ፡ መድኃኒት፡ ወሶበ፡ ቀርበ፡ ዕለተ፡ ሞቱ፡ ኢይክል፡ ፈውሶቶ፡ መስኃኒት፨
+                        </ab>
+                    </div>       
+                </div>
+                
+                
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7145MFTabiban.xml
+++ b/new/LIT7145MFTabiban.xml
@@ -6,8 +6,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">Maṣḥafa falāsfā ṭabibān (long recension)</title>
-                <title xml:lang="en" corresp="#t1">The book of the wise philosophers</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Maṣḥafa falāsfā ṭabibān</title>
+                <title xml:lang="en" corresp="#t1">The book of the wise philosophers (long recension)</title>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
@@ -30,11 +30,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </encodingDesc>
         <profileDesc>
             <creation/>
-            <abstract>
-                <p>
-                    <!-- Add abstract -->
-                </p>
-            </abstract>
+                <abstract>
+                    <p>
+                        This is the long recension of the <foreign xml:lang="gez">Maṣḥafa falāsfā ṭabibān</foreign>, containing additional sayings of the Church Fathers
+                        and other stories, especially of <persName ref="PRS1499Ahiqar"/>. 
+                        This recension is different from <ref type="work" corresp="LIT7144MFTabiban"/>,
+                        especially in the second part of the work. Several sentences are missing, others are more developed or followed by a commentary. 
+                        The sentences preceding and following that of Plato are arranged in
+                        a different order.
+                        The three paragraphs with the three anachoretes' sentences
+                        are included here at the end of the work together
+                        with other sentences by anachoretes, which in the other recension are included throughout the work.
+                        (see <bibl>
+                            <ptr target="bm:Zotenberg1877Catalogue"/>
+                            <citedRange unit="page">260-261</citedRange>.
+                        </bibl>).
+                    </p>
+                </abstract>
             <textClass>
                 <keywords>
                     <term key="ChristianLiterature"/>
@@ -56,16 +68,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listRelation>
-                <!--  
-                <relation name="saws:isVersionInAnotherLanguageOf" active="LIT1925Mashaf#t1" passive="LIT1925Mashaf#t2arabic"/>
-                <relation name="saws:isAttributedToAuthor" active="LIT1925Mashaf#t2arabic" passive="PRS7509Nasralla">
-                    <desc>It is not clear whether <persName ref="PRS7509Nasralla"/>, who is otherwise unknown, is the compiler or author.-->
-                <bibl>
-                    <ptr target="bm:Pietruschka2005EAEFalasfa"/>
-                </bibl>
-                </desc>
-                </relation>
-                <relation name="saws:isAttributedToAuthor" active="LIT1925Mashaf#t1" passive="PRS7077Mikael"/>
+                <listRelation>
+                    <relation name="saws:isVersionOf" active="LIT7145MFTabiban" passive="LIT1925Mashaf"/>
+                    <relation name="saws:isDifferentTo" active="LIT7145MFTabiban" passive="LIT7144MFTabiban"/>
+                </listRelation>
             </listRelation>
             <div type="bibliography">
                 <listBibl type="secondary">
@@ -79,61 +85,83 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <ptr target="bm:Euringer1941Lehrsprueche"/>
                     </bibl>
                     <bibl>
-                        <ptr target="bm:Pietruschka2002Falasfa"/>
-                    </bibl>
-                    <bibl>
                         <ptr target="bm:Goldschmidt1893Bibliotheca"/>
                         <citedRange unit="page">20-21</citedRange>
                     </bibl>
+                    <bibl>
+                        <ptr target="bm:Zotenberg1877Catalogue"/>
+                        <citedRange unit="page">260-261</citedRange>.
+                    </bibl>
                 </listBibl>
                 
-                <div type="edition">
-                    <div type="textpart" subtype="incipit" xml:lang="gez">
-                        <note>
-                            The following incipit is taken from <ref type="mss" corresp="BAVet118#i2"/></note>
-                        <ab>
-                            ንዌጥን፡ በረድኤተ፡ እግዚእነ፡ ኢየሱስ፡ ክርስቶስ፡ በጽሒፈ፡ መጽሐፈ፡ ፈላስፋ፡ ጠቢባን፡ ዘተናገሩ፡ 
-                            ባቲ፡ ለለ፩፩፡ እምኔሆሙ፡ በአምጣነ፡ ክሂሎቶሙ፡ ወናሁ፡ አስተጋብኡ፡ ውስቴታ፡ ነገረ፡ ምዕዳን፡ 
-                            ብዙኃ<supplied reason="omitted">ት</supplied>፡ <choice>
-                                <sic>ወተገሣጸ፡</sic>
-                                <corr resp="PRS4805Grebaut PRS9530Tisseran">ወተግሣጽ፡</corr>
-                            </choice> ሠናያት፡ ወዜና፡ ቅሥምተ፡ ከመ፡ ፄው፡ <gap reason="omitted" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/> 
-                            <locus target="#32r"/> ይቤ፡ እንከ፡ እስመ፡ 
-                            ዘያነብብ፡ <supplied reason="omitted">ለ</supplied>ዛቲ፡ መጽሐፍ፡ አምላካዊት፡ ዘልፈ፡ 
-                            ይረክብ፡ ረባሐ፡ እስመ፡ መጽሕፍትሰ፡ መካነ፡ መዝገበ፡ አእምሮ፡ ወጥበብ፡ እሙንቱ፡ <gap reason="omitted" extent="unknown" resp="PRS4805Grebaut PRS9530Tisseran"/> ይቤ፡ ልዎ፡ ለመነኮስ፡ በእንተ፡ ምንትኑ፡ ኀደገ፡ 
-                            ዓለመ፡ ይቤ፡ ጠየቁ፡ አነ፡ ከመ፡ አነ፡ እመጽእ፡ ምስሌሃ፡ እንበለ፡ ፈቃድከ፡ ወካዕበ፡ ይቤልዎ፡ 
-                            ለመነኮስ፡ መኑ፡ ውእቱ፡ ኃዳጌ፡ ዓለም፡ ወመናኔ፡ ዓለም፡ ይቤ፡ ዘያመዘግን፡ በንዋይ፡ በኅዳጥ፡ እምነ፡ 
-                            ሲሳይ፡ ወዘድልው፡ ዘልፈ፡ ለመዊት፡ ወይቤሎ፡ ለምንትኑ፡ ትለብስ፡ ሠቀ፡ ይቤ፡ ከመ፡ እትመሰሎሙ፡ 
-                            ለሰብእ፡ ምኩራን፨
-                        </ab>
-                    </div>       
-                    <div type="textpart" subtype="explicit" xml:lang="gez">
-                        <note>The following explicit is taken from <ref type="mss" corresp="BAVet118#i2"/> </note>
-                        <ab>
-                            ይቤ፡ ጠቢብ፡ ፩እምጠቢባን፡ ሐመ፡ ደዌ፡ ጽኑዓ፡ በሕማመ፡ ከርሥ፡ ወሶበ፡ ቀርበ፡ ዕለተ፡ ሞቱ፡ 
-                            ይቤልዎ፡ <choice>
-                                <sic>አርዳዊሁ፡</sic>
-                                <corr resp="PRS4805Grebaut PRS9530Tisseran">አርዳኢሁ፡</corr>
-                            </choice> እስመ፡ ጠቢብ፡ አንተ፡ ዘትሁብ፡ ፈውሰ፡ ለኵሉ፡ እፎ፡ ዘይትፌወስ፡ ርእሰከ፡ ወእምዝ፡ 
-                            አውጽአ፡ ማየ፡ ዘድልወቱ፡ ፻፡ 
-                            <sic>ልጥረ፡</sic>
-                            <sic>ወወድየ፡</sic>
-                            ውስቴቱ፡ ፩፡ 
-                            <sic>ድኅርመ፡</sic>
-                            መድኃኒት፡ ወአይበሶ፡ ወኮነ፡ ከመ፡ ዕብን፡ 
-                            ኢትሬእዩኑ፡ ዘከመ፡ አይበስኩ፡ 
-                            <sic>በ፩ድሕርመ፡</sic>
-                            መድኃኒት፡ ፻፡ <add place="above">ል</add>ጥረ፡ 
-                            ማይ፡ ወእምይእዜሰ፡ በላዕኩ፡ <gap reason="illegible"/>ጥረ፡ 
-                            <sic>መድኃኒት፡</sic>
-                            ዘአይበሰ፡ ፩ልጥረ፡ ማይ፡ ወናሁ፡ ስዕ<supplied reason="omitted">ን</supplied>ኩ፡ ፈውሶ፡ ሕማመ፡ 
-                            ከርሥየ፡ በውእቱ፡ መድኃኒት፡ ወሶበ፡ በጽሐ፡ ለሰብእ፡ ጽኑዕ፡ ደዌ፡ 
-                            <sic>ወኢቀረበ፡</sic>
-                            ዕለተ፡ ሞቱ፡ ይክል፡ ፈውሶቶ፡ መድኃኒት፡ ወሶበ፡ ቀርበ፡ ዕለተ፡ ሞቱ፡ ኢይክል፡ ፈውሶቶ፡ መስኃኒት፨
-                        </ab>
-                    </div>       
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>
+                        The following incipit is taken from <ref type="mss" corresp="BNFet159"/> according to <bibl><ptr target="bm:Zotenberg1877Catalogue"/>
+                            <citedRange unit="page">259</citedRange></bibl>.
+                    </note>
+                    <ab>
+                        በስመ፡ እግዚአብሔር፡ መሓሪ፡ ወመስተሣህል፡ ወውእቱ፡ ረዳኢነ፡ ወተስፋነ፡ ላዕለ፡ ኵሉ፡ ግብር። ንዌጥን፡ በረድኤተ፡ 
+                        እግዚአብሔር፡ በጽሒፈ፡ አንጋረ፡ ፈላስፋ፡ ዘውእቶሙ፡ ጠቢባን፡ ብሂል፡ ዘተናገሩ፡ ባቲ፡ ውስተ፡ ዛቲ፡ መጽሐፍ፡ ለለ፩፡
+                        እምኔሆሙ፡ ከመ፡ ትኩን፡ በቍዔተ፡ ለዘያነብባ፡ ወለዘይሰምዓ፡ ወይገብር፡ ባቲ።
+                    </ab>
+                </div>      
+                <div type="textpart" xml:id="Preamble" xml:lang="gez">
+                    <label>Preamble</label>
+                    <note>
+                        The following text is taken from <ref type="mss" corresp="BNFet159"/> according to <bibl><ptr target="bm:Zotenberg1877Catalogue"/>
+                            <citedRange unit="page">259-260</citedRange></bibl>.
+                    </note>
+                    <ab>
+                        ወናሁ፡ አስተጋብኡ፡ ውስቴታ፡ ብዙኀ፡ ነገረ፡ ምዕዳን፡ ወተግሣጽ፡ ሠናይ፡ ወዜና፡ ቅሱም፡ ከመ፡ ፄው። 
+                        ዘጽይሕት፡ ፍናዊሃ፡ ለዘየዓቅባ፡ ወቀሊል፡ ሰሚዖታ፡ ወያስተፌሥሕ፡ አልባበ፡ ወትሁብ፡ ልቡና፡ ለለባዊ። ዘከሩ፡
+                        ውስቴታ፡ ዝክረ፡ ሠናየ፡ ዘይረክብ፡ ባቲ፡ ኵሉ፡ መፍቅዶ። እንተ፡ ይእቲ፡ ጥበቦሙ፡ ለጠቢባን፡ ወንባቦሙ፡
+                        ለማእምራን፡ ወይእቲ፡ ትኄይስ፡ ወትትበደር፡ እምነ፡ ወርቅ፡ ወምብሩር፡ ወእምዕንቍ፡ ክቡር። ወዓዲ፡ 
+                        ትኆእይስ፡ እምጽጌ፡ ገነታት፡ ዘዘዚአሁ፡ ኅበሪሆሙ። ወዛቲሰ፡ ገነት፡ ቀሊል፡ ይእቲ፡ ጸራ። ለእመ፡ አንበብከ፡ 
+                        ውስቴታ፡ ትሁበከ፡ ኵሎ፡ መፍቅደከ፡ ወትጼግወከ፡ ልቡና፡ ፍጹመ። ወታሠምረከ፡ ወታኅረኅርኅ፡ እከይ።
+                        ወትቀስም፡ ልሳነከ፡ በፄወ፡ ጥበብ፡ ወአእምሮ፡ ወየውሃት፡ ወልቡና፡ ወትዕግሥት። ወትሬሲ፡ ግዕዘከ፡ ሠናየ፡
+                        ወኅሩየ። ወንባበከሂ፡ ጥዑመ፡ ውስተ፡ እዝነ፡ እለ፡ ይሰምዕዋ። ወትሴርሕ፡ ኵሉ፡ ፍናዊከ። ተአምር፡ በአሐቲ፡
+                        ወርኅ፡ ዘኢተአምሮ፡ በኵሉ፡ መዋዕሊከ፡ እምአፈ፡ ኵሉ፡ ዕደው፡ ጠቢባን፡ ሶበ፡ ተኀሥሣ፡ ምስለ፡ ዕረፍት፡
+                        ወኅድዓት፡ ወተቃወመከ፡ በአንቀጸ፡ ረባሕ፡ ወበቍዔት። ወዛቲ፡ ትኄይስ፡ እምኵሎን፡ መዛግብት። ወትፄኑ፡
+                        እምኵሎን፡ አፈዋት። ትትኤዘዝ፡ ለከ፡ በሌሊት፡ ከመ፡ መዓልት። ወበውስተ፡ ፍኖትከሂ፡ ትሄሉ፡ ምስሌከ።         
+                    </ab>
                 </div>
-                
+                <div type="textpart" xml:id="Sentence1" xml:lang="gez">
+                    <note>
+                        The following text is taken from <ref type="mss" corresp="BNFet159"/> according to <bibl><ptr target="bm:Zotenberg1877Catalogue"/>
+                            <citedRange unit="page">260</citedRange></bibl>.
+                    </note>
+                    <ab>
+                        ይቤ፡ ጠቢብ፡ ወሬዛ፡ ጠቢብ፡ ይኄይስ፡ እምነ፡ አረጋዊ፡ ዓብድ። ተግሣጽ፡ ወጥበብ፡ ያሌዕሉ፡ ዘመደ፡ ኅውራን፡ ወያበጽሑ፡ ኀበ፡ ምቅዋመ፡ ክቡራን። 
+                        ያከብሩ፡ በእንተ፡ ተባይጾ።
+                        ግዕዝ፡ ሠናይ፡ ይትሜሰል፡ ከመ፡ አዕርክት፡ ሠናያን። ወመጽሐፍሂ፡ ናዛዚሁ፡ ለትኩዝ፡ ውእቱ። ጥበብሰ፡ ይትዌሰኮ፡ ለብእሲ፡ ልቡና፡ ወትመርሆ፡ ፍኖተ፡ ትዕግሥት። 
+                        ጥበብሰ፡ ዓርክ፡ ይእቲ፡ አመ፡ ተአንግዶ። ወግርማ፡ ይእቲ፡ በውስተ፡ ጉባኤ። መቅድመ፡ ኵሉ፡ ይደልዎ፡ ለብእሲ፡ ከመ፡ ይዕቀብ፡ እሎንተ፡ ቃላተ። እሉ፡ እሙንቱ፡
+                        ልቡና፡ ወተግሣጽ፡ ንጽሕና፡ ወጥበብ፡ ትዕግሥት፡ ወየውሃት፡ ወአውትሮ፡ ጸሎታት፡ ወታበጽሐ፡ ለብእሲ፡ ኀበ፡ ፈጣሪሁ፡ ሎቱ፡ ስብሐት።
+                        ወዓዲ፡ ነገረ፡ ጽድቅ፡ ወርኂቅ፡ እመሐላ፡ በሐሰት፡ ወተቀብሎ፡ ሰብእ፡ በብሩህ፡ ገጽ። ወአክብሮ፡ አንጋድ፡ ወዓቂበ፡ ጎር፡ ወገቢረ፡ ሠናያት።      
+                    </ab>
+                </div>
+            <div type="textpart" xml:id="Alexander" xml:lang="gez">
+                <label>Discourse of the philosophers in presence of the body of Alexander</label>
+                <note>
+                    The following text is taken from <ref type="mss" corresp="BNFet159"/> according to <bibl><ptr target="bm:Zotenberg1877Catalogue"/>
+                        <citedRange unit="page">260</citedRange></bibl>. The text begins as follows:
+                </note>
+                <ab>
+                    መጽሐፈ፡ ምዕዳን፡ ወተግሣጽ፡ ዘተናገሩ፡ ፈላስፋ፡ ዘበትርጓሜሁ፡ መፍቀርያነ፡ ጥበብ፡ ብሂል። ነበቡ፡ ዘንተ፡ ቅድሜሁ፡ ለእስክንድር፡
+                    ንጉሥ፡ ዘ፪አቅርንቲሁ። ዘኢይፈርህ፡ መነሂ፡ ኢይፈርሆ፡ መኑሂ። ዘአርትዓ፡ ፍትሖ፡ ወተግኅሠ፡ እምዓመፃ፡ ይቀውም፡ ሎቱ፡ 
+                    ጽድቅ፡ ወይረድኦ።
+                </ab>
+            </div>
+                <div type="textpart" xml:id="PreciousPearl" xml:lang="gez">
+                    <label>Sentences and anecdotes of the Arabic "Precious Pearls of the Wise"</label>
+                    <note>
+                        The following text is taken from <ref type="mss" corresp="BNFet159"/> according to <bibl><ptr target="bm:Zotenberg1877Catalogue"/>
+                            <citedRange unit="page">260</citedRange></bibl>. The text begins as follows:
+                    </note>
+                    <ab>
+                        በስመ፡ እግዚአብሔር፡ መርሕ፡ ኀበ፡ ጽድቅ፤ ወውእቱ፡ መጋቤ፡ ረድኤት። ቃል፡ እምባሕርየ፡ ዕንቆሙ፡ ለጠቢባን። ንንግር፡
+                        እንከ፡ እምዜና፡ ነገሥት፡ ወነገረ፡ ጠቢባን፡ ወትሩፋነ፡ ምግባር።
+                    </ab>
+                </div>
                 
             </div>
         </body>


### PR DESCRIPTION
Following https://github.com/BetaMasaheft/Documentation/issues/2686#event-15281654086, I have created two new records for the short and long recensions of the Maṣḥafa falāsfā ṭabibān.

There's still much to do with single textparts, but this probably requires a specific and thorough effort because the order and presence of individual sentences seem to vary and must be checked against the single manuscripts, since there's no edition to which to refer.

MS records have been updated here: https://github.com/BetaMasaheft/Manuscripts/pull/2707