### PR TITLE
Update LIT4117Interpretation.xml

### DIFF
--- a/4001-5000/LIT4117Interpretation.xml
+++ b/4001-5000/LIT4117Interpretation.xml
@@ -85,6 +85,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                    <relation name="lawd:hasAttestation" active="LIT4117Interpretation" passive="BNFet150"/>
                    <relation name="saws:isAttributedToAuthor" active="LIT4117Interpretation" passive="PRS14035Yeshaq"/>
                    <relation name="betmas:formerlyAlsoListedAs" active="LIT4117Interpretation" passive="LIT6824CommentariesOldTest"/>
+                   <relation name="betmas:formerlyAlsoListedAs" active="LIT4117Interpretation" passive="LIT6157MamherTasiliye"></relation>
                    <relation name="saws:isCommentOn" active="LIT4117Interpretation" passive="LIT2083Octate"/>
                 </listRelation>
 


### PR DESCRIPTION


I assume this old branch 
https://github.com/BetaMasaheft/Works/compare/master...Tasiliye 
with the changes to `LIT6157MamherTasiliye.xml
` should be deleted as the record `new/LIT6157MamherTasiliye.xml` does not exist any more, it seems to have been deleted and is listed in https://betamasaheft.eu/deleted.html, but unfortunately with no `relation `to tell us why.

It is not pointed to either from `BNFabb149 `(quoted in the relation) nor in `BNFabb195 `(mentioned in the edition)

However the text provided in the edition under the LIT6157MamherTasiliye
```
<ab>
		በስመ፡ እግዚአብሔር፡ መሐሪ፡ ወመስተ፡ ሣህል፨ እወጥን፡ ጽሒፈ፡
		መጽሐፍ፡ ዘይሰምይ፡ መምህር፡ ተስኢልየ፡ እማእምራን፡ መጻሕፍት፨ ርባሁሰ፡
		ለዝ፡ መጽሐፍ፡ ይሜህር፡ ወይተረጉሞ፡ ቃላተ፡ ወነገራተ፡
		ዘኦሪት፡ እንተ፡ የዓፅብ፡ ወይስዓን፡ ለዘኢየአምር፡ ብእሲ፨
		</ab>
```

Makes me think it is actually `LIT4117Interpretation`, so I suggest to add the missing relation to make it clear and delete the stale branch.

(This is the way to proceed with every old branch - carefully check what it has and assess what needs to be done with each record)