### PR TITLE
Create LIT7237QeneFequrana.xml

### DIFF
--- a/new/LIT7237QeneFequrana.xml
+++ b/new/LIT7237QeneFequrana.xml
@@ -1,0 +1,77 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7237QeneFequrana" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">ፍቁራነ፡ ኮኑ፡ ወኢተሴሰዩ፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Fǝqurāna konu wa-ʾitasessayu (Qǝne of the mawaddǝs-kʷǝllǝkǝmu-type)</title>
+                <title xml:lang="en" corresp="#t1">They were happy even though they were not fed…</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <listWit>
+                    <witness corresp="BNFabb145"/>
+                </listWit>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Neither type nor author of the qǝne are indicated in the manuscript. According to the classification by 
+                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl> a qǝne of the 
+                    mawaddǝs-kʷǝllǝkǝmu-type.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Poetry"/>
+                    <term key="Qene"/>
+                    <term key="Kwellekomu"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-01-12">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="edition" xml:lang="gez">
+                <note>This edition is based on <ref type="mss" corresp="BNFabb145"/>, fol. 56ra-b. Division into verses is indicated with ። . 
+                    The end of the poem is indicated with ። ። .</note>
+                <ab>
+                    <l n="1">ፍቁራነ፡ ኮኑ፡ ወኢተሴሰዩ፡ <add place="above">ጊዜ፡ ሞቶሙ፡ ረድኤት፡ ወ</add>ጊዜ፡ ሕይወቶሙ፡ ሣህል<supplied reason="omitted">።</supplied></l> 
+                    <l n="2"> በግበ፡ አንበሳ፡ መፍርህ<choice resp="CH"><sic>።</sic><corr>፡</corr></choice> ኢየሩሳሌም፡ ጥሉል።</l>
+                    <l n="3">ብሔረ፡ መከራ፡ ወጽኑዕ፡ ኃጕል።</l>
+                    <l n="4">በኀበ፡ ዓለም፡ ዳንኤል።</l>
+                    <l n="5">ዘይጸልዕዎ፡ ዘልፈ፡ ኢሎፍሊ፡ ሰብአ፡ በዐል።</l>   
+                    <l n="6">ኀበ፡ ኮነ፡ ወተሠምዖ፡ መገሥፀ፡ ዕልው፡ ቤል።</l>
+                    <l n="7">በባቢሎን፡ ሀገ<del rend="overUnderlined">ሀ</del>ሮሙ፡ እምሀገረ፡ ጽርዕ፡ ዘትሌዓል።</l>  
+                    <l n="8">በዓቢይ፡ ሥልጣን፡ ወ<cb n="56rb"/>መንግሥተ፡ ብዕል።</l>
+                    <l n="9">ሳኦል፡ ጾመ፡ ሙሴ፡ ወዮናታን፡ ሚካኤል። ።</l>
+                </ab>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7237QeneFequrana.xml
+++ b/new/LIT7237QeneFequrana.xml
@@ -6,8 +6,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ፍቁራነ፡ ኮኑ፡ ወኢተሴሰዩ፡</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">Fǝqurāna konu wa-ʾitasessayu (Qǝne of the mawaddǝs-kʷǝllǝkǝmu-type)</title>
-                <title xml:lang="en" corresp="#t1">They were happy even though they were not fed…</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Fǝqurāna konu wa-ʾi-tasesayu (Qǝne of the mawaddǝs kʷǝllǝkǝmu-type)</title>
+                <title xml:lang="en" corresp="#t1">They were loved, but they were not fed…</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -35,8 +35,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <creation/>
             <abstract>
                 <p>Neither type nor author of the qǝne are indicated in the manuscript. According to the classification by 
-                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl> a qǝne of the 
-                    mawaddǝs-kʷǝllǝkǝmu-type.</p>
+                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl>, it is a qǝne of the 
+                    mawaddǝs kʷǝllǝkǝmu-type.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -62,7 +62,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     The end of the poem is indicated with ። ። .</note>
                 <ab>
                     <l n="1">ፍቁራነ፡ ኮኑ፡ ወኢተሴሰዩ፡ <add place="above">ጊዜ፡ ሞቶሙ፡ ረድኤት፡ ወ</add>ጊዜ፡ ሕይወቶሙ፡ ሣህል<supplied reason="omitted">።</supplied></l> 
-                    <l n="2"> በግበ፡ አንበሳ፡ መፍርህ<choice resp="CH"><sic>።</sic><corr>፡</corr></choice> ኢየሩሳሌም፡ ጥሉል።</l>
+                    <l n="2">በግበ፡ አንበሳ፡ መፍርህ<choice resp="CH"><sic>።</sic><corr>፡</corr></choice> ኢየሩሳሌም፡ ጥሉል።</l>
                     <l n="3">ብሔረ፡ መከራ፡ ወጽኑዕ፡ ኃጕል።</l>
                     <l n="4">በኀበ፡ ዓለም፡ ዳንኤል።</l>
                     <l n="5">ዘይጸልዕዎ፡ ዘልፈ፡ ኢሎፍሊ፡ ሰብአ፡ በዐል።</l>   


### PR DESCRIPTION
Several features are problematic in this Qene in BNFet145. 

- [ ] The first problem is the verse break after መፍርህ, which disturbs the rhyme that is always in ል in this poem. For this reason, I have deleted this verse break and moved it to ሣህል, which is two words before. 
- [ ] The second problem is the addition of ጊዜ፡ ሞቶሙ፡ ረድኤት፡  and ወ, which was written between the lines. I am not quite sure, if I have put these words in the right place in verse 1. You can check, if this verse sounds smooth to you. 
- [ ] The third problem is the translation of the title. I have translated it as a circumstantial clause similar to an Arabic ḫāl-sentence. Perhaps you have another suggestion. It may be better to include more words from the first verse in the title. 
- [ ] The fourth is the qene type. If I understand Guidi correctly, all poems with eight verses are mawaddes while nine verses make up a mawaddes kwellekemu. It does not sound very logical to me, but my Italian is too weak to be sure about Guidi's statement. Please check and confirm my assumption (also relevant for LIT7223QeneMenase and other records of mawaddes kwellekemu). 
- [ ] Fifth I did not follow Nafisa's reading of ኢሎፍሲ፡ and preferred ኢሎፍሊ፡, because I think it is about 'Philistines'.