### PR TITLE
New texts in BAVet131

### DIFF
--- a/new/LIT7227Blessing.xml
+++ b/new/LIT7227Blessing.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1"> ቃለ፡ በረከት፡ ዘአቡነ፡ ያሬድ፡</title>
-                <title xml:lang="gez" type="normalized" corresp="#t1">Qāla barakat za-ʾabunaYāred Sǝmʿani</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">Qāla barakat za-ʾabunaYāred</title>
                 <title xml:lang="en" corresp="#t1">Blessing of Yāred</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>

--- a/new/LIT7227Blessing.xml
+++ b/new/LIT7227Blessing.xml
@@ -1,0 +1,81 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7227Blessing" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1"> ቃለ፡ በረከት፡ ዘአቡነ፡ ያሬድ፡</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">Qāla barakat za-ʾabunaYāred Sǝmʿani</title>
+                <title xml:lang="en" corresp="#t1">Blessing of Yāred</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>It forms part of the <ref type="work" corresp="LIT3186Meeraf"/>; further study is needed on the distribution of this text as independent work.
+                </p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Liturgy"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2025-01-07">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">            
+                <listRelation>
+                    <relation name="saws:formsPartOf" active="LIT7227Blessing" passive="LIT3186Meeraf"/>
+                </listRelation>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BAVet131"/> according to 
+                        <bibl><ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">529</citedRange></bibl>.</note>
+                    <ab>
+                        ቃለ፡ በረከት፡ ዘአቡነ፡ ያሬድ፡ ካህን፡ ዘይትነበብ፡ በ፫ ዕለታት፡ ወበጎደሎ፡ ዘ<add place="above">ኢ</add>ይትነበብ፡ ሠውር፡ እምላዕሌነ፡ ክበድ፡ ኃጣውኢነ፡
+                        እግዚእነ። ኩን፡ ደምሳሴ፡ ወሰዳዴ፡ በኵሉ፡ ህሊና፡ እኪት። ነጽር፡ እግዚኦ፡ በአዕይንቲከ፡ ወኩን፡ ሰማዔ፡ ኦእግዚኦ፡ አምላክነ፡ አምላከ፡ ሕያዋን፡ አንቅዕት፡ 
+                        ለጽሙኣን፨ ፈኑ፡ ሣህለከ፡ ላዕሌነ። ወሣህሉሰ፡ ለእግዚአብሔር፡ እምዓለም፡ ወስከ፡ ለዓለም፡ ዲበ፡ እለ፡ ይፈርህዎ፡ ለይኩን፡ አሜን።
+                    </ab>
+                </div>
+                <div type="textpart" subtype="explicit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BAVet131"/> according to 
+                        <bibl><ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">530</citedRange></bibl>.</note>
+                    <ab>
+                        ዘጸምዓ፡ ወማየ፡ የሐምግ፡ ወሣእረ፡ <choice><corr resp="PRS4805Grebaut PRS9530Tisseran">ይቀፍጽ፡</corr><sic>ይቅፍጽ፡</sic></choice> ወአይነ፡ 
+                        ጸላኢ፡ ኢይቀርቦ፡ ዘኢይርኅቅ፡ እምእግዚአብሔር፡ ወኢይወጽእ፡ እምሰብእ፡ የሀብክሙ፡ እግዚአብሔር፡ ጸልዩ፡ ወሰአሉ፨
+                    </ab>
+                </div>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7227Blessing.xml
+++ b/new/LIT7227Blessing.xml
@@ -6,8 +6,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1"> ቃለ፡ በረከት፡ ዘአቡነ፡ ያሬድ፡</title>
-                <title xml:lang="gez" type="normalized" corresp="#t1">Qāla barakat za-ʾabunaYāred</title>
-                <title xml:lang="en" corresp="#t1">Blessing of Yāred</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">Qāla barakat za-ʾabuna Yāred</title>
+                <title xml:lang="en" corresp="#t1">Blessing of ʾAbuna Yāred</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="MV"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT7228Order.xml
+++ b/new/LIT7228Order.xml
@@ -1,0 +1,68 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7228Order" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Order of the psalmody for the consecration of the church and the altar</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="MV"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>It may form part of the liturgy for the dedication of a church, as in <ref type="mss" corresp="EMIP00629"/>. 
+                    Further study is needed on the distribution of this text as independent work.
+                </p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Liturgy"/>
+                    <term key="RitualsAndRites"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="MV" when="2025-01-07">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">              
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <ref type="mss" corresp="BAVet131"/> according to 
+                        <bibl><ptr target="bm:GrebTiss1935Codices"/><citedRange unit="page">532-533</citedRange></bibl>.</note>
+                    <ab>
+                        <sic>መዝመር፡</sic> ዘቤተ፡ ክርስቲያን፡ አመ፡ <sic>ሕንፂሃ፡</sic> ወሶበ፡ ታነሥእ፡ ታቦተ፡ ምስለ፡ ንዋየ፡ ግበሪሃ፡
+                    </ab>
+                </div>              
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
Following https://github.com/BetaMasaheft/Documentation/issues/2756, here come two texts contained in BAVet131: the first (Blessing of Yāred) is part of the Mǝʿrāf, the second is part of the liturgy for the consecration of a new church.