### PR TITLE
Update labels textparts according edition Diez

### DIFF
--- a/6001-7000/LIT6936TarWaAmidBeta.xml
+++ b/6001-7000/LIT6936TarWaAmidBeta.xml
@@ -67,9 +67,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2024-02-15">Created entity</change>
+            <change when="2024-02-15" who="CH">Created entity</change>
             <change when="2024-03-31" who="CH">Updated subdivision of textparts</change>
-            <change when="2024-12-23" who="CH">Added textpart Alexander from Budge edition</change>
+            <change when="2024-12-23" who="CH">Added textpart on Alexander from edition Budge</change>
+            <change when="2024-01-20" who="CH">Added textpart on Moses' wife from edition Derat/Seignobos</change>
+            <change when="2024-01-23" who="CH">Updated labels according to edition Diez</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -145,14 +147,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <bibl>
                             <ptr target="bm:Hoffmann2021Amid"/><citedRange unit="page">62-66</citedRange>
                         </bibl>
-                        <!-- -->
                     </listBibl>
                 </div>
             </div>
             <div type="edition">
-                <note>This division into textparts and the generations' numeration follows the devision in <bibl>
-                    <ptr target="bm:Diez2024Amid"/></bibl>. The orthography of the names follow the attestation in 
-                    <bibl><ptr target="bm:Goldschmidt1897catalogue"/><citedRange unit="page">71–83</citedRange></bibl>.</note> 
+                <note>This division into textparts and labels follows the devision in <bibl><ptr target="bm:Diez2024Amid"/></bibl>.</note> 
                 <div type="textpart" subtype="part" xml:id="Preface">
                     <label>Attribution to the author and outline of the content by the translator.</label>
                 </div>
@@ -192,63 +191,66 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <label>The pre-Islamic history from <persName ref="PRS1386Adam"/> to <persName ref="PRS5294Heracliu"/>.</label>
                 
                     <div type="textpart" subtype="part" xml:id="Adam">
-                        <label>1st Generation - ʾAdam</label>
+                        <label>1st Generation - Adam</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Set">
-                        <label>2nd Generation - Set (Seth)</label>
+                        <label>2nd Generation - Seth</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Enos">
-                        <label>3rd Generation - ʾEnos (Enosh)</label>
+                        <label>3rd Generation - Enosh</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Qaynan">
-                        <label>4th Generation - Qaynān (Kenan)</label>
+                        <label>4th Generation - Kenan</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Malalel">
-                        <label>5th Generation - Mahlālel (Mahalalel)</label>
+                        <label>5th Generation - Mahalalel</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yared">
-                        <label>6th Generation - Yāred (Jared)</label>
+                        <label>6th Generation - Jared</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Henok2">
-                        <label>7th Generation - Henok (Enoch)</label>
+                        <label>7th Generation - Enoch</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Matusela">
-                        <label>8th Generation - Matusālā (Methuselah)</label>
+                        <label>8th Generation - Methuselah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Lameh">
-                        <label>9th Generation - Lameh (Lamech)</label>
+                        <label>9th Generation - Lamech</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Noh">
-                        <label>10th Generation - Noḥ (Noah)</label>
+                        <label>10th Generation - Noah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Sem">
-                        <label>11th Generation - Sem (Shem)</label>
+                        <label>11th Generation - Shem</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Arpaksed">
-                        <label>12th Generation - Arfāksād (Arpachshad)</label>
+                        <label>12th Generation - Arpachshad</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Qaynan2">
-                        <label>13th Generation - Qaynān dāgmāwi (Kenan the second / Kenan son of Arpachshad)</label>
+                        <label>13th Generation - Kenan the second</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Sala">
-                        <label>14th Generation - Sālā (Shelah)</label>
+                        <label>14th Generation - Shelah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Eber">
-                        <label>15th Generation - ʾEber (Eber)</label>
+                        <label>15th Generation - Eber</label>
+                        <div type="textpart" subtype="part" xml:id="EberLife">
+                            <label>Life and language of Eber</label>
+                        </div>
                         <div type="textpart" subtype="part" xml:id="Geography" corresp="#A #D #E #H #J #M #N #P #Q #S #T">
                             <label>Geographical Treatise</label>
                             <note>Based on the edition of 
@@ -605,54 +607,60 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                                 </div>
                             </div>
                         </div>
+                        <div type="textpart" subtype="part" xml:id="Wonders">
+                            <label>The Wonders of the World</label>
+                        </div>
+                        <div type="textpart" subtype="part" xml:id="EberEnd">
+                            <label>Conclusion on Eber's Life</label>
+                        </div>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Faleq">
-                        <label>16th Generation - Fāleq (Peleg)</label>
+                        <label>16th Generation - Peleg</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Ragew">
-                        <label>17th Generation - Rāgǝw (Reu)</label>
+                        <label>17th Generation - Reu</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Sargw">
-                        <label>18th Generation - Sārgǝw (Serug)</label>
+                        <label>18th Generation - Serug</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Nakor">
-                        <label>19th Generation - Nākor (Nahor)</label>
+                        <label>19th Generation - Nahor</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Tara">
-                        <label>20th Generation - Tārā (Terah)</label>
+                        <label>20th Generation - Terah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Abreham">
-                        <label>21st Generation - ʾAbrǝhām (Abraham)</label>
+                        <label>21st Generation - Abraham</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yeshaq">
-                        <label>22nd Generation - Yǝsḥāq (Isaac)</label>
+                        <label>22nd Generation - Isaac</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yaqob">
-                        <label>23rd Generation - Yāʿqob (Jacob)</label>
+                        <label>23rd Generation - Jacob</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Lewi">
-                        <label>24th Generation - Lewi (Levi)</label>
+                        <label>24th Generation - Levi</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Qaat">
-                        <label>25th Generation - Qahat (Kohath)</label>
+                        <label>25th Generation - Kohath</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Anbaran">
-                        <label>26th Generation - ʾAnbaran (Amram)</label>
+                        <label>26th Generation - Amram</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Muse">
-                        <label>27th Generation - Muse (Moses)</label>
+                        <label>27th Generation - Moses</label>
                         <div type="textpart" subtype="part" xml:id="WifeMuse">
                             <label>Story of the Ethiopian wife of Moses</label>
                             <note>The following section on the alleged Ethiopian wife of <persName ref="PRS7181MosesM">Moses</persName> is
@@ -691,51 +699,53 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Iyasu">
-                        <label>28th Generation - ʾIyāsu (Joshua)</label>
+                        <label>28th Generation - Joshua</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Finhos">
-                        <label>29th Generation - Finhos (Phinehas)</label>
+                        <label>29th Generation - Phinehas</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="KusaSenaim">
-                        <label>30th Generation - Kusā Senāʾim (Cushan-Rishathaim)</label>
+                        <label>30th Generation - Cushan-Rishathaim</label>
+                        <note>Referred to as <foreign xml:lang="gez">Kusā Senāʾim</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Gotonyal">
-                        <label>31st Generation - Gotonyāl (Othniel)</label>
+                        <label>31st Generation - Othniel</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Eglon">
-                        <label>32nd Generation (Eglon)</label>
+                        <label>32nd Generation - Eglon</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Ehud">
-                        <label>33rd Generation - ʾEhud (Ehud)</label>
+                        <label>33rd Generation - Ehud</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Semeger">
-                        <label>34th Generation - Semeger (Shamgar)</label>
+                        <label>34th Generation - Shamgar</label>
                     </div>
                     
-                    <div type="textpart" subtype="part" xml:id="Gedewon">
-                        <label>35th Generation - Gedewon (Jabin)</label>
+                    <div type="textpart" subtype="part" xml:id="Jabin">
+                        <label>35th Generation - Jabin</label>
+                        <note>Wrongly attributed to Gedewon in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Dibora">
-                        <label>36th Generation - Diborā (Deborah)</label>
+                        <label>36th Generation - Deborah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="ZebahZalmunna">
-                        <label>37th Generation - (Zebah and Zalmunna)</label>
+                        <label>37th Generation - Zebah and Zalmunna</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Gideon">
-                        <label>38th Generation - Gedeon (Gideon)</label>
+                        <label>38th Generation - Gideon</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Abimelech">
-                        <label>39th Generation - (Abimelech)</label>
+                        <label>39th Generation - Abimelech</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Tola">
@@ -743,7 +753,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Jair">
-                        <label>41st Generation - (Jair)</label>
+                        <label>41st Generation - Jair</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Felestem1">
@@ -752,11 +762,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yeftah">
-                        <label>43rd Generation - Yeftah (Jephthah)</label>
+                        <label>43rd Generation - Jephthah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Abisan">
-                        <label>44th Generation - (Abisan)</label>
+                        <label>44th Generation - Ibzan</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Elon">
@@ -764,7 +774,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Abdon">
-                        <label>46th Generation - (Abdon son of Hillel)</label>
+                        <label>46th Generation - Abdon son of Hillel</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Felestem2">
@@ -777,180 +787,179 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Mika">
-                        <label>49th Generation - Mikā (Micah)</label>
+                        <label>49th Generation - Micah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Eli">
-                        <label>50th Generation - ʾEli (Eli)</label>
+                        <label>50th Generation - Eli</label>
                     </div>     
                     
                     <div type="textpart" subtype="part" xml:id="Samuel">
-                        <label>51st Generation - Sāmuʾel</label>
+                        <label>51st Generation - Samuel</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Saol">
-                        <label>52nd Generation - Sāʾol (Saul)</label>
+                        <label>52nd Generation - Saul</label>
                     </div>
                    
                     <div type="textpart" subtype="part" xml:id="Dawit">
-                        <label>53rd Generation - Dāwit (David)</label>
+                        <label>53rd Generation - David</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Salomon">
-                        <label>54th Generation - Sālomon (Solomon)</label>
+                        <label>54th Generation - Solomon</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Robam">
-                        <label>55th Generation - Robām (Rehoboam)</label>
+                        <label>55th Generation - Rehoboam</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Abya">
-                        <label>56th Generation - ʾAbyā (Abijah)</label>
+                        <label>56th Generation - Abijah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Asaf">
-                        <label>57th Generation - ʾAsāf (Asa)</label>
+                        <label>57th Generation - Asa</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yosafet">
-                        <label>58th Generation - Yosāfet (Jehoshaphat)</label>
+                        <label>58th Generation - Jehoshaphat</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Iyoram">
-                        <label>59th Generation - ʾIyorām (Joram)</label>
+                        <label>59th Generation - Joram</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Akazyas">
-                        <label>60th Generation - ʾAkāzyās (Ahaziah)</label>
+                        <label>60th Generation - Ahaziah</label>
                     </div>
                     
-                    <div type="textpart" subtype="part" xml:id="Gotolya">
-                        <label>61st Generation - Gotolyā (Athaliah)</label>
+                    <div type="textpart" subtype="part" xml:id="Athaliah">
+                        <label>61st Generation - Athaliah</label>
+                        <note>Wrongly attributed to <foreign xml:lang="gez">Gotolyā</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Iyoas">
-                        <label>62nd Generation - ʾIyoʾas (Joash)</label>
+                        <label>62nd Generation - Joash</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Amesyas">
-                        <label>63rd Generation - ʾAmesyās (Amaziah)</label>
+                        <label>63rd Generation - Amaziah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Azaryas">
-                        <label>64th Generation - ʾAzaryās (Uzziah)</label>
+                        <label>64th Generation - Uzziah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Iyoatam">
-                        <label>65th Generation - ʾIyoʾatam (Jotham)</label>
+                        <label>65th Generation - Jotham</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Akaz">
-                        <label>66th Generation - ʾAkaz (Ahaz)</label>
+                        <label>66th Generation - Ahaz</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Hezqeyas">
-                        <label>67th Generation - Ḥǝzqǝyās (Hezekiah)</label>
+                        <label>67th Generation - Hezekiah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Menase">
-                        <label>68th Generation - Mǝnāse (Manasseh)</label>
+                        <label>68th Generation - Manasseh</label>
                     </div>
                     
-                    <div type="textpart" subtype="part" xml:id="Amos">
-                        <label>69th Generation - ʾAmoṣ (Amon)</label>
+                    <div type="textpart" subtype="part" xml:id="Amon">
+                        <label>69th Generation - Amon</label>
+                        <note>Wrongly attributed to <foreign xml:lang="gez">ʾAmoṣ</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Iyosyos">
-                        <label>70th Generation - ʾIyosyos (Josiah)</label>
+                        <label>70th Generation - Josiah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yoakas">
-                        <label>71st Generation - ʾIyoʾakǝs (Jehoahaz)</label>
+                        <label>71st Generation - Jehoahaz</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Elyaqem">
-                        <label>72nd Generation - ʾElyāqem (Joakim)</label>
+                        <label>72nd Generation - Joakim</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yoaqem">
-                        <label>73rd Generation - ʾIyoʾaqem (Joachin)</label>
+                        <label>73rd Generation - Joachin</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Menase2">
-                        <label>74th Generation - Mǝnāse, the last king of Juda (Manasseh)</label>
+                        <label>74th Generation - Manasseh (= Mattaniah) Zedekiah</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Nabudanasor">
-                        <label>75th Generation - Nebukadneṣār (Nebuchadnezzar)</label>
+                        <label>75th Generation - Nebuchadnezzar</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Eweyalmarodeq">
-                        <label>76th Generation - ʾEweyālmārodeq (Evil-Merodach)</label>
+                        <label>76th Generation - Evil-Merodach</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Beltasor">
-                        <label>77th Generation - Beltāṣor (Besshazzar)</label>
+                        <label>77th Generation - Belshazzar</label>
                     </div>
                     
-                    <div type="textpart" subtype="part" xml:id="Daryos">
-                        <label>78th Generation - Dāryos (Darius the Mede)</label>
+                    <div type="textpart" subtype="part" xml:id="DariusCyrus">
+                        <label>78th and 79th Generation - Darius the Mede and Cyrus the Persian</label>
                     </div>
                     
-                    <div type="textpart" subtype="part" xml:id="Kweres">
-                        <label>79th Generation - Kʷǝrǝs (Cyrus)</label>
-                    </div>
-                    
-                    <div type="textpart" subtype="part" xml:id="Fihosyos">
-                        <label>80th Generation - Fihosyos (Cambyses)</label>
+                    <div type="textpart" subtype="part" xml:id="Cambyses">
+                        <label>80th Generation - Cambyses</label>
+                        <note>Referred to as <foreign xml:lang="gez">Fihosyos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Daryos2">
-                        <label>81st Generation - Dāryos (Darius I)</label>
+                        <label>81st Generation - Darius I</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Samardyos">
-                        <label>82nd Generation - Samārdyos Masgalāy (Smerdis the Magian)</label>
+                        <label>82nd Generation - Smerdis the Magian</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Ahsurs">
-                        <label>83rd Generation - ʾAḥsurs (Ahasuerus)</label>
+                        <label>83rd Generation - Ahasuerus (= Xerxes)</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Azdasir">
-                        <label>84th Generation - ʾAzdasir (Artaxerxes I)</label>
+                        <label>84th Generation - Artaxerxes I Longimanus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="AzdaserDagemay">
-                        <label>85th Generation - ʾAzdaser dāgmāy (Artaxerxes II / Xerxes II)</label>
+                        <label>85th Generation - Artaxerxes II (= Xerxes II)</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Saerinos">
-                        <label>86th Generation - Ṣāʿǝrinos (Sogdianus)</label>
+                        <label>86th Generation - Sogdianus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Daryos3">
-                        <label>87th Generation - Dāryos (Darius II)</label>
+                        <label>87th Generation - Darius II Nothos</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Azdaser2">
-                        <label>88th Generation - ʾAzdaser walda ʾǝḫuhu la-Kʷǝrǝs (Artaxerxes II Mnemon)</label>
+                        <label>88th Generation - Artaxerxes II Mnemon</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Azdasir3">
-                        <label>89th Generation - ʾAzdasir za-yǝssammay ʾAkʷǝs (Artaxerxes III Ochus)</label>
+                        <label>89th Generation - Artaxerxes III Ochus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Arses">
-                        <label>90th Generation - ʾArses (Arses)</label>
+                        <label>90th Generation - Arses</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Dara">
-                        <label>91st Generation - Dārā walda ʾArses (Darius III Codomannus)</label>
+                        <label>91st Generation - Darius III Codomannus</label>
                         <note>On <persName ref="PRS14628Daryos"/>, the last emperor of the Achaemenid Persian Empire.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Eskender">
-                        <label>92nd Generation - ʾƎskǝndǝr (Alexander)</label>
+                        <label>92nd Generation - Alexander the Great</label>
                         <note>The following section on life and deeds of <persName ref="PRS1666Alexande"/> is based on the edition of
                             <bibl><ptr target="bm:Budge1896Alexander1"/><citedRange>207-225</citedRange></bibl>, which is based on the
                             attestation in <ref type="mss" corresp="#M">London, British Library, BL Oriental 814, folio 69vc-74vb</ref>.</note>
@@ -1240,226 +1249,243 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos">
-                        <label>93rd Generation - Baṭlimos (Ptolemy I)</label>
+                        <label>93rd Generation - Ptolemy I</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos2">
-                        <label>94th Generation - Baṭlimos (Ptolemy II)</label>
+                        <label>94th Generation - Ptolemy II</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos3">
-                        <label>95th Generation - Baṭlimos (Ptolemy III)</label>
+                        <label>95th Generation - Ptolemy III</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos4">
-                        <label>96th Generation - Baṭlimos (Ptolemy IV)</label>
+                        <label>96th Generation - Ptolemy IV</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos5">
-                        <label>97th Generation - Baṭlimos (Ptolemy V)</label>
+                        <label>97th Generation - Ptolemy V</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos6">
-                        <label>98th Generation - Baṭlimos (Ptolemy VI)</label>
+                        <label>98th Generation - Ptolemy VI</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos7">
-                        <label>99th Generation - Baṭlimos (Ptolemy VII)</label>
+                        <label>99th Generation - Ptolemy VII</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos8">
-                        <label>100th Generation - Baṭlimos (Ptolemy VIII)</label>
+                        <label>100th Generation - Ptolemy VIII</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos9">
-                        <label>101st Generation - Baṭlimos (Ptolemy IX)</label>
+                        <label>101st Generation - Ptolemy IX</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos10">
-                        <label>102nd Generation - Baṭlimos (Ptolemy X)</label>
+                        <label>102nd Generation - Ptolemy X</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos11">
-                        <label>103rd Generation  - Baṭlimos (Ptolemy XI)</label>
+                        <label>103rd Generation  - Ptolemy XI</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos12">
-                        <label>104th Generation - Baṭlimos (Ptolemy XII)</label>
+                        <label>104th Generation - Ptolemy XII</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Batlimos13">
-                        <label>105th Generation - Baṭlimos (Ptolemy XIII)</label>
+                        <label>105th Generation - Ptolemy XIII</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Kalaabetara">
-                        <label>106th Generation - Kalaʾabǝtarā (Cleopatra)</label>
+                        <label>106th Generation - Cleopatra</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Awgustus">
-                        <label>107th Generation - ʾAwgusṭos Qesār (Augustus Caesar)</label>
+                        <label>107th Generation - Augustus Caesar</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Tibaryos">
-                        <label>108th Generation - Ṭibāryos (Tiberius)</label> 
+                        <label>108th Generation - Tiberius</label> 
                             <div type="textpart" subtype="part" xml:id="Christ">
                                 <label>Birth of Christ</label>
                             </div>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Gabyos">
-                        <label>109th Generation - Gābyos (Caius)</label>
+                        <label>109th Generation - Caius</label>
+                        <note>Referred to as <foreign xml:lang="gez">Gābyos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Galyos">
-                        <label>111th Generation - Gālyos (Galba)</label>
+                        <label>111th Generation - Galba</label>
+                        <note>Referred to as <foreign xml:lang="gez">Gālyos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Fitalos">
-                        <label>112th Generation - Fitālos (Vitellius)</label>
+                        <label>112th Generation - Vitellius</label>
+                        <note>Referred to as <foreign xml:lang="gez">Fitālos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Asbasyanos">
-                        <label>113th Generation - ʾAsbāsyānos (Vespasianus)</label>
+                        <label>113th Generation - Vespasianus</label>
+                        <note>Referred to as <foreign xml:lang="gez">ʾAsbāsyānos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Titos">
-                        <label>114th Generation - Titos (Titus)</label>
+                        <label>114th Generation - Titus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Dostyanos">
-                        <label>115th Generation - Dostǝyānos (Domitian)</label>
+                        <label>115th Generation - Domitian</label>
+                        <note>Referred to as <foreign xml:lang="gez">Dostǝyānos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Taodas">
-                        <label>116th Generation - Tāʾodās Qesār (Trajan)</label>
+                        <label>116th Generation - Trajan</label>
+                        <note>Referred to as <foreign xml:lang="gez">Tāʾodās Qesār</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Anadyanos">
-                        <label>117th Generation - ʾAnādyānos (Hadrian)</label>
+                        <label>117th Generation - Hadrian</label>
+                        <note>Referred to as <foreign xml:lang="gez">ʾAnādyānos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Antonyos">
-                        <label>118th Generation - ʾAnṭonǝyos (Antoninus Pius)</label>
+                        <label>118th Generation - Antoninus Pius</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Urelyanos">
-                        <label>ʾAwrelǝyos (Marcus Aurelius)</label>
+                        <label>Marcus Aurelius</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Qamudos">
-                        <label>119th Generation - Qāmudos (Commodus)</label>
+                        <label>Commodus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Faqitabkos">
-                        <label>130th Generation - Faqitabǝkos (Pertinax)</label>
+                        <label>Pertinax</label>
+                        <note>Referred to as <foreign xml:lang="gez">Faqitabǝkos</foreign> in <ref target="#J"/>.</note> 
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Soryanos">
-                        <label>131th Generation - Soryānos (Septimius Severus?)</label>
+                        <label>Septimius Severus?</label>
+                        <note>Referred to as <foreign xml:lang="gez">Faqitabǝkos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Antonyos2">
-                        <label>132th Generation - ʾAnṭonǝyos (Antonius Caracalla)</label>
+                        <label>Antonius Caracalla</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Maqedonyos">
-                        <label>133th Generation - Maqǝdonyos (Macrinus?)</label>
+                        <label>Macrinus</label>
+                        <note>Referred to as <foreign xml:lang="gez">Maqǝdonyos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Entonyos">
-                        <label>134th Generation - ʾƎnṭonǝyos (Antoninus Elagabalus)</label>
+                        <label>Antoninus Elagabalus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Eskenderos">
-                        <label>131th Generation - ʾƎskǝndǝros (Severus Alexander)</label>
+                        <label>Severus Alexander</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Maqsimos">
-                        <label>130th Generation - Maqsimos (Maximinus Thrax)</label>
+                        <label>Maximinus Thrax</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Norinos">
-                        <label>132th Generation - Norinos (?)</label>
+                        <label>Norinos (?)</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Gardeyanos">
-                        <label>Gārdǝyānos (Gordian)</label>
+                        <label>Gordian</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Filpos">
-                        <label>133th Generation - Filṗos (Philip the Arab)</label>
+                        <label>Philip the Arab</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Daqseyos">
-                        <label>134th Generation - Dāqsǝyos (Decius)</label>
+                        <label>Decius</label>
+                        <note>Referred to as <foreign xml:lang="gez">Dāqsǝyos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Galyos2">
-                        <label>135th Generation - Gālyos (Trebonianus Gallus)</label>
+                        <label>Trebonianus Gallus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Walaryanos">
-                        <label>136th Generation - Wālāryānos (Valerian)</label>
+                        <label>Valerian</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Galawdewos">
-                        <label>137th Generation - Galāwdewos (Claudius Gothicus)</label>
+                        <label>Claudius Gothicus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Uralyanos">
-                        <label>138th Generation - ʾUrālyānos (Aurelian)</label>
+                        <label>Aurelian</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Tafsos">
-                        <label>139th Generation - Ṭāfsos (Tacitus)</label>
+                        <label>Tacitus</label>
+                        <note>Referred to as <foreign xml:lang="gez">Ṭāfsos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Abrofos">
-                        <label>140th Generation - ʾAbrofos (Probus)</label>
+                        <label>Probus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Aryos">
-                        <label>141th Generation - ʾAryos (Carus)</label>
+                        <label>Carus</label>
+                        <note>Referred to as <foreign xml:lang="gez">ʾAryos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Deyoqletyanos">
-                        <label>142th Generation - Dǝyoqleṭyānos (Diocletian)</label>
+                        <label>Diocletian</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Maksemyanos">
-                        <label>143th Generation - Maksǝmǝyānos (Maximian)</label>
+                        <label>Maximian</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Qwastantinos">
-                        <label>144th Generation - Qʷǝsṭanṭinos (Constanine I the Great)</label>
+                        <label>Constanine I the Great</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Qwastantinos2">
-                        <label>145th Generation - Qʷǝsṭanṭinos (Constantine II?)</label>
+                        <label>Constantine II (?)</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yolyanos">
-                        <label>146th Generation - Yolyānos (Julian)</label>
+                        <label>Julian</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yokyanos">
-                        <label>148th Generation - Yokyānos (Jovian)</label>
+                        <label>Jovian</label>
+                        <note>Referred to as <foreign xml:lang="gez">Yokyānos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Walitos">
-                        <label>149th Generation - Wāliṭos (Valentinian)</label>
+                        <label>Valentinian</label>
+                        <note>Referred to as <foreign xml:lang="gez">Wāliṭos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Walyos">
-                        <label>150th Generation - Wālyos (Valens?)</label>
+                        <label>Valens (?)</label>
+                        <note>Referred to as <foreign xml:lang="gez">Wālyos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Garadyanos">
-                        <label>151th Generation - Gāradyānos (Gratian)</label>
+                        <label>Gratian</label>
+                        <note>Referred to as <foreign xml:lang="gez">Gāradyānos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Tewodosyos">
-                        <label>152th Generation - Tewodosyos (Theodosius I the Great)</label>
+                        <label>Theodosius I the Great</label>
                         <div type="textpart" subtype="part" xml:id="SevenSleepers">
                             <label>Legend of the Seven Sleepers</label>
                         </div>    
@@ -1469,59 +1495,60 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Arqadyos">
-                        <label>153th Generation - ʾArqādyos (Arcadius)</label>
+                        <label>Arcadius</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Tewodosyos2">
-                        <label>154th Generation - Tewodosyos (Theodosius II)</label>
+                        <label>Theodosius II</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Marqyan">
-                        <label>155th Generation - Mārqyān (Marcian)</label>
+                        <label>Marcian</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Leyon">
-                        <label>156th Generation - Lǝyon (Leo I the Thracian)</label>
+                        <label>Leo I the Thracian</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Leyon2">
-                        <label>157th Generation - Lǝyon (Leo II the Younger)</label>
+                        <label>Leo II the Younger</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Zaynun">
-                        <label>158th Generation - Zāynun (Zeno)</label>
+                        <label>Zeno</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Anestas">
-                        <label>159th Generation - ʾAnastāsius (Anastasius I Dicorus)</label>
+                        <label>Anastasius I Dicorus</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Bestyanos">
-                        <label>160th Generation - Besṭyānos (Justin I)</label>
+                        <label>Justin I</label>
+                        <note>Referred to as <foreign xml:lang="gez">Besṭyānos</foreign> in <ref target="#J"/>.</note>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yostinos">
-                        <label>161th Generation - Yostinos (Justinian I)</label>
+                        <label>Justinian I</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Yostos">
-                        <label>162th Generation - Yostos (Justin II)</label>
+                        <label>Justin II</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Tibaryos2">
-                        <label>163th Generation - Tibāryos (Tiberius II Constantine)</label>
+                        <label>Tiberius II Constantine</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Muriq">
-                        <label>164th Generation - Muriq (Maurice)</label>
+                        <label>Maurice</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Foqa">
-                        <label>165th Generation - Foqā (Phocas)</label>
+                        <label>Phocas</label>
                     </div>
                     
                     <div type="textpart" subtype="part" xml:id="Harqal">
-                        <label>166th Generation - Ḥarqal (Heraclius)</label>
+                        <label>Heraclius</label>
                     </div>
                     
                 <div type="textpart" subtype="part" xml:id="Epilogue">
@@ -1865,6 +1892,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <div type="textpart" subtype="part" xml:id="Councils">
                     <label>The ecumenical councils.</label>
                     
+                    <div type="textpart" subtype="part" xml:id="CouncilsIntro">
+                        <label>Introduction to the history of the Ecumenical Councils</label>
+                    </div>
+                    
                     <div type="textpart" subtype="part" xml:id="CouncilNicaea">
                         <label>The council of Nicaea.</label>
                     </div>
@@ -1895,6 +1926,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     
                     <div type="textpart" subtype="part" xml:id="CouncilConstantinople4">
                         <label>The council of Constantinople. (Constantinople IV)</label>
+                    </div>
+                    
+                    <div type="textpart" subtype="part" xml:id="CouncilExplicit">
+                        <label>Explicit of the history of the Ecumenical Councils</label>
                     </div>
                 </div>
                 


### PR DESCRIPTION
I decided to update the labels of the textparts according to the edition of the Arabic text as published by Diez, which covers the text from Adam to the end of the Achaemenids. I was not content with the transliterations of Ethiopic forms any, which stem from ms. J (FSUor134), because many cases are random garbles and the orthography is not representative for many witnesses. Also the enumeration is distorted and should be better based on the Arabic Vorlage. For this reason, I deleted the numbers of the generations for the latter parts and wait for the publication of the second part by Martino Diez and Livia Muccini later this year. 