### PR TITLE
Modifications on the generic miracle record 3592 ( Miracle of Mary: St Mary and Isaac)

### DIFF
--- a/3001-4000/LIT3592Miracle.xml
+++ b/3001-4000/LIT3592Miracle.xml
@@ -6,9 +6,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <fileDesc>
          <titleStmt>
             <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of the monk Isaac</title>
-            <title xml:id="t2" xml:lang="en">Miracle of the monk Yǝsḥāq</title>
+            <title xml:id="t2" xml:lang="en">Miracle of Mary: Miracle of the priest Isaac</title>
             <title xml:id="t3" xml:lang="en">The monk, Yǝsḥaq, who prayed for seven years that St
                Mary would appear to him</title>
+            <title xml:id="t4" xml:lang="en">The priest and Abbot, Yǝsḥaq, who celebrated Marian
+               feast anually, but later migrated to another monastery due to financial problems</title>
          </titleStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
@@ -37,14 +39,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <profileDesc>
          <abstract>
             <p> A miracle conflation appears in various manuscripts, linked to this generic miracle
-               theme. To clarify, two CAe IDs have been established. One ID features a devout monk
-               Isaac who prays to the Virgin Mary for seven years, ultimately receiving a vision of
-               her and a promise of joining her in heaven after three days. The second ID centers
-               also on the same protagonist, Isaac, a despite his devotion during a Marian feast,
-               faces financial struggles and leaves his monastery. The Virgin Mary then appears to
-               chastise him for his departure. Three days later, as she promised, he joined her in
-               heaven. Despite the differing narratives, both versions conclude with the same stanza
-               and miniature.</p>
+               theme. To clarify, two CAe IDs have been established. The first mircale version
+               features a devout monk Isaac who prays to the Virgin Mary for seven years, ultimately
+               receiving a vision of her and a promise of joining her in heaven after three days.
+               The second centers (also on the same protagonist, Isaac) despite his devotion during
+               a Marian feast, faces financial struggles and leaves his monastery. The Virgin Mary
+               then appears to chastise him for his departure. Three days later, as she promised, he
+               joined her in heaven. Despite the differing narratives, both versions conclude with
+               the same stanza and miniature, specifically associated with the so-called ʾAkkonu
+               Bǝʾsi miracles</p>
          </abstract>
          <langUsage>
             <language ident="en">English</language>
@@ -66,6 +69,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
          <change who="DR" when="2018-11-12">Added keyword, Macomber reference</change>
          <change who="AM" when="2019-04-08">added text</change>
          <change who="AM" when="2019-07-29">added relation</change>
+         <change who="GS" when="2024-11-28">added abstract and provided modifications of incipits
+            and relations </change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -109,18 +114,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                            >06v-108</ref>v, StrBritLib 47, n<locus target="#32">32</locus>, 16.-6). -->
             <listRelation>
                <relation name="saws:formsPartOf" active="LIT3592Miracle" passive="LIT2384Taamme"/>
-               
+
             </listRelation>
          </div>
          <div type="edition">
             <div type="textpart" subtype="incipit" xml:lang="gez">
-               <note>This incipit, related to the first miracle version is taken from <ref type="mss" corresp="EMML5520"/>.</note>
+               <note>This incipit, related to the first miracle version is taken from <ref
+                     type="mss" corresp="EMML5520"/>.</note>
                <ab> ወኮነ፡ በዝንቱ፡ ደብር፡ ቅዱስ፡ ዘዝኩር፡ በመዋዕሊሁ፡ ለአቡነ፡ አባ፡ ገብርኤል፡ ሊቀ፡ ጳጳሳት፡ ዘለእስክንድርያ፡ ብእሲ፡
                   መነኮስ፡ ቅዱስ፡ ወእምንእሱ፡ ነበረ፡ ህየ፡ ወስሙ፡ ይስሐቅ። </ab>
             </div>
             <div type="textpart" subtype="incipit" xml:lang="gez">
-               <note>This incipit , related to the second miracle version is taken from <ref type="mss" corresp="EMML 6938, f. 43v"/>.</note>
-               <ab> ወሀሎ፡ በዝንቱ፡ ደብር፡ ዘዝኩር፡ ብእሲ፡ ቀሲስ፡ ዘይሰመይ፡ ይስሐቅ፡ ወውእቱ፡ ሊቀ፡ ምኔት፡ ወለለ፡ ዓመት፡ በገቢረ፡ በዐል፡ ይጻሙ፡ ብዙኀ፡ </ab>
+               <note>This incipit , related to the second miracle version is taken from <ref
+                     type="mss" corresp="EMML 6938, f. 43v"/>.</note>
+               <ab> ወሀሎ፡ በዝንቱ፡ ደብር፡ ዘዝኩር፡ ብእሲ፡ ቀሲስ፡ ዘይሰመይ፡ ይስሐቅ፡ ወውእቱ፡ ሊቀ፡ ምኔት፡ ወለለ፡ ዓመት፡ በገቢረ፡ በዐል፡
+                  ይጻሙ፡ ብዙኀ፡ </ab>
             </div>
          </div>
       </body>

--- a/3001-4000/LIT3592Miracle.xml
+++ b/3001-4000/LIT3592Miracle.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/Schema/master/tei-betamesaheft.rng"
-type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" type="work" xml:lang="en" xml:id="LIT3592Miracle">
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="work" xml:lang="en" xml:id="LIT3592Miracle">
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
             <title xml:id="t1" xml:lang="en">Miracle of Mary: Miracle of the monk Isaac</title>
             <title xml:id="t2" xml:lang="en">Miracle of the monk Yǝsḥāq</title>
-            <title xml:id="t3" xml:lang="en">The monk, Yǝsḥaq, who prayed for seven years that St Mary would appear to him</title>
+            <title xml:id="t3" xml:lang="en">The monk, Yǝsḥaq, who prayed for seven years that St
+               Mary would appear to him</title>
          </titleStmt>
          <publicationStmt>
             <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
-            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+               Forschungsumgebung / Beta maṣāḥǝft</publisher>
             <pubPlace>Hamburg</pubPlace>
             <availability>
                <licence target="http://creativecommons.org/licenses/by-sa/4.0/">
-                  <p>
-                                    This file is licensed under the Creative Commons
-                                    Attribution-ShareAlike 4.0. </p>
+                  <p> This file is licensed under the Creative Commons Attribution-ShareAlike 4.0.
+                  </p>
                </licence>
             </availability>
          </publicationStmt>
@@ -25,7 +27,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+            href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
             <xi:fallback>
                <p>Definitions of prefixes used.</p>
             </xi:fallback>
@@ -33,9 +36,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
       </encodingDesc>
       <profileDesc>
          <abstract>
-            <p/>
+            <p> A miracle conflation appears in various manuscripts, linked to this generic miracle
+               theme. To clarify, two CAe IDs have been established. One ID features a devout monk
+               Isaac who prays to the Virgin Mary for seven years, ultimately receiving a vision of
+               her and a promise of joining her in heaven after three days. The second ID centers
+               also on the same protagonist, Isaac, a despite his devotion during a Marian feast,
+               faces financial struggles and leaves his monastery. The Virgin Mary then appears to
+               chastise him for his departure. Three days later, as she promised, he joined her in
+               heaven. Despite the differing narratives, both versions conclude with the same stanza
+               and miniature.</p>
          </abstract>
-         <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="gez">Gǝʿǝz</language>
+         </langUsage>
          <textClass>
             <keywords>
                <term key="ChristianLiterature"/>
@@ -46,7 +60,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </textClass>
       </profileDesc>
       <revisionDesc>
-         <change who="PL" when="2016-11-17">Created XML record from Ethio authority google spreadsheet</change>
+         <change who="PL" when="2016-11-17">Created XML record from Ethio authority google
+            spreadsheet</change>
          <change who="MV" when="2017-03-31">Added keywords and relations</change>
          <change who="DR" when="2018-11-12">Added keyword, Macomber reference</change>
          <change who="AM" when="2019-04-08">added text</change>
@@ -62,23 +77,23 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <citedRange unit="item">6</citedRange>
                </bibl>
             </listBibl>
-               <listBibl type="translation">
-                  <bibl>
-                     <ptr target="bm:Budge1933Miracles"/>
-                     <citedRange unit="item">6</citedRange>
-                     <citedRange unit="page">20-22</citedRange>
-                  </bibl>
-                  <bibl>
+            <listBibl type="translation">
+               <bibl>
+                  <ptr target="bm:Budge1933Miracles"/>
+                  <citedRange unit="item">6</citedRange>
+                  <citedRange unit="page">20-22</citedRange>
+               </bibl>
+               <bibl>
                   <ptr target="bm:Colin2004TaamraMaryam"/>
                   <citedRange unit="item">101</citedRange>
                   <citedRange unit="page">265-266</citedRange>
                </bibl>
-                  <bibl>
+               <bibl>
                   <ptr target="bm:Colin2004TaamraMaryam"/>
                   <citedRange unit="item">70</citedRange>
                   <citedRange unit="page">187</citedRange>
                </bibl>
-               </listBibl>
+            </listBibl>
             <listBibl type="secondary">
                <bibl>
                   <ptr target="bm:MacomberMiracles"/>
@@ -92,79 +107,20 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                            >32</locus>, I, D.-13; éth. 60, <locus from="15v" to="17">15v-17</locus>,
                         ZotBNat 62, n°60-7; Orient. 8814, fols. 1<ref type="mss" corresp="ES06v108"
                            >06v-108</ref>v, StrBritLib 47, n<locus target="#32">32</locus>, 16.-6). -->
-               <listRelation>
+            <listRelation>
                <relation name="saws:formsPartOf" active="LIT3592Miracle" passive="LIT2384Taamme"/>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML6938">
-                            <desc>see 
-                               <ref type="mss" corresp="EMML6938#43v">EMML 6938, f. 43v</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML5520">
-                            <desc>see
-                               <ref type="mss" corresp="EMML5520#53r">EMML 5520, f. 53r</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML4205">
-                            <desc>see 
-                               <ref type="mss" corresp="EMML4205">EMML 4205, ff. 25v, 51r, 26r</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML2378">
-                            <desc>
-                               <ref type="mss" corresp="EMML2378">EMML 2378, f. 31r</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML6640">
-                            <desc>
-                               <ref type="mss" corresp="EMML6640">EMML 6640, f. 19r</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML2059">
-                            <desc>
-                               <ref type="mss" corresp="EMML2059">EMML 2059, f. 135r</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML2060">
-                            <desc>
-                               <ref type="mss" corresp="EMML2060">EMML 2060, f. 183r</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML2066">
-                            <desc>
-                               <ref type="mss" corresp="EMML2066">EMML 2066, f.  60r, 115v</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML2802">
-                            <desc>
-                               <ref type="mss" corresp="EMML2802">EMML 2803, f. 66v</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML6196">
-                            <desc>
-                               <ref type="mss" corresp="EMML6196">EMML 6196, f. 19v</ref>
-                            </desc>
-                         </relation>
-                         <relation name="lawd:hasAttestation" active="LIT3592Miracle" passive="EMML7543">
-                            <desc>
-                               <ref type="mss" corresp="EMML7543">EMML 7543, f. 27r</ref>
-                            </desc>
-                         </relation>
+               
             </listRelation>
          </div>
          <div type="edition">
-             <div type="textpart" subtype="incipit" xml:lang="gez">
-                <note>This incipit is taken from <ref type="mss" corresp="EMML5520"/>.</note>
-                 <ab>
-                     ወኮነ፡ በዝንቱ፡ ደብር፡ ቅዱስ፡ ዘዝኩር፡ በመዋዕሊሁ፡ ለአቡነ፡ አባ፡ ገብርኤል፡ ሊቀ፡ ጳጳሳት፡ ዘለእስክንድርያ፡
-                     ብእሲ፡ መነኮስ፡ ቅዱስ፡ ወእምንእሱ፡ ነበረ፡ ህየ፡ ወስሙ፡ ይስሐቅ።
-                 </ab>
-             </div>
             <div type="textpart" subtype="incipit" xml:lang="gez">
-               <note>This incipit is taken from <ref type="mss" corresp="EMML4205"/>.</note>
-               <ab>
-                  ወሀሎ፡ አሐዱ፡ መነኮስ፡ ኄር፡ ዘስሙ፡ ይስሐቅ፡ ወያፈቅራ፡ ለእግዝእትነ፡ ማርያም፡
-                  ወእምንእሱ፡ ነበረ፡ በአሐቲ፡ ደብር፡ በመዋዕሊሁ፡ ለአባ፡ ገብርኤል።
-               </ab>
+               <note>This incipit, related to the first miracle version is taken from <ref type="mss" corresp="EMML5520"/>.</note>
+               <ab> ወኮነ፡ በዝንቱ፡ ደብር፡ ቅዱስ፡ ዘዝኩር፡ በመዋዕሊሁ፡ ለአቡነ፡ አባ፡ ገብርኤል፡ ሊቀ፡ ጳጳሳት፡ ዘለእስክንድርያ፡ ብእሲ፡
+                  መነኮስ፡ ቅዱስ፡ ወእምንእሱ፡ ነበረ፡ ህየ፡ ወስሙ፡ ይስሐቅ። </ab>
+            </div>
+            <div type="textpart" subtype="incipit" xml:lang="gez">
+               <note>This incipit , related to the second miracle version is taken from <ref type="mss" corresp="EMML 6938, f. 43v"/>.</note>
+               <ab> ወሀሎ፡ በዝንቱ፡ ደብር፡ ዘዝኩር፡ ብእሲ፡ ቀሲስ፡ ዘይሰመይ፡ ይስሐቅ፡ ወውእቱ፡ ሊቀ፡ ምኔት፡ ወለለ፡ ዓመት፡ በገቢረ፡ በዐል፡ ይጻሙ፡ ብዙኀ፡ </ab>
             </div>
          </div>
       </body>


### PR DESCRIPTION
Following my discussion with , I believe @eu-genia it is essential to create two CAe IDs for the generic miracle record, LIT3592Miracle. This record is linked to several manuscripts, making it difficult to modify. Therefore, I propose to leave the generic record (only modified the realtions and added note in the abstract on the differences) and create two CAe IDs that correspond to it, each providing the specific manuscript attestations for the two related but distinct miracles. I will provide the newly created CAe IDs soon. In the meantime, I would appreciate your thoughts on modifying this generic work record.