### PR TITLE
Update LIT1340EnochE.xml

### DIFF
--- a/1001-2000/LIT1340EnochE.xml
+++ b/1001-2000/LIT1340EnochE.xml
@@ -250,7 +250,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
                <bibl
                   corresp="#bavet71 #bnfabb16 #bnfabb30 #bnfabb35 #bnfabb55 #bnfabb99 #bnfabb197 #bnfet49 #bnfet50 #bdlbruce74 #bdlor531 #bladd24185 #bladd24990 #blorient484 #blorient485 #blorient486 #blorient490 #blorient491 #blorient492 #blorient499
-                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5 #camadd1570 #emml36 #emml179 #emml201 #emml629 #emml1279 #emml1531 #emml1768 #emml1950 #emml2080 #emml2440 #emml3407 #emml4437 #emml6281 #emml6974 #FSUrueppII1 #SHOr271a #petermannIInachtrag29 #tanasee9 #bdleu5">
+                  #blorient8822 #blorient8823 #shor271a #fsurueppII1 #jryl23 #petermannIInachtrag29  #tanasee9 #bdleu5 #camadd1570 #emml36 #emml179 #emml201 #emml629 #emml1279 #emml1531 #emml1768 #emml1950 #emml2080 #emml2440 #emml3407 #emml4437 #emml6281 #emml6974 #petermannIInachtrag29 #tanasee9 #bdleu5">
                   <ptr target="bm:Uhlig1984Henochbuch"/>
                </bibl>
             </listBibl>


### PR DESCRIPTION
The IDs `#FSUrueppII1` and `#SHOr271a` are not valid witness IDs. The correct IDs are `#fsurueppII1` and `#shor271a` (capitalization is significant) and both are already present in the list.

