### PR TITLE
Created LIT7240PPAddam

### DIFF
--- a/new/LIT7233PrColic.xml
+++ b/new/LIT7233PrColic.xml
@@ -5,7 +5,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Prayer against colic, chest pain, Dask...</title>
+                <title xml:lang="gez" xml:id="t1">ጸሎት፡ በእንተ፡ ቁርጸት፡ ወውግዓት፡ ደስክ፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Ṣalot baʾǝnta qurṣat wa-wǝgʿāt Dask</title>
+                <title xml:lang="en" corresp="#t1">Prayer against colic and chest pain, Dask...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT7240PPAddam.xml
+++ b/new/LIT7240PPAddam.xml
@@ -1,0 +1,76 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7240PPAddam" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">Prayer by virtue of the secret names revealed by God to Adam</title>
+                <title xml:lang="gez" xml:id="t2">ዘለሐከ፡ ለአዳም፡</title>
+                <title xml:lang="gez" type="normalized" corresp="#t2">Za-laḥaka la-ʾAddām</title>
+                <title xml:lang="en" corresp="#t2">What was revealed (?) to Adam</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Magic prayer by virtue of the secret names revealed by God to <persName ref="PRS1389Adam">Adam</persName>, similar
+                    to <ref type="work" corresp="#LIT4576MagicPr "/> and <ref type="work" corresp="#LIT4600Salot "/> with the
+                    <term key="Asmat">ʾasmāt-word</term> <foreign xml:lang="gez">በኢያኤል</foreign>, which is also attested in 
+                    <ref type="work" corresp="LIT1758Lefafa"/> as well as in <ref type="mss" corresp="ESbmqm010#a2"/> and
+                    <ref type="mss" corresp="BMLor403#ms_i3"/>.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Magic"/>
+                    <term key="Prayers"/>
+                    <term key="Asmat"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-01-13">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="dc:relation" active="LIT7240PPAddam" passive="LIT4576MagicPr"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4576MagicPr"/>.</desc></relation>
+                    <relation name="dc:relation" active="LIT7240PPAddam" passive="LIT4600Salot"><desc>Thematically similar to
+                        <ref type="work" corresp="LIT4600Salot"/>.</desc></relation>
+                </listRelation>
+            </div>
+            <div type="edition">
+                <ab>ወምድር፡ ዘአቀም፡ ለሰማይ፡ ወሣረራ፡ ለምድር፡ ዲበ፡ ማይ፡ ዘለሐከ፡ ለአዳም፡ ነሢኦ፡ መሬተ፡ እምድረ፡ ዱዴሌም፡ በአርአያሁ፡ ወበዓቢይ፡ ግብሩ፡ ወነፍሐ፡ ላዕሌሁ፡ መንፈሰ፡
+                    ሕይወት፡ እንዘ፡ ይብል፡ በስመ፡ <gap reason="ellipsis"/> ወይቤሎ፡ እግዚአብሔር፡ ለአዳም፡ ሀበኒ፡ ንሥሐ፡ ከመ፡ እትወከፍ፡ እምኔከ፡ ወይቤሎ፡ አዳም፡ ለእግዚኡ፡ 
+                    አንተኬ፡ እግዚእየ፡ ሀበኒ፡ ንስሐ፡ ወይቤሎ፡ ክርስቶስ፡ ለአዳም፡ በል፡ አንተ፡ ሀበኒ፡ ንስሐ፡ <gap reason="ellipsis"/> በዝ፡ ቃል፡ 
+                    በሕቡዕ<supplied reason="undefined">፡</supplied> ስምከ፡ በኢያኤል፡ ስምከ፡ በኢያኤል፡ ስምከ፡</ab>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created a record for LIT7240PPAddam as discussed in https://github.com/BetaMasaheft/Documentation/issues/2769. I had difficulties to explain the term ዘለለሐከ. In cannot find ለሐከ in the dictionaries. I thought, it may mean "revealed". If we cannot verify this meaning, I would possibly be better not take this phrase for the title, which is probably not from the beginning, but rather from the end of the text.

I updated the title in LIT7233PrColic.