### PR TITLE
Up magic (3t, etc)

### DIFF
--- a/new/LIT7059Shimdan.xml
+++ b/new/LIT7059Shimdan.xml
@@ -5,9 +5,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ሺምዳን፡</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">Ṣalot baʾǝnta ḥǝmāma ʿaynat šimdān</title>
-                <title xml:lang="en" corresp="#t1">Prayer against the harm of ʿaynat šimdān</title>
+                <title xml:lang="gez" xml:id="t1">ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ሺምዳን፡ ሺምዳን፡ ሺምዳን፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Ṣalot baʾǝnta ḥǝmāma ʿaynat šimdān šimdān šimdān</title>
+                <title xml:lang="en" corresp="#t1">Prayer against the harm of ʿaynat šimdān šimdān šimdān</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -56,7 +56,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <div type="edition" subtype="incipit" xml:lang="gez">
                 <note>This incipit is taken from <ref type="mss" corresp="BLorient11763"/> according to the catalogue description in 
                     <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">113</citedRange></bibl>.</note>
-                <ab>በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ሺምዳን፡ ተክለ፡ ሽርታን፡</ab>
+                <ab>በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዓይነት፡ ሺምዳን፡ ሺምዳን፡ ሺምዳን፡ ተክለ፡ ሽርታን፡</ab>
             </div><!---->
         </body>
     </text>

--- a/new/LIT7085Papur.xml
+++ b/new/LIT7085Papur.xml
@@ -5,9 +5,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">ጸሎት፡ በእንተ፡ ማዕሠረ፡ አጋንንት፡ ጰጱር፡ ጵውያካኤል፡</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">Ṣalot baʾǝnta māʿśara ʾagānǝnt ṗaṗur ṗǝwyākāʾel</title>
-                <title xml:lang="en" corresp="#t1">Prayer for binding demons ṗaṗur ṗǝwyākāʾel</title>
+                <title xml:lang="gez" xml:id="t1">ጸሎት፡ በእንተ፡ ማዕሠረ፡ አጋንንት፡ ጰጱር፡ ጰጱር፡ ጰጱር፡ ጵውያካኤል፡</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Ṣalot baʾǝnta māʿśara ʾagānǝnt ṗaṗur ṗaṗur ṗaṗur ṗǝwyākāʾel</title>
+                <title xml:lang="en" corresp="#t1">Prayer for binding demons ṗaṗur ṗaṗur ṗaṗur ṗǝwyākāʾel</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -70,7 +70,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <note>The following incipit is taken from <ref type="mss" corresp="BLorient11602"/> as quoted in
                     <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">119</citedRange></bibl>.</note>
                 <div type="textpart" subtype="incipit">
-                    <ab>በስመ፡<gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ማዕሠረ፡ አጋንንት፡ ጰጱር፡ ጵውያካኤል፡</ab>
+                    <ab>በስመ፡<gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ማዕሠረ፡ አጋንንት፡ ጰጱር፡ ጰጱር፡ ጰጱር፡ ጵውያካኤል፡</ab>
                 </div>
             </div>
         </body>

--- a/new/LIT7120Respect.xml
+++ b/new/LIT7120Respect.xml
@@ -56,7 +56,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <note>The following incipit is taken from <ref type="mss" corresp="BLorient12859"/> as quoted in
                     <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">124</citedRange></bibl>.</note>
                 <div type="textpart" subtype="incipit">
-                    <ab>በስመ፡ <gap reason="ellipsis"/> ዑን፡ ነቢ፡ ሰላማ፡ <gap reason="ellipsis"/> ከማሁ፡ <foreign xml:lang="am">አሸብሮሙ፡</foreign>
+                    <ab>በስመ፡ <gap reason="ellipsis"/> ዑን፡ ዑን፡ ዑን፡ ዑን፡ ዑን፡ ዑን፡ ዑን፡ ነቢ፡ ነቢ፡ ነቢ፡ ነቢ፡ ነቢ፡ ነቢ፡ ነቢ፡ ሰላማ፡ <gap reason="ellipsis"/> ከማሁ፡ <foreign xml:lang="am">አሸብሮሙ፡</foreign>
                         ለሰብአ፡ ኵሉ፡ ፍጥረት፡ በግርማ፡ ገጸ፡ ገብርከ፡</ab>
                 </div>
             </div><!---->

--- a/new/LIT7146Zar.xml
+++ b/new/LIT7146Zar.xml
@@ -65,7 +65,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <div type="edition" xml:lang="gez">
                 <note>This incipit is based on <ref type="mss" corresp="BLorient12959"/> according to the catalogue description in 
                     <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">123</citedRange></bibl>.</note>
-                <ab>በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዛር፡ ወትግሪዳ፡ አላሁማ፡ ያቹነጂ፡ አለመለኪ፡</ab>
+                <ab>በስመ፡ <gap reason="ellipsis"/> ጸሎት፡ በእንተ፡ ሕማመ፡ ዛር፡ ወትግሪዳ፡ አላሁማ፡ አላሁማ፡ አላሁማ፡ ያቹነጂ፡ አለመለኪ፡</ab>
             </div>
             <div type="bibliography">
                 <listBibl type="secondary">

--- a/new/LIT7220SalotTekto.xml
+++ b/new/LIT7220SalotTekto.xml
@@ -56,7 +56,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="edition" subtype="incipit" xml:lang="gez">
-                <ab>ጸሎት፡ በእንተ፡ ሕማመ፡ ደም፡ ወ<sic>ውኅዘተ፡</sic> ደም፡ ወትክቶ፡ <sic>ሰስሎሜ፡</sic></ab>
+                <ab>ጸሎት፡ በእንተ፡ ሕማመ፡ ደም፡ ወ<sic>ውኅዘተ፡</sic> ደም፡ ወትክቶ፡ <sic>ሰስሎሜ፡ ሰስሎሜ፡ ሰስሎሜ፡</sic></ab>
             </div>
         </body>
     </text>

--- a/new/LIT7258FetahQ.xml
+++ b/new/LIT7258FetahQ.xml
@@ -5,8 +5,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <teiHeader>
             <fileDesc>
                 <titleStmt>
-                    <title xml:lang="gez" xml:id="t1"> ፍታሕ፡ ቅሕዱዳን፡ አርክያን፡ እምንስቲት፡ መኪርያ፡</title>
-                    <title xml:lang="gez" type="normalized" corresp="#t1">Fǝtāḥ Qǝḥdudān ʾArkyān ʾǝm-nǝstit Makiryā</title>
+                    <title xml:lang="gez" xml:id="t1"> ፍታሕ፡ ቅሕዱዳን፡ ቅሕዱዳን፡ ቅሕዱዳን፡ አርክያን፡ እምንስቲት፡ መኪርያ፡</title>
+                    <title xml:lang="gez" type="normalized" corresp="#t1">Fǝtāḥ Qǝḥdudān Qǝḥdudān Qǝḥdudān ʾArkyān ʾǝm-nǝstit Makiryā</title>
                     <title xml:lang="en" corresp="#t1">Dissolve Qǝḥdudān, ʾArkyān, from the 'small Makiryā'</title>
                     <editor role="generalEditor" key="AB"/>
                     <editor key="CH"/>
@@ -65,7 +65,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <note>This incipit is taken from <ref type="mss" corresp="BLorient13227"/> according to the description in 
                         <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">132</citedRange></bibl>.</note>
                     <div type="edition" subtype="incipit">
-                        <ab>በስመ፡ <gap reason="ellipsis"/> ፍታሕ፡ ቅሕዱዳን፡ አርክያን፡ እምንስቲት፡ መኪርያ፡</ab>
+                        <ab>በስመ፡ <gap reason="ellipsis"/> ፍታሕ፡ ቅሕዱዳን፡ ቅሕዱዳን፡ ቅሕዱዳን፡ አርክያን፡ እምንስቲት፡ መኪርያ፡</ab>
                     </div>    
                 </div>
             </body>


### PR DESCRIPTION
I found the abbreviation 3t., 4t., 7t. etc. in various descriptions by St. Strelcyn. First, I did not understand, what this would mean and ignored it, but later I realized, that the meaning was, that the preceding word is written several times. I updated all LIT records affected by this neglection as proposed in https://github.com/BetaMasaheft/Manuscripts/pull/2835.