### PR TITLE
Lit1340 enoch nv

### DIFF
--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -110,9 +110,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </bibl>
                <bibl>
                   <ptr target="bm:Charles1912Enoch"/>
+                  ´Orient. 271a
                </bibl>
                <bibl>
                   <ptr target="bm:KnibbUllendorff1978Enoch1"/>
+                  based on Ethiopian MS 23
                </bibl>
                <bibl>
                   <ptr target="bm:Laurence1839Enoch"/>
@@ -120,6 +122,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </listBibl>
 
             <listBibl type="translation">
+               Silvestre de Sacy
                <bibl>
                   <ptr target="bm:KnibbUllendorff1978Enoch2"/>
                </bibl>

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -123,8 +123,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                <witness corresp="BAVcerulli75"/>
                <witness corresp="BAVcerulli110"/>
                <witness corresp="BAVcerulli131"/>
-               <!-- There are other manuscripts used for editions and translations,  but they do not  seem toexist in the bm for the moment, so I left them out. They are the following:
-               British and Foreign Bible Society Ms 187, BAV Cerulli 75, Cerulli 110, Cerulli 131, München Cod. aeth. 30, Pontificio Istituto Biblico, Banco A2, II, Princeton Ethiop.2=Garrett Dep. 1468, Zion.-->
+               <witness corresp="BSLet187"/>
+               <witness corresp="BSBaeth30"/>
+               <witness corresp="PULgarrettEth042"/>
+               <witness corresp="Parm3843"/>
+               <witness corresp="GG00151"/>
+               <witness corresp="DW01"/>
+               <witness corresp="BDLaethd18"/>
+               <witness corresp="Schoyen2657"/>
+               
+               <!-- Zion - Davis microfilms
+        Pontificio Istituto Biblico, Banco A2, II - Bausi
+        Jerusalem EOTC 5e (stub probably needed)
+        
+        >
 
 
             </listWit>

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -68,7 +68,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <witness corresp="BLorient8822" xml:id="blorient8822">BL Oriental 8822</witness>
                <witness corresp="BLorient8823" xml:id="blorient8823">BL Oriental 8823</witness>
                <witness corresp="CamAdd1570" xml:id="camadd1570">CUL Add. 1570</witness>
-               <witness corresp="EMML36" xml:id="emml36">MML no. 36</witness>
+               <witness corresp="EMML36" xml:id="emml36">EMML 36</witness>
                <witness corresp="EMML179" xml:id="emml179">EMML 179</witness>
                <witness corresp="EMML201" xml:id="emml201">EMML 201</witness>
                <witness corresp="EMML629" xml:id="emml629">EMML 629</witness>
@@ -160,14 +160,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <bibl corresp="#bdlbruce74 #bdlor531 #blorient8822 #blorient8823 #fsurueppII1" >
                   <ptr target="bm:Dillmann1851Henoch"/>
                </bibl>
+             
                <bibl corresp="bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
-                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29">
-                  <ptr target="bm:Charles1912Enoch"/>
-                  ´Orient. 271a
-               </bibl>
-               <bibl>
+                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5">
                   <ptr target="bm:KnibbUllendorff1978Enoch1"/>
-                  based on Ethiopian MS 23
                </bibl>
           
             </listBibl>
@@ -176,6 +172,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <bibl corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
                   #blorient8822 #blorient8823 #fsurueppII1 #jryl23 #petermannIInachtrag29">
                   <ptr target="bm:Flemming1902Henok"/>
+               </bibl>
+               <bibl corresp="bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29">
+                  <ptr target="bm:Charles1912Enoch"/>
                </bibl>
                <bibl>
                   <ptr target="bm:KnibbUllendorff1978Enoch2"/>

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -50,91 +50,61 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <p>A TEI file converted from the ETHIO-authority google spreadsheet</p>
          </sourceDesc>
          <sourceDesc>
-            <listWit rend="edition">
+            <listWit>
 
-               <witness corresp="BAVet71" xml:id="bavet71">BAV Aeth. 71</witness>
-               <witness corresp="BNFabb16" xml:id="bnfabb16">BnF Éthiopien d'Abbadie 16</witness>
-               <witness corresp="BNFabb30" xml:id="bnfabb30">BnF Éthiopien d'Abbadie 30</witness>
-               <witness corresp="BNFabb35" xml:id="bnfabb35">BnF Éthiopien d'Abbadie 35</witness>
-               <witness corresp="BNFabb55" xml:id="bnfabb55">BnF Éthiopien d'Abbadie 55</witness>
-               <witness corresp="BNFabb99" xml:id="bnfabb99">BnF Éthiopien d'Abbadie 99</witness>
-               <witness corresp="BNFabb197" xml:id="bnfabb197">BnF Éthiopien d'Abbadie 197</witness>
-               <witness corresp="BNFet49" xml:id="bnfet49">BnF Éthiopien 49</witness>
-               <witness corresp="BNFet50" xml:id="bnfet50">BnF Éthiopien 50</witness>
-               <witness corresp="BDLbruce74" xml:id="bdlbruce74">Bodleian Bruce 74</witness>
-               <witness corresp="BDLor531" xml:id="bdlor531">Bodleian Orient 531</witness>
-               <witness corresp="BLadd24185" xml:id="bladd24185">BL Additional 24185</witness>
-               <witness corresp="BLadd24990" xml:id="bladd24990">BL Additional 24990</witness>
-               <witness corresp="BLorient484" xml:id="blorient484">BL Oriental 484</witness>
-               <witness corresp="BLorient485" xml:id="blorient485">BL Oriental 485</witness>
-               <witness corresp="BLorient490" xml:id="blorient490">BL Oriental 490</witness>
-               <witness corresp="BLorient491" xml:id="blorient491">BL Oriental 491</witness>
-               <witness corresp="BLorient492" xml:id="blorient492">BL Oriental 492</witness>
-               <witness corresp="BLorient499" xml:id="blorient499">BL Oriental 499</witness>
-               <witness corresp="BLorient8822" xml:id="blorient8822">BL Oriental 8822</witness>
-               <witness corresp="BLorient8823" xml:id="blorient8823">BL Oriental 8823</witness>
-               <witness corresp="JRyl23" xml:id="jryl23">John Rylands Library Ethiop. 23</witness>
-               <witness corresp="FSUrueppII1" xml:id="fsurueppII1">Rüppell II 1</witness>
-               <witness corresp="SHOr271a" xml:id="shor271a">Cod. orient. 271a</witness>
-               <witness corresp="PetermannIINachtrag29" xml:id="petermannIInachtrag29">Petermann II
-                  Nachtrag 29</witness>
-               <witness corresp="Tanasee9" xml:id="tanasee9">Ṭānāsee 9</witness>
-               <witness corresp="BDLeu5" xml:id="bdleu5">Bodleian Ullendorff 5</witness>
-
-            </listWit>
-            <listWit rend="translation">
-               <witness corresp="BAVet71">BAV Aeth. 71</witness>
-               <witness corresp="BNFabb16">BnF Éthiopien d'Abbadie 16</witness>
-               <witness corresp="BNFabb30">BnF Éthiopien d'Abbadie 30</witness>
-               <witness corresp="BNFabb35">BnF Éthiopien d'Abbadie 35</witness>
-               <witness corresp="BNFabb55">BnF Éthiopien d'Abbadie 55</witness>
-               <witness corresp="BNFabb99">BnF Éthiopien d'Abbadie 99</witness>
-               <witness corresp="BNFabb197">BnF Éthiopien d'Abbadie 197</witness>
-               <witness corresp="BNFet49">BnF Éthiopien 49</witness>
-               <witness corresp="BNFet50">BnF Éthiopien 50</witness>
-               <witness corresp="BDLbruce74">Bodleian Bruce 74</witness>
-               <witness corresp="BDLor531">Bodleian Orient 531</witness>
-               <witness corresp="BLadd24185">BL Additional 24185</witness>
-               <witness corresp="BLadd24990">BL Additional 24990</witness>
-               <witness corresp="BLorient484">BL Oriental 484</witness>
-               <witness corresp="BLorient485">BL Oriental 485</witness>
-               <witness corresp="BLorient490">BL Oriental 490</witness>
-               <witness corresp="BLorient491">BL Oriental 491</witness>
-               <witness corresp="BLorient492">BL Oriental 492</witness>
-               <witness corresp="BLorient499">BL Oriental 499</witness>
-               <witness corresp="BLorient8822">BL Oriental 8822</witness>
-               <witness corresp="BLorient8823">BL Oriental 8823</witness>
-               <witness corresp="CamAdd1570" xml:id="camadd1570">CUL Add. 1570</witness>
-               <witness corresp="EMML36" xml:id="emml36">EMML 36</witness>
-               <witness corresp="EMML179" xml:id="emml179">EMML 179</witness>
-               <witness corresp="EMML201" xml:id="emml201">EMML 201</witness>
-               <witness corresp="EMML629" xml:id="emml629">EMML 629</witness>
-               <witness corresp="EMML1279" xml:id="emml1279">EMML 1279</witness>
-               <witness corresp="EMML1531" xml:id="emml1531">EMML 1531</witness>
-               <witness corresp="EMML1768" xml:id="emml1768">EMML 1768</witness>
-               <witness corresp="EMML1950" xml:id="emml1950">EMML 1950</witness>
-               <witness corresp="EMML2080" xml:id="emml2080">EMML 2080</witness>
-               <witness corresp="EMML2440" xml:id="emml2440">EMML 2440</witness>
-               <witness corresp="EMML3470" xml:id="emml3470">EMML 3470</witness>
-               <witness corresp="EMML4437" xml:id="emml4437">EMML 4437</witness>
-               <witness corresp="EMML6281" xml:id="emml6281">EMML 6281</witness>
-               <witness corresp="EMML6974" xml:id="emml6974">EMML 6974</witness>
-               <!--  the following mss are said to be used by Nickelsburg 2001, but one needs to check more to understand. For the moment I left him out.
-               <witness corresp="EMML6686" xml:id="emml6686">EMML 6686</witness>
+               <witness corresp="BAVet71" xml:id="bavet71"/>
+               <witness corresp="BNFabb16" xml:id="bnfabb16"/>
+               <witness corresp="BNFabb30" xml:id="bnfabb30"/>
+               <witness corresp="BNFabb35" xml:id="bnfabb35"/>
+               <witness corresp="BNFabb55" xml:id="bnfabb55"/>
+               <witness corresp="BNFabb99" xml:id="bnfabb99"/>
+               <witness corresp="BNFabb197" xml:id="bnfabb197"/>
+               <witness corresp="BNFet49" xml:id="bnfet49"/>
+               <witness corresp="BNFet50" xml:id="bnfet50"/>
+               <witness corresp="BDLbruce74" xml:id="bdlbruce74"/>
+               <witness corresp="BDLor531" xml:id="bdlor531"/>
+               <witness corresp="BLadd24185" xml:id="bladd24185"/>
+               <witness corresp="BLadd24990" xml:id="bladd24990"/>
+               <witness corresp="BLorient484" xml:id="blorient484"/>
+               <witness corresp="BLorient485" xml:id="blorient485"/>
+               <witness corresp="BLorient490" xml:id="blorient490"/>
+               <witness corresp="BLorient491" xml:id="blorient491"/>
+               <witness corresp="BLorient492" xml:id="blorient492"/>
+               <witness corresp="BLorient499" xml:id="blorient499"/>
+               <witness corresp="BLorient8822" xml:id="blorient8822"/>
+               <witness corresp="BLorient8823" xml:id="blorient8823"/>
+               <witness corresp="JRyl23" xml:id="jryl23"/>
+               <witness corresp="FSUrueppII1" xml:id="fsurueppII1"/>
+               <witness corresp="SHOr271a" xml:id="shor271a"/>
+               <witness corresp="PetermannIINachtrag29" xml:id="petermannIInachtrag29"/>
+               <witness corresp="Tanasee9" xml:id="tanasee9"/>
+               <witness corresp="BDLeu5" xml:id="bdleu5"/>
+               <witness corresp="CamAdd1570" xml:id="camadd1570"/>
+               <witness corresp="EMML36" xml:id="emml36"/>
+               <witness corresp="EMML179" xml:id="emml179"/>
+               <witness corresp="EMML201" xml:id="emml201"/>
+               <witness corresp="EMML629" xml:id="emml629"/>
+               <witness corresp="EMML1279" xml:id="emml1279"/>
+               <witness corresp="EMML1531" xml:id="emml1531"/>
+               <witness corresp="EMML1768" xml:id="emml1768"/>
+               <witness corresp="EMML1950" xml:id="emml1950"/>
+               <witness corresp="EMML2080" xml:id="emml2080"/>
+               <witness corresp="EMML2440" xml:id="emml2440"/>
+               <witness corresp="EMML3470" xml:id="emml3470"/>
+               <witness corresp="EMML4437" xml:id="emml4437"/>
+               <witness corresp="EMML6281" xml:id="emml6281"/>
+               <witness corresp="EMML6974" xml:id="emml6974"/>
+               <witness corresp="EMML6686" xml:id="emml6686"/>
       
-               <witness corresp="EMML6706" xml:id="emml6706">EMML 6706</witness>
-               <witness corresp="EMML6930" xml:id="emml6930">EMML 6930</witness>
+               <witness corresp="EMML6706"/>
+               <witness corresp="EMML6930"/>
            
-               <witness corresp="EMML7103" xml:id="emml7103">EMML 7103</witness>
-               <witness corresp="EMML7584" xml:id="emml7584">EMML 7584</witness>-->
+               <witness corresp="EMML7103"/>
+               <witness corresp="EMML7584"/>
+               <witness corresp="NLA23"/>
                <!-- There are other manuscripts used for editions and translations,  but they do not  seem toexist in the bm for the moment, so I left them out. They are the following:
                British and Foreign Bible Society Ms 187, BAV Cerulli 75, Cerulli 110, Cerulli 131, München Cod. aeth. 30, Pontificio Istituto Biblico, Banco A2, II, Princeton Ethiop.2=Garrett Dep. 1468, Zion.-->
 
-               <witness corresp="FSUrueppII1">Rüppell II 1</witness>
-               <witness corresp="SHOr271a">Cod. orient. 271a</witness>
-               <witness corresp="PetermannIINachtrag29">Petermann II Nachtrag 29</witness>
-               <witness corresp="Tanasee9">Ṭānāsee 9</witness>
-               <witness corresp="BDLeu5">Bodleian Ullendorff 5</witness>
 
             </listWit>
             <listBibl type="clavis">
@@ -231,7 +201,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                <bibl
                   corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
-                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5 #camadd1570 #emml3 #emml179 #emml201 #emml629 #emml1279 #emml1531 #emml1768 #emml1950 #emml2080 #emml2440 #emml3470 #emml4437 #emml6281 #emml6974 #FSUrueppII1 #SHOr271a #petermannIInachtrag29 #tanasee9 #bdleu5">
+                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5 #camadd1570 #emml34 #emml179 #emml201 #emml629 #emml1279 #emml1531 #emml1768 #emml1950 #emml2080 #emml2440 #emml3470 #emml4437 #emml6281 #emml6974 #FSUrueppII1 #SHOr271a #petermannIInachtrag29 #tanasee9 #bdleu5">
                   <ptr target="bm:Uhlig1984Henochbuch"/>
                </bibl>
             </listBibl>

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -181,7 +181,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <change who="RHC" when="2017-07-18">Sent word file with unicode encoded text.</change>
          <change who="PL" when="2017-07-21">Marked up minimally the text provided.</change>
          <change who="DR" when="2018-11-28">Added TUK IDs</change>
-         <change who="NV" when="2024-11-25">changed the title, added lists of witnesses used for editions and / or translations, extanded bibl.</change>
+         <change who="NV" when="2024-11-25">changed the title, added lists of witnesses used for
+            editions and / or translations, extanded bibl.</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -98,7 +98,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       
                <witness corresp="EMML6706"/>
                <witness corresp="EMML6930"/>
-           
                <witness corresp="EMML7103"/>
                <witness corresp="EMML7584"/>
                <witness corresp="EMML7942"/>
@@ -121,6 +120,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                <witness corresp="EMIP00741"/>
                <witness corresp="EMIP00746"/>
                <witness corresp="TAfait013"/>
+               <witness corresp="BAVcerulli75"/>
+               <witness corresp="BAVcerulli110"/>
+               <witness corresp="BAVcerulli131"/>
                <!-- There are other manuscripts used for editions and translations,  but they do not  seem toexist in the bm for the moment, so I left them out. They are the following:
                British and Foreign Bible Society Ms 187, BAV Cerulli 75, Cerulli 110, Cerulli 131, München Cod. aeth. 30, Pontificio Istituto Biblico, Banco A2, II, Princeton Ethiop.2=Garrett Dep. 1468, Zion.-->
 

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -4,14 +4,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:lang="gez" xml:id="t1">መጽሐፈ፡ ሄኖክ፡</title>
-            <title xml:lang="gez" corresp="#t1" type="normalized">Maṣḥafa Henok</title>
-            <title xml:lang="en" corresp="#t1">Book of Enoch</title>
+            <title xml:lang="gez" xml:id="t1">ሄኖክ፡</title>
+            <title xml:lang="gez" corresp="#t1" type="normalized">Henok</title>
+            <title xml:lang="en" corresp="#t1">Enoch</title>
             <title xml:id="t2" xml:lang="en">Ethiopic Book of Enoch</title>
             <title xml:id="t3" xml:lang="en">1 Enoch</title>
-            <title xml:id="t4aramaic">Aramaic Version of Enoch</title>
-            <!--titles of work in foreign languages written in English-->
-            <title xml:id="t5greek">Greek Version of Enoch</title>
             <title type="short">Hen.</title>
             <editor role="generalEditor" key="AB"/>
             <editor key="RHC"/>
@@ -48,6 +45,55 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <p>A TEI file converted from the ETHIO-authority google spreadsheet</p>
          </sourceDesc>
          <sourceDesc>
+            <listWit rend="edition">
+               <witness corresp="BAVet71" xml:id="bavet71">BAV Aeth. 71</witness>
+               <witness corresp="BNFabb16" xml:id="bnfabb16">BnF Éthiopien d'Abbadie 16</witness>
+               <witness corresp="BNFabb30" xml:id="bnfabb30">BnF Éthiopien d'Abbadie 30</witness>
+               <witness corresp="BNFabb35" xml:id="bnfabb35">BnF Éthiopien d'Abbadie 35</witness>
+               <witness corresp="BNFabb55" xml:id="bnfabb55">BnF Éthiopien d'Abbadie 55</witness>
+               <witness corresp="BNFabb99" xml:id="bnfabb99">BnF Éthiopien d'Abbadie 99</witness>
+               <witness corresp="BNFabb197" xml:id="bnfabb197">BnF Éthiopien d'Abbadie 197</witness>
+               <witness corresp="BNFet49" xml:id="bnfet49">BnF Éthiopien 49</witness> 
+               <witness corresp="BNFet50" xml:id="bnfet50">BnF Éthiopien 50</witness> 
+               <witness corresp="BDLbruce74" xml:id="bdlbruce74">Bodleian Bruce 74</witness> 
+               <witness corresp="BDLor531" xml:id="bdlor531">Bodleian Orient 531</witness> 
+               <witness corresp="BLadd24185" xml:id="bladd24185">BL Additional 24185</witness>
+               <witness corresp="BLadd24990" xml:id="bladd24990">BL Additional 24990</witness>
+               <witness corresp="BLorient484" xml:id="blorient484">BL Oriental 484</witness>
+               <witness corresp="BLorient485" xml:id="blorient485">BL Oriental 485</witness>
+               <witness corresp="BLorient490" xml:id="blorient490">BL Oriental 490</witness>
+               <witness corresp="BLorient491" xml:id="blorient491">BL Oriental 491</witness>
+               <witness corresp="BLorient492" xml:id="blorient492">BL Oriental 492</witness>
+               <witness corresp="BLorient499" xml:id="blorient499">BL Oriental 499</witness>
+               <witness corresp="CamAdd1570" xml:id="camadd1570">CUL Add. 1570</witness>
+               <witness corresp="EMML36" xml:id="emml36">MML no. 36</witness>
+               <witness corresp="EMML179" xml:id="emml179">EMML 179</witness>
+               <witness corresp="EMML201" xml:id="emml201">EMML 201</witness>
+               <witness corresp="EMML629" xml:id="emml629">EMML 629</witness>
+               <witness corresp="EMML1279" xml:id="emml1279">EMML 1279</witness>
+               <witness corresp="EMML1531" xml:id="emml1531">EMML 1531</witness>
+               <witness corresp="EMML1768" xml:id="emml1768">EMML 1768</witness>
+               <witness corresp="EMML1950" xml:id="emml1950">EMML 1950</witness>
+               <witness corresp="EMML2080" xml:id="emml2080">EMML 2080</witness>
+               <witness corresp="EMML2440" xml:id="emml2440">EMML 2440</witness>
+               <witness corresp="EMML3470" xml:id="emml3470">EMML 3470</witness>
+               <witness corresp="EMML4437" xml:id="emml4437">EMML 4437</witness>
+               <witness corresp="EMML6281" xml:id="emml6281">EMML 6281</witness>
+               <witness corresp="EMML6686" xml:id="emml6686">EMML 6686</witness>
+               <witness corresp="EMML6706" xml:id="emml6706">EMML 6706</witness>
+               <witness corresp="EMML6930" xml:id="emml6930">EMML 6930</witness>
+               <witness corresp="EMML6974" xml:id="emml6974">EMML 6974</witness>
+               <witness corresp="EMML7103" xml:id="emml7103">EMML 7103</witness>
+               <witness corresp="EMML7584" xml:id="emml7584">EMML 7584</witness>
+               <witness corresp="FSUrueppII1" xml:id="fsurueppII1"> Rüppell II 1</witness>
+               <witness corresp="SHOr271a" xml:id="shor271a">Cod. orient.
+                  271a</witness>
+               <witness corresp="PetermannIINachtrag29" xml:id="petermannIInachtrag29">Petermann II Nachtrag 29</witness>
+               <witness corresp="Tanasee9" xml:id="tanasee9">Ṭānāsee 9</witness>
+               <witness corresp="BDLeu5" xml:id="bdleu5">Bodleian Ullendorff 5</witness>
+               
+            </listWit>
+            
                <listBibl type="clavis">
                   <bibl type="CAVT">
                      <ptr target="bm:CAVT"/>
@@ -63,7 +109,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       </encodingDesc>
       <profileDesc>
          <abstract>
-            <p>The <foreign xml:lang="gez">Maṣḥafa Henok</foreign> is a Jewish apocalypse preserved
+            <p><foreign xml:lang="gez">Henok</foreign> is a Jewish apocalypse preserved
                only in Gǝʿǝz. The original language of the work seems to have been Aramaic. There
                are fragments of a Greek version, which have been used by the Ethiopic translator as
                a Vorlage. <bibl>
@@ -122,9 +168,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </listBibl>
 
             <listBibl type="translation">
-               Silvestre de Sacy
                <bibl>
                   <ptr target="bm:KnibbUllendorff1978Enoch2"/>
+               </bibl>
+            </listBibl>
+            <listBibl type="secondary">
+               <bibl>
+                  <ptr target="bm:ErhoStuckenbruck2013Enoch"/>
                </bibl>
             </listBibl>
 

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -249,7 +249,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                <bibl
                   corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
-                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5 #camadd1570 #emml34 #emml179 #emml201 #emml629 #emml1279 #emml1531 #emml1768 #emml1950 #emml2080 #emml2440 #emml3407 #emml4437 #emml6281 #emml6974 #FSUrueppII1 #SHOr271a #petermannIInachtrag29 #tanasee9 #bdleu5">
+                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5 #camadd1570 #emml36 #emml179 #emml201 #emml629 #emml1279 #emml1531 #emml1768 #emml1950 #emml2080 #emml2440 #emml3407 #emml4437 #emml6281 #emml6974 #FSUrueppII1 #SHOr271a #petermannIInachtrag29 #tanasee9 #bdleu5">
                   <ptr target="bm:Uhlig1984Henochbuch"/>
                </bibl>
             </listBibl>

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -10,6 +10,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <title xml:id="t2" xml:lang="en">Ethiopic Book of Enoch</title>
             <title xml:id="t3" xml:lang="en">1 Enoch</title>
             <title type="short">Hen.</title>
+            
             <editor role="generalEditor" key="AB"/>
             <editor key="RHC"/>
             <editor key="DR"/>
@@ -161,7 +162,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <ptr target="bm:Dillmann1851Henoch"/>
                </bibl>
              
-               <bibl corresp="bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+               <bibl corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
                   #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5">
                   <ptr target="bm:KnibbUllendorff1978Enoch1"/>
                </bibl>
@@ -173,17 +174,25 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   #blorient8822 #blorient8823 #fsurueppII1 #jryl23 #petermannIInachtrag29">
                   <ptr target="bm:Flemming1902Henok"/>
                </bibl>
-               <bibl corresp="bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+               <bibl corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
                   #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29">
                   <ptr target="bm:Charles1912Enoch"/>
                </bibl>
                <bibl>
                   <ptr target="bm:KnibbUllendorff1978Enoch2"/>
                </bibl>
+               
+               <bibl corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5">
+                  <ptr target="bm:Uhlig1984Henochbuch"/>
+               </bibl>
             </listBibl>
             <listBibl type="secondary">
                <bibl>
                   <ptr target="bm:ErhoStuckenbruck2013Enoch"/>
+               </bibl>
+               <bibl>
+                  <ptr target="bm:Erho2023Bruce"/>
                </bibl>
             </listBibl>
 

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="work" xml:lang="en" xml:id="LIT1340EnochE">
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="work" xml:lang="en" xml:id="LIT1340EnochE">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
@@ -9,8 +10,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <title xml:lang="en" corresp="#t1">Enoch</title>
             <title xml:id="t2" xml:lang="en">Ethiopic Book of Enoch</title>
             <title xml:id="t3" xml:lang="en">1 Enoch</title>
+            <title xml:id="t4aramaic">Aramaic Version of Enoch</title>
+            <!--titles of work in foreign languages written in English-->
+            <title xml:id="t5greek">Greek Version of Enoch</title>
             <title type="short">Hen.</title>
-            
             <editor role="generalEditor" key="AB"/>
             <editor key="RHC"/>
             <editor key="DR"/>
@@ -28,7 +31,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </editionStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
-            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+               Forschungsumgebung / Beta maṣāḥǝft</publisher>
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
@@ -47,6 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </sourceDesc>
          <sourceDesc>
             <listWit rend="edition">
+
                <witness corresp="BAVet71" xml:id="bavet71">BAV Aeth. 71</witness>
                <witness corresp="BNFabb16" xml:id="bnfabb16">BnF Éthiopien d'Abbadie 16</witness>
                <witness corresp="BNFabb30" xml:id="bnfabb30">BnF Éthiopien d'Abbadie 30</witness>
@@ -54,10 +59,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <witness corresp="BNFabb55" xml:id="bnfabb55">BnF Éthiopien d'Abbadie 55</witness>
                <witness corresp="BNFabb99" xml:id="bnfabb99">BnF Éthiopien d'Abbadie 99</witness>
                <witness corresp="BNFabb197" xml:id="bnfabb197">BnF Éthiopien d'Abbadie 197</witness>
-               <witness corresp="BNFet49" xml:id="bnfet49">BnF Éthiopien 49</witness> 
-               <witness corresp="BNFet50" xml:id="bnfet50">BnF Éthiopien 50</witness> 
-               <witness corresp="BDLbruce74" xml:id="bdlbruce74">Bodleian Bruce 74</witness> 
-               <witness corresp="BDLor531" xml:id="bdlor531">Bodleian Orient 531</witness> 
+               <witness corresp="BNFet49" xml:id="bnfet49">BnF Éthiopien 49</witness>
+               <witness corresp="BNFet50" xml:id="bnfet50">BnF Éthiopien 50</witness>
+               <witness corresp="BDLbruce74" xml:id="bdlbruce74">Bodleian Bruce 74</witness>
+               <witness corresp="BDLor531" xml:id="bdlor531">Bodleian Orient 531</witness>
                <witness corresp="BLadd24185" xml:id="bladd24185">BL Additional 24185</witness>
                <witness corresp="BLadd24990" xml:id="bladd24990">BL Additional 24990</witness>
                <witness corresp="BLorient484" xml:id="blorient484">BL Oriental 484</witness>
@@ -68,6 +73,37 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <witness corresp="BLorient499" xml:id="blorient499">BL Oriental 499</witness>
                <witness corresp="BLorient8822" xml:id="blorient8822">BL Oriental 8822</witness>
                <witness corresp="BLorient8823" xml:id="blorient8823">BL Oriental 8823</witness>
+               <witness corresp="JRyl23" xml:id="jryl23">John Rylands Library Ethiop. 23</witness>
+               <witness corresp="FSUrueppII1" xml:id="fsurueppII1">Rüppell II 1</witness>
+               <witness corresp="SHOr271a" xml:id="shor271a">Cod. orient. 271a</witness>
+               <witness corresp="PetermannIINachtrag29" xml:id="petermannIInachtrag29">Petermann II
+                  Nachtrag 29</witness>
+               <witness corresp="Tanasee9" xml:id="tanasee9">Ṭānāsee 9</witness>
+               <witness corresp="BDLeu5" xml:id="bdleu5">Bodleian Ullendorff 5</witness>
+
+            </listWit>
+            <listWit rend="translation">
+               <witness corresp="BAVet71">BAV Aeth. 71</witness>
+               <witness corresp="BNFabb16">BnF Éthiopien d'Abbadie 16</witness>
+               <witness corresp="BNFabb30">BnF Éthiopien d'Abbadie 30</witness>
+               <witness corresp="BNFabb35">BnF Éthiopien d'Abbadie 35</witness>
+               <witness corresp="BNFabb55">BnF Éthiopien d'Abbadie 55</witness>
+               <witness corresp="BNFabb99">BnF Éthiopien d'Abbadie 99</witness>
+               <witness corresp="BNFabb197">BnF Éthiopien d'Abbadie 197</witness>
+               <witness corresp="BNFet49">BnF Éthiopien 49</witness>
+               <witness corresp="BNFet50">BnF Éthiopien 50</witness>
+               <witness corresp="BDLbruce74">Bodleian Bruce 74</witness>
+               <witness corresp="BDLor531">Bodleian Orient 531</witness>
+               <witness corresp="BLadd24185">BL Additional 24185</witness>
+               <witness corresp="BLadd24990">BL Additional 24990</witness>
+               <witness corresp="BLorient484">BL Oriental 484</witness>
+               <witness corresp="BLorient485">BL Oriental 485</witness>
+               <witness corresp="BLorient490">BL Oriental 490</witness>
+               <witness corresp="BLorient491">BL Oriental 491</witness>
+               <witness corresp="BLorient492">BL Oriental 492</witness>
+               <witness corresp="BLorient499">BL Oriental 499</witness>
+               <witness corresp="BLorient8822">BL Oriental 8822</witness>
+               <witness corresp="BLorient8823">BL Oriental 8823</witness>
                <witness corresp="CamAdd1570" xml:id="camadd1570">CUL Add. 1570</witness>
                <witness corresp="EMML36" xml:id="emml36">EMML 36</witness>
                <witness corresp="EMML179" xml:id="emml179">EMML 179</witness>
@@ -82,46 +118,52 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <witness corresp="EMML3470" xml:id="emml3470">EMML 3470</witness>
                <witness corresp="EMML4437" xml:id="emml4437">EMML 4437</witness>
                <witness corresp="EMML6281" xml:id="emml6281">EMML 6281</witness>
+               <witness corresp="EMML6974" xml:id="emml6974">EMML 6974</witness>
+               <!--  the following mss are said to be used by Nickelsburg 2001, but one needs to check more to understand. For the moment I left him out.
                <witness corresp="EMML6686" xml:id="emml6686">EMML 6686</witness>
+      
                <witness corresp="EMML6706" xml:id="emml6706">EMML 6706</witness>
                <witness corresp="EMML6930" xml:id="emml6930">EMML 6930</witness>
-               <witness corresp="EMML6974" xml:id="emml6974">EMML 6974</witness>
+           
                <witness corresp="EMML7103" xml:id="emml7103">EMML 7103</witness>
-               <witness corresp="EMML7584" xml:id="emml7584">EMML 7584</witness>
-               <witness corresp="JRyl23" xml:id="jryl23">John Rylands Library Ethiop. 23</witness>
-               <witness corresp="FSUrueppII1" xml:id="fsurueppII1">Rüppell II 1</witness>
-               <witness corresp="SHOr271a" xml:id="shor271a">Cod. orient.
-                  271a</witness>
-               <witness corresp="PetermannIINachtrag29" xml:id="petermannIInachtrag29">Petermann II Nachtrag 29</witness>
-               <witness corresp="Tanasee9" xml:id="tanasee9">Ṭānāsee 9</witness>
-               <witness corresp="BDLeu5" xml:id="bdleu5">Bodleian Ullendorff 5</witness>
-               
+               <witness corresp="EMML7584" xml:id="emml7584">EMML 7584</witness>-->
+               <!-- There are other manuscripts used for editions and translations,  but they do not  seem toexist in the bm for the moment, so I left them out. They are the following:
+               British and Foreign Bible Society Ms 187, BAV Cerulli 75, Cerulli 110, Cerulli 131, München Cod. aeth. 30, Pontificio Istituto Biblico, Banco A2, II, Princeton Ethiop.2=Garrett Dep. 1468, Zion.-->
+
+               <witness corresp="FSUrueppII1">Rüppell II 1</witness>
+               <witness corresp="SHOr271a">Cod. orient. 271a</witness>
+               <witness corresp="PetermannIINachtrag29">Petermann II Nachtrag 29</witness>
+               <witness corresp="Tanasee9">Ṭānāsee 9</witness>
+               <witness corresp="BDLeu5">Bodleian Ullendorff 5</witness>
+
             </listWit>
-            
-               <listBibl type="clavis">
-                  <bibl type="CAVT">
-                     <ptr target="bm:CAVT"/>
-                     <citedRange unit="item">61</citedRange>
-                  </bibl>
-               </listBibl>
+            <listBibl type="clavis">
+               <bibl type="CAVT">
+                  <ptr target="bm:CAVT"/>
+                  <citedRange unit="item">61</citedRange>
+               </bibl>
+            </listBibl>
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         
-               <p>Re-encoded from a stub.</p>
-            
+
+         <p>Re-encoded from a stub.</p>
+
       </encodingDesc>
       <profileDesc>
          <abstract>
-            <p><foreign xml:lang="gez">Henok</foreign> is a Jewish apocalypse preserved
-               only in Gǝʿǝz. The original language of the work seems to have been Aramaic. There
-               are fragments of a Greek version, which have been used by the Ethiopic translator as
-               a Vorlage. <bibl>
+            <p><foreign xml:lang="gez">Henok</foreign> is a Jewish apocalypse preserved only in
+               Gǝʿǝz. The original language of the work seems to have been Aramaic. There are
+               fragments of a Greek version, which have been used by the Ethiopic translator as a
+               Vorlage. <bibl>
                   <ptr target="bm:Uhlig2005EAEEnoch"/>
                </bibl>
             </p>
          </abstract>
-         <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="gez">Gǝʿǝz</language>
+         </langUsage>
          <textClass>
             <keywords>
                <term key="ChristianLiterature"/>
@@ -139,6 +181,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="RHC" when="2017-07-18">Sent word file with unicode encoded text.</change>
          <change who="PL" when="2017-07-21">Marked up minimally the text provided.</change>
          <change who="DR" when="2018-11-28">Added TUK IDs</change>
+         <change who="NV" when="2024-11-25">changed the title, added lists of witnesses used for editions and / or translations, extanded bibl.</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -158,47 +201,59 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <bibl corresp="#bdlbruce74">
                   <ptr target="bm:Laurence1839Enoch"/>
                </bibl>
-               <bibl corresp="#bdlbruce74 #bdlor531 #blorient8822 #blorient8823 #fsurueppII1" >
+               <bibl corresp="#bdlbruce74 #bdlor531 #blorient8822 #blorient8823 #fsurueppII1">
                   <ptr target="bm:Dillmann1851Henoch"/>
                </bibl>
-             
-               <bibl corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+
+               <bibl
+                  corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
                   #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5">
                   <ptr target="bm:KnibbUllendorff1978Enoch1"/>
                </bibl>
-          
+
             </listBibl>
 
             <listBibl type="translation">
-               <bibl corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+               <bibl
+                  corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
                   #blorient8822 #blorient8823 #fsurueppII1 #jryl23 #petermannIInachtrag29">
                   <ptr target="bm:Flemming1902Henok"/>
                </bibl>
-               <bibl corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+               <bibl
+                  corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
                   #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29">
                   <ptr target="bm:Charles1912Enoch"/>
                </bibl>
                <bibl>
                   <ptr target="bm:KnibbUllendorff1978Enoch2"/>
                </bibl>
-               
-               <bibl corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
-                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5">
+
+               <bibl
+                  corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5 #camadd1570 #emml3 #emml179 #emml201 #emml629 #emml1279 #emml1531 #emml1768 #emml1950 #emml2080 #emml2440 #emml3470 #emml4437 #emml6281 #emml6974 #FSUrueppII1 #SHOr271a #petermannIInachtrag29 #tanasee9 #bdleu5">
                   <ptr target="bm:Uhlig1984Henochbuch"/>
                </bibl>
             </listBibl>
             <listBibl type="secondary">
+               <bibl>
+                  <ptr target="bm:Stuckenbruck2007Enoch"/>
+               </bibl>
                <bibl>
                   <ptr target="bm:ErhoStuckenbruck2013Enoch"/>
                </bibl>
                <bibl>
                   <ptr target="bm:Erho2023Bruce"/>
                </bibl>
+               <bibl>
+                  <ptr target="bm:Erho2024Peter"/>
+               </bibl>
             </listBibl>
 
             <listRelation>
-               <relation name="saws:isVersionInAnotherLanguageOf" active="LIT1340EnochE#t5greek" passive="LIT1340EnochE#t4aramaic"/>
-               <relation name="saws:isVersionInAnotherLanguageOf" active="LIT1340EnochE#t1" passive="LIT1340EnochE#t5greek"/>
+               <relation name="saws:isVersionInAnotherLanguageOf" active="LIT1340EnochE#t5greek"
+                  passive="LIT1340EnochE#t4aramaic"/>
+               <relation name="saws:isVersionInAnotherLanguageOf" active="LIT1340EnochE#t1"
+                  passive="LIT1340EnochE#t5greek"/>
             </listRelation>
          </div>
 
@@ -209,14 +264,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <listRelation>
 
                   <relation name="skos:broadMatch"
-                            active="https://corpuscoranicum.de/kontexte/index/sure/2/vers/102/intertext/769"
-                            passive="betmas:LIT1340EnochE.1.6-9"/>
+                     active="https://corpuscoranicum.de/kontexte/index/sure/2/vers/102/intertext/769"
+                     passive="betmas:LIT1340EnochE.1.6-9"/>
                   <relation name="skos:broadMatch"
-                            active="https://corpuscoranicum.de/kontexte/index/sure/2/vers/164/intertext/909"
-                            passive="betmas:LIT1340EnochE.1.2-5"/>
+                     active="https://corpuscoranicum.de/kontexte/index/sure/2/vers/164/intertext/909"
+                     passive="betmas:LIT1340EnochE.1.2-5"/>
                   <relation name="skos:broadMatch"
-                            active="https://corpuscoranicum.de/kontexte/index/sure/17/vers/1/intertext/1325"
-                            passive="betmas:LIT1340EnochE.1.26-27"/>
+                     active="https://corpuscoranicum.de/kontexte/index/sure/17/vers/1/intertext/1325"
+                     passive="betmas:LIT1340EnochE.1.26-27"/>
 
                </listRelation>
                <div type="textpart" subtype="chapter" n="1">
@@ -235,11 +290,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ዘሥጋ ፡ በእንተ ፡ ኲሉ ፡ ዘገብሩ ፡ ወረሰዩ ፡ ላዕሌሁ ፡ ኃጥአን ፡ ወረሲዓን ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/1/vers/2/intertext/906"
-                               passive="betmas:LIT1340EnochE.1.1"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/1/vers/2/intertext/906"
+                        passive="betmas:LIT1340EnochE.1.1"/>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/18/vers/47/intertext/784"
-                               passive="betmas:LIT1340EnochE.1.1"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/18/vers/47/intertext/784"
+                        passive="betmas:LIT1340EnochE.1.1"/>
 
                   </listRelation>
                </div>
@@ -419,8 +474,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ቅዱስ ። ወአንሥአኒ ፡ ወአቅረበኒ ፡ እስከ ፡ ኆኅት ፤ ወአንሰ ፡ ገጽየ ፡ ታሕተ ፡ እኔጽር ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/2/vers/2/intertext/911"
-                               passive="betmas:LIT1340EnochE.1.14"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/2/vers/2/intertext/911"
+                        passive="betmas:LIT1340EnochE.1.14"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="15">
@@ -483,9 +538,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ውእቶሙ ፡ እለ ፡ ኀለፉ ፡ ትእዛዘ ፡ እግዚአብሔር ፡ እምቅድመ ፡ ጽባሖሙ ፡ እስመ ፡ ኢመጽኡ ፡ በጊዜሆሙ ። ወተምዕዖሙ ፡
                      ወአሠሮሙ ፡ እስከ ፡ ጊዜ ፡ ተፍጻሜተ ፡ ኀጢአቶሙ ፡ በዓመተ ፡ ምሥጢር ። </ab>
                   <listRelation>
-     <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/13/vers/2/intertext/1130"
-                               passive="betmas:LIT1340EnochE.1.18"/>
+                     <relation name="skos:broadMatch"
+                        active="https://corpuscoranicum.de/kontexte/index/sure/13/vers/2/intertext/1130"
+                        passive="betmas:LIT1340EnochE.1.18"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="19">
@@ -516,12 +571,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ወኢዕበዮ ፡ እክህልኩ ፡ ነጽሮ ፡ ወስእንኩ ፡ ነጽሮ ፡ ዐይኑ ። ውእተ ፡ ጊዜ ፡ እቤ ፡ እፎ ፡ ግሩም ፡ ዝንቱ ፡ መካን
                      ፡ ወሕማም ፡ ለነጽሮ ። ውእተ ፡ ጊዜ ፡ አውሥአኒ ፡ ኡርኤል ፡ ፩እመላእክት ፡ ቅዱሳን ፡ ዘምስሌየ ፡ ሀለወ ፡ አውሥአኒ
                      ፡ ወይቤለኒ ፡ ሄኖክ ፡ ምንት ፡ ውእቱ ፡ ፍርሃትከ ፡ ከመዝ ፡ ወድንጋፄከ ፡ በእንተዝ ፡ ግሩም ፡ መካን ፡ ወቅድመ ፡
-                     ገጹ ፡ ለዝ ፡ ሕማም ። ወይቤለኒ ፡ ዝመካን ፡ ቤተ ፡ ሞቅሖሙ ፡ ለመላእክት ፡ ወበህየ ፡ ይትአኅዙ ፡ እስከ ፡ ለዓለም ።
-                  </ab>
+                     ገጹ ፡ ለዝ ፡ ሕማም ። ወይቤለኒ ፡ ዝመካን ፡ ቤተ ፡ ሞቅሖሙ ፡ ለመላእክት ፡ ወበህየ ፡ ይትአኅዙ ፡ እስከ ፡ ለዓለም ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/104/vers/6/intertext/922"
-                               passive="betmas:LIT1340EnochE.1.21"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/104/vers/6/intertext/922"
+                        passive="betmas:LIT1340EnochE.1.21"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="22">
@@ -547,7 +601,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      አበሳ ፡ ወምስለ ፡ አባስያን ፡ ይከውኑ ፡ ከማሆሙ ፡ ወነፍሶሙሰ ፡ ኢትትቀተል ፡ በዕለተ ፡ ኲነኔ ፡ ወኢይትነሥኡ ፡
                      እምዝየ ። ውእተ ፡ ጊዜ ፡ ባረክዎ ፡ ለእግዚአ ፡ ስብሐት ፡ ወእቤ ፡ ቡሩክ ፡ ውእቱ ፡ እግዚእየ ፡ እግዚአ ፡ ስብሐት ፡
                      ወጽድቅ ፡ ዘኲሎ ፡ ይመልክ ፡ እስከ ፡ ለዓለም ። </ab>
-                  
+
                </div>
                <div type="textpart" subtype="chapter" n="23">
                   <ab>ወእምህየ ፡ ሖርኩ ፡ ካልአ ፡ መካነ ፡ መንገለ ፡ ዓረብ ፡ እስከ ፡ አጽናፈ ፡ ምድር ። ወርኢኩ ፡ እሳተ ፡ ዘይነድድ ፡
@@ -673,8 +727,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <listRelation>
 
                   <relation name="skos:broadMatch"
-                            active="https://corpuscoranicum.de/kontexte/index/sure/50/vers/44/intertext/904"
-                            passive="betmas:LIT1340EnochE.2.50-51"/>
+                     active="https://corpuscoranicum.de/kontexte/index/sure/50/vers/44/intertext/904"
+                     passive="betmas:LIT1340EnochE.2.50-51"/>
 
                </listRelation>
 
@@ -700,8 +754,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <listRelation>
 
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/7/vers/8/intertext/903"
-                               passive="betmas:LIT1340EnochE.2.38"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/7/vers/8/intertext/903"
+                        passive="betmas:LIT1340EnochE.2.38"/>
 
                   </listRelation>
                </div>
@@ -729,8 +783,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ለዓለመ ፡ ዓለም ። ወተወለጠ ፡ ገጽየ ፡ እስከ ፡ ስእንኩ ፡ ነጽሮ ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/3/vers/151/intertext/928"
-                               passive="betmas:LIT1340EnochE.2.39"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/3/vers/151/intertext/928"
+                        passive="betmas:LIT1340EnochE.2.39"/>
 
                   </listRelation>
                </div>
@@ -771,8 +825,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ኢይክል ፡ ከሊአ ፡ እስመ ፡ መኰንን ፡ ለኲሎሙ ፡ ይሬኢ ፡ ወእሎንተ ፡ ኲሎሙ ፡ በቅድሜሁ ፡ ውእቱ ፡ ይኴንን ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/15/vers/21/intertext/930"
-                               passive="betmas:LIT1340EnochE.2.41"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/15/vers/21/intertext/930"
+                        passive="betmas:LIT1340EnochE.2.41"/>
 
                   </listRelation>
                </div>
@@ -834,11 +888,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ወጸሎቶሙ ፡ ለጻድቃን ፡ ተሰምዐ ፡ ወደሙ ፡ ለጻድቅ ፡ በቅድመ ፡ እግዚአ ፡ መናፍስት ፡ ተፈቅደ ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/78/vers/38/intertext/913"
-                               passive="betmas:LIT1340EnochE.2.47"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/78/vers/38/intertext/913"
+                        passive="betmas:LIT1340EnochE.2.47"/>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/10/vers/21/intertext/914"
-                               passive="betmas:LIT1340EnochE.2.47"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/10/vers/21/intertext/914"
+                        passive="betmas:LIT1340EnochE.2.47"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="48">
@@ -931,8 +985,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      በዲበ ፡ ምድር ፡ ወበእንተዝ ፡ ይትኀጐሉ ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/13/vers/5/intertext/910"
-                               passive="betmas:LIT1340EnochE.2.54"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/13/vers/5/intertext/910"
+                        passive="betmas:LIT1340EnochE.2.54"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="55">
@@ -1102,8 +1156,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ይእኅዝዋ ፡ ለየብስ ፡ በቅድመ ፡ እግዚአ ፡ መናፍስት ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/35/vers/37/intertext/912"
-                               passive="betmas:LIT1340EnochE.2.63"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/35/vers/37/intertext/912"
+                        passive="betmas:LIT1340EnochE.2.63"/>
 
                   </listRelation>
                </div>
@@ -1484,8 +1538,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      እባርኮ ፡ ለእግዚአ ፡ ዓለማት ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/85/vers/22/intertext/905"
-                               passive="betmas:LIT1340EnochE.3.81"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/85/vers/22/intertext/905"
+                        passive="betmas:LIT1340EnochE.3.81"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="82">
@@ -1553,8 +1607,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ገጸ ፡ ሰማይ ፡ ወተንሥአ ፡ ወየሐውር ፡ ፍኖተ ፡ እንተ ፡ ተርእየት ፡ ሎቱ ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/1/vers/4/intertext/908"
-                               passive="betmas:LIT1340EnochE.4.83"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/1/vers/4/intertext/908"
+                        passive="betmas:LIT1340EnochE.4.83"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="84">
@@ -1752,8 +1806,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ኲሉ ፡ ኖላውያን ። ወነሢኦ ፡ አንበረ ፡ ኀቤሁ ፡ ኪያሁ ፡ መጽሐፈ ፡ ወወጽአ ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/12/vers/13/intertext/916"
-                               passive="betmas:LIT1340EnochE.4.89"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/12/vers/13/intertext/916"
+                        passive="betmas:LIT1340EnochE.4.89"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="90">
@@ -1978,8 +2032,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ይመውቱ ፡ ፍጡነ ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/10/vers/21/intertext/915"
-                               passive="betmas:LIT1340EnochE.5.98"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/10/vers/21/intertext/915"
+                        passive="betmas:LIT1340EnochE.5.98"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="99">
@@ -2007,8 +2061,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ያሕጒልክሙ ፡ ለኲልክሙ ፡ በሰይፍ ፤ ወኲሎሙ ፡ ጻድቃን ፡ ወቅዱሳን ፡ ይዜከሩ ፡ ኀጢአተ ፡ ዚአክሙ ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/22/vers/2/intertext/902"
-                               passive="betmas:LIT1340EnochE.5.99"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/22/vers/2/intertext/902"
+                        passive="betmas:LIT1340EnochE.5.99"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="100">
@@ -2035,8 +2089,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ኢትክሉ ፡ ቀዊመ ፡ ቅድሜሆሙ ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/3/vers/10/intertext/923"
-                               passive="betmas:LIT1340EnochE.5.100"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/3/vers/10/intertext/923"
+                        passive="betmas:LIT1340EnochE.5.100"/>
                   </listRelation>
                </div>
                <div type="textpart" subtype="chapter" n="101">
@@ -2194,8 +2248,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                      ወአዝማን ። </ab>
                   <listRelation>
                      <relation name="skos:broadMatch"
-                               active="https://corpuscoranicum.de/kontexte/index/sure/4/vers/56/intertext/931"
-                               passive="betmas:LIT1340EnochE.5.108"/>
+                        active="https://corpuscoranicum.de/kontexte/index/sure/4/vers/56/intertext/931"
+                        passive="betmas:LIT1340EnochE.5.108"/>
                   </listRelation>
                </div>
             </div>

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -65,6 +65,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <witness corresp="BLorient491" xml:id="blorient491">BL Oriental 491</witness>
                <witness corresp="BLorient492" xml:id="blorient492">BL Oriental 492</witness>
                <witness corresp="BLorient499" xml:id="blorient499">BL Oriental 499</witness>
+               <witness corresp="BLorient8822" xml:id="blorient8822">BL Oriental 8822</witness>
+               <witness corresp="BLorient8823" xml:id="blorient8823">BL Oriental 8823</witness>
                <witness corresp="CamAdd1570" xml:id="camadd1570">CUL Add. 1570</witness>
                <witness corresp="EMML36" xml:id="emml36">MML no. 36</witness>
                <witness corresp="EMML179" xml:id="emml179">EMML 179</witness>
@@ -85,7 +87,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <witness corresp="EMML6974" xml:id="emml6974">EMML 6974</witness>
                <witness corresp="EMML7103" xml:id="emml7103">EMML 7103</witness>
                <witness corresp="EMML7584" xml:id="emml7584">EMML 7584</witness>
-               <witness corresp="FSUrueppII1" xml:id="fsurueppII1"> Rüppell II 1</witness>
+               <witness corresp="JRyl23" xml:id="jryl23">John Rylands Library Ethiop. 23</witness>
+               <witness corresp="FSUrueppII1" xml:id="fsurueppII1">Rüppell II 1</witness>
                <witness corresp="SHOr271a" xml:id="shor271a">Cod. orient.
                   271a</witness>
                <witness corresp="PetermannIINachtrag29" xml:id="petermannIInachtrag29">Petermann II Nachtrag 29</witness>
@@ -151,7 +154,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </listBibl>
 
             <listBibl type="editions">
-               <bibl>
+               <bibl corresp="#bdlbruce74">
+                  <ptr target="bm:Laurence1839Enoch"/>
+               </bibl>
+               <bibl corresp="#bdlbruce74 #bdlor531 #blorient8822 #blorient8823 #fsurueppII1" >
                   <ptr target="bm:Dillmann1851Henoch"/>
                </bibl>
                <bibl>
@@ -162,12 +168,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <ptr target="bm:KnibbUllendorff1978Enoch1"/>
                   based on Ethiopian MS 23
                </bibl>
-               <bibl>
-                  <ptr target="bm:Laurence1839Enoch"/>
-               </bibl>
+          
             </listBibl>
 
             <listBibl type="translation">
+               <bibl corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+                  #blorient8822 #blorient8823 #fsurueppII1 #jryl23 #petermannIInachtrag29">
+                  <ptr target="bm:Flemming1902Henok"/>
+               </bibl>
                <bibl>
                   <ptr target="bm:KnibbUllendorff1978Enoch2"/>
                </bibl>

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -101,7 +101,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
            
                <witness corresp="EMML7103"/>
                <witness corresp="EMML7584"/>
+               <witness corresp="EMML7942"/>
+               <witness corresp="EMML8098"/>
+               <witness corresp="EMML8347"/>
+               <witness corresp="EMML8544"/>
+               <witness corresp="EMML8546"/>
+               <witness corresp="EMML8560"/>
+               <witness corresp="EMML8608"/>
+               <witness corresp="EMML8703"/>
+               <witness corresp="EMML8768"/>
+               <witness corresp="EMML8775"/>
+               <witness corresp="EMML8846"/>
+               <witness corresp="EMML9009"/>
+               <witness corresp="NLA3"/>
                <witness corresp="NLA23"/>
+               <witness corresp="NLA24"/>
+               <witness corresp="DimmaUnesco1004"/>
+               <witness corresp="DimmaUnesco1043"/>
+               <witness corresp="EMIP00741"/>
+               <witness corresp="EMIP00746"/>
+               <witness corresp="TAfait013"/>
                <!-- There are other manuscripts used for editions and translations,  but they do not  seem toexist in the bm for the moment, so I left them out. They are the following:
                British and Foreign Bible Society Ms 187, BAV Cerulli 75, Cerulli 110, Cerulli 131, München Cod. aeth. 30, Pontificio Istituto Biblico, Banco A2, II, Princeton Ethiop.2=Garrett Dep. 1468, Zion.-->
 

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -17,6 +17,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <editor role="generalEditor" key="AB"/>
             <editor key="RHC"/>
             <editor key="DR"/>
+            <editor key="NV"/>
             <respStmt>
                <resp>Digitization and encoded by</resp>
                <persName>Michal Jerabek</persName>
@@ -51,7 +52,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          </sourceDesc>
          <sourceDesc>
             <listWit>
-
+               <witness corresp="BAVcerulli75"/>
+               <witness corresp="BAVcerulli110"/>
+               <witness corresp="BAVcerulli131"/>
                <witness corresp="BAVet71" xml:id="bavet71"/>
                <witness corresp="BNFabb16" xml:id="bnfabb16"/>
                <witness corresp="BNFabb30" xml:id="bnfabb30"/>
@@ -63,6 +66,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                <witness corresp="BNFet50" xml:id="bnfet50"/>
                <witness corresp="BDLbruce74" xml:id="bdlbruce74"/>
                <witness corresp="BDLor531" xml:id="bdlor531"/>
+               <witness corresp="BSLet187"/>
                <witness corresp="BLadd24185" xml:id="bladd24185"/>
                <witness corresp="BLadd24990" xml:id="bladd24990"/>
                <witness corresp="BLorient484" xml:id="blorient484"/>
@@ -73,12 +77,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                <witness corresp="BLorient499" xml:id="blorient499"/>
                <witness corresp="BLorient8822" xml:id="blorient8822"/>
                <witness corresp="BLorient8823" xml:id="blorient8823"/>
-               <witness corresp="JRyl23" xml:id="jryl23"/>
-               <witness corresp="FSUrueppII1" xml:id="fsurueppII1"/>
-               <witness corresp="SHOr271a" xml:id="shor271a"/>
-               <witness corresp="PetermannIINachtrag29" xml:id="petermannIInachtrag29"/>
-               <witness corresp="Tanasee9" xml:id="tanasee9"/>
-               <witness corresp="BDLeu5" xml:id="bdleu5"/>
                <witness corresp="CamAdd1570" xml:id="camadd1570"/>
                <witness corresp="EMML36" xml:id="emml36"/>
                <witness corresp="EMML179" xml:id="emml179"/>
@@ -90,55 +88,73 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                <witness corresp="EMML1950" xml:id="emml1950"/>
                <witness corresp="EMML2080" xml:id="emml2080"/>
                <witness corresp="EMML2440" xml:id="emml2440"/>
-               <witness corresp="EMML3470" xml:id="emml3470"/>
+               <witness corresp="EMML3407" xml:id="emml3407"/>
                <witness corresp="EMML4437" xml:id="emml4437"/>
+               <witness corresp="EMML4750" xml:id="emml4750"/>
+               <witness corresp="EMML5589" xml:id="emml5589"/>
                <witness corresp="EMML6281" xml:id="emml6281"/>
-               <witness corresp="EMML6974" xml:id="emml6974"/>
-               <witness corresp="EMML6686" xml:id="emml6686"/>
-      
-               <witness corresp="EMML6706"/>
-               <witness corresp="EMML6930"/>
+                <witness corresp="EMML6686" xml:id="emml6686"/>
+                    <witness corresp="EMML6706"/>
+                 <witness corresp="EMML6930"/>
+               <witness corresp="EMML6974" xml:id="emml6974"/>             
                <witness corresp="EMML7103"/>
                <witness corresp="EMML7584"/>
+                 <witness corresp="FSUrueppII1" xml:id="fsurueppII1"/>
+                  <witness corresp="SHOr271a" xml:id="shor271a"/>
+               <witness corresp="JRyl23" xml:id="jryl23"/>
+              <witness corresp="BSBaeth30"/>
+               <!-- Pontificio Istituto Biblico, Banco A2, II - Bausi  -->
+               <witness corresp="PULgarrettEth042"/>
+               <witness corresp="PetermannIINachtrag29" xml:id="petermannIInachtrag29"/>
+               <witness corresp="Tanasee9" xml:id="tanasee9"/>
+               <witness corresp="BDLeu5" xml:id="bdleu5"/>
+               <!-- Zion, Macomber-->
+               <witness corresp="BDLaethd18"/>
+               <witness corresp="EMIP00741"/>
+               <witness corresp="EMIP00743"/>
+               <witness corresp="EMIP00746"/>
+               <witness corresp="EMIP00937"/>
+               <witness corresp="EMIP00949"/>
+               <witness corresp="EMML207"/>
+               <witness corresp="EMML2436"/>
+               <witness corresp="EMML4648"/>
+               <witness corresp="EMML5003"/>
+               <witness corresp="EMML5591"/>
+               <witness corresp="EMML6252"/>
+               <witness corresp="Je5e"/>
+               <witness corresp="TAfait013"/>
+               <witness corresp="GG00151"/>
+               <witness corresp="IES392"/>
+               <witness corresp="IES1736"/>
+               <witness corresp="EMDA106"/>
+               <witness corresp="Parm3843"/>
+               <witness corresp="EMDA202"/>
+               <!--  Remnant Trust -->
+               <witness corresp="Schoyen2657"/>
+               <!--   <witness corresp="EStny008"=TNY-008 (C2–IV–348)/> -->
+               <witness corresp="NLA3"/>
+               <witness corresp="NLA23"/>
+               <witness corresp="NLA24"/>
+               <witness corresp="DimmaUnesco1004"/>
+               <witness corresp="DimmaUnesco1043"/>
+               <witness corresp="DW01"/>
                <witness corresp="EMML7942"/>
                <witness corresp="EMML8098"/>
+               <witness corresp="EMML8234"/>
                <witness corresp="EMML8347"/>
+               <witness corresp="EMML8400"/>
+               <witness corresp="EMML8433"/>
                <witness corresp="EMML8544"/>
                <witness corresp="EMML8546"/>
+               <witness corresp="EMML8548"/>
                <witness corresp="EMML8560"/>
                <witness corresp="EMML8608"/>
                <witness corresp="EMML8703"/>
                <witness corresp="EMML8768"/>
                <witness corresp="EMML8775"/>
                <witness corresp="EMML8846"/>
+               <witness corresp="EMML8943"/>
                <witness corresp="EMML9009"/>
-               <witness corresp="NLA3"/>
-               <witness corresp="NLA23"/>
-               <witness corresp="NLA24"/>
-               <witness corresp="DimmaUnesco1004"/>
-               <witness corresp="DimmaUnesco1043"/>
-               <witness corresp="EMIP00741"/>
-               <witness corresp="EMIP00746"/>
-               <witness corresp="TAfait013"/>
-               <witness corresp="BAVcerulli75"/>
-               <witness corresp="BAVcerulli110"/>
-               <witness corresp="BAVcerulli131"/>
-               <witness corresp="BSLet187"/>
-               <witness corresp="BSBaeth30"/>
-               <witness corresp="PULgarrettEth042"/>
-               <witness corresp="Parm3843"/>
-               <witness corresp="GG00151"/>
-               <witness corresp="DW01"/>
-               <witness corresp="BDLaethd18"/>
-               <witness corresp="Schoyen2657"/>
-               
-               <!-- Zion - Davis microfilms
-        Pontificio Istituto Biblico, Banco A2, II - Bausi
-        Jerusalem EOTC 5e (stub probably needed)
-        
-        >
-
-
             </listWit>
             <listBibl type="clavis">
                <bibl type="CAVT">
@@ -184,8 +200,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <change who="RHC" when="2017-07-18">Sent word file with unicode encoded text.</change>
          <change who="PL" when="2017-07-21">Marked up minimally the text provided.</change>
          <change who="DR" when="2018-11-28">Added TUK IDs</change>
-         <change who="NV" when="2024-11-25">changed the title, added lists of witnesses used for
-            editions and / or translations, extanded bibl.</change>
+         <change who="NV" when="2024-11-25">changed the title, added lists of witnesses, associated witnesses with bibliography:</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -234,7 +249,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                <bibl
                   corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
-                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5 #camadd1570 #emml34 #emml179 #emml201 #emml629 #emml1279 #emml1531 #emml1768 #emml1950 #emml2080 #emml2440 #emml3470 #emml4437 #emml6281 #emml6974 #FSUrueppII1 #SHOr271a #petermannIInachtrag29 #tanasee9 #bdleu5">
+                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5 #camadd1570 #emml34 #emml179 #emml201 #emml629 #emml1279 #emml1531 #emml1768 #emml1950 #emml2080 #emml2440 #emml3407 #emml4437 #emml6281 #emml6974 #FSUrueppII1 #SHOr271a #petermannIInachtrag29 #tanasee9 #bdleu5">
                   <ptr target="bm:Uhlig1984Henochbuch"/>
                </bibl>
             </listBibl>

--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -160,7 +160,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <bibl corresp="#bdlbruce74 #bdlor531 #blorient8822 #blorient8823 #fsurueppII1" >
                   <ptr target="bm:Dillmann1851Henoch"/>
                </bibl>
-               <bibl>
+               <bibl corresp="bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
+                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29">
                   <ptr target="bm:Charles1912Enoch"/>
                   ´Orient. 271a
                </bibl>


### PR DESCRIPTION
Hello! I have updated the record: changed the title, developed bibl. I have also created two listwit, one for witnesses used for the editions and one for witnesses used for the translations. I have tried to connect them with precise bibl records. 
I have made some comments in the record, namely that
1)    There are other manuscripts used for editions and translations,  but they do not  seem to exist in the bm for the moment (at least I failed to locate them. There is Princeton Ethiop.2 in bm, but it does not seem to be the right ms), so I left them out. They are the following:
               British and Foreign Bible Society Ms 187, BAV Cerulli 75, Cerulli 110, Cerulli 131, München Cod. aeth. 30, Pontificio Istituto Biblico, Banco A2, II, Princeton Ethiop.2=Garrett Dep. 1468, Zion.
Let me know if they do exist or if you want me to create them. 
2. There are mss, which are  said to be used by Nickelsburg 2001 (EMML 6686,EMML 6706, EMML 6930, EMML 7103, EMML 7584), but one needs to check more to understand. For the moment I left him out. If you think it is right, I will ask Ted Erho for help. 
              
So I would be happy for your expertises on what I have done so far and how I should proceed with the two questions above. 