### PR TITLE
Create LIT7301QeneBalelit.xml

### DIFF
--- a/new/LIT7301QeneBalelit.xml
+++ b/new/LIT7301QeneBalelit.xml
@@ -34,9 +34,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Neither type nor author of the qǝne are indicated in the manuscript. According to the classification by 
+                <p>Neither the type nor the author of the qǝne are indicated in the manuscript. According to the classification by 
                     <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl> a qǝne of the 
-                    śǝllāse-type.</p>
+                    śǝllāse-type. The story of the poem probably refers to <ref type="work" corresp="LIT2700Kings">2 Kings 3:1-27</ref>.</p>
             </abstract>
             <textClass>
                 <keywords>

--- a/new/LIT7301QeneBalelit.xml
+++ b/new/LIT7301QeneBalelit.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">በሌሊት፡ ለሞዓብ፡ አመ፡ ያጠፍኣ፡ ወአመ፡ ተካፈሉ፡ ሕዝብ፡ በርበረ፡ ቤተ፡ ሞዓብ፡ ኵሎ።</title>
-                <title xml:lang="gez" type="normalized" corresp="#t1">Ba-lelit la-Moʿāb ʾama yāṭaffǝʾā wa-ʾama takāfelu ḥǝzb ba-rǝbara 
+                <title xml:lang="gez" type="normalized" corresp="#t1">Ba-lelit la-Moʿāb ʾama yāṭaffǝʾā wa-ʾama takāfalu ḥǝzb barbara 
                     beta Moʿāb kʷǝllo (qǝne)</title>
                 <title xml:lang="en" corresp="#t1">In the night, when he was destroying Moab, and when the people got separated, he 
                     ransacked the entire house of Moab...</title>
@@ -58,7 +58,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="edition" xml:lang="gez">
-                <note>This edition is based on <ref type="mss" corresp="BNFabb145"/>, fol. 56ra. Division into verses is indicated with ። . 
+                <note>This edition is based on <ref type="mss" corresp="BNFabb145"/>, fol. 56rc. Division into verses is indicated with ። . 
                     The end of the poem is indicated with ። ። ።.</note>
                 <ab>
                     <l n="1">በሌሊት፡ ለሞዓብ፡ አመ፡ ያጠፍአ፡ ወአመ፡ ተካፈሉ፡ ሕዝብ፡ በርበረ፡ ቤተ፡ ሞዓብ፡ ኵሎ።</l> 

--- a/new/LIT7301QeneBalelit.xml
+++ b/new/LIT7301QeneBalelit.xml
@@ -1,0 +1,77 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7301QeneBalelit" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">በሌሊት፡ ለሞዓብ፡ አመ፡ ያጠፍአ፡</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">Ba-lelit la-Moʿāb ʾama yāṭaffǝʾa (qǝne)</title>
+                <title xml:lang="en" corresp="#t1">...</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Neither type nor author of the qǝne are indicated in the manuscript. According to the classification by 
+                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl> possibly a qǝne of the 
+                    mawaddǝs-kʷǝllǝkǝmu-type with nine verses ending in <foreign xml:lang="gez">ሎ</foreign>, if the insertion of three more
+                    verse breaks after <foreign xml:lang="gez">ተከፍሎ፡</foreign> (verse 2), <foreign xml:lang="gez">ይጠበልሎ፡</foreign> (verse 5)
+                    and <foreign xml:lang="gez">ሀሎ፡</foreign> (verse 8) can be accepted.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Poetry"/>
+                    <term key="Qene"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Kwellekomu"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-02-26">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="edition" xml:lang="gez">
+                <note>This edition is based on <ref type="mss" corresp="BNFabb145"/>, fol. 56ra. Division into verses is indicated with ። . 
+                    The end of the poem is indicated with ። ። ።.</note>
+                <ab>
+                    <l n="1">በሌሊት፡ ለሞዓብ፡ አመ፡ ያጠፍአ፡ ወአመ፡ ተካፈሉ፡ ሕዝብ፡ በርበረ፡ ቤተ፡ ሞዓብ፡ ኵሎ።</l> 
+                    <l n="2">እምነ፡ ገቦሁ፡ ሰሜን፡ ኢያእመሩ፡ ተከፍሎ<supplied reason="omitted" resp="CH">።</supplied></l>
+                    <l n="3"> ነጐድጓድ፡ አቢሳ፡ ወኢዮዓብ፡ ዓውሎ።</l>
+                    <l n="4">ለዳዊት፡ መብረቀ፡ ሴሎ።</l>
+                    <l n="5">ደመና፡ አኪሚሌከ፡ ወልታ፡ ዘእምቀዳሚ፡ ይጠበልሎ<supplied reason="omitted" resp="CH">።</supplied></l>
+                    <l n="6">ለከሰ፡ አማኑኤል፡ ሐዋርያ፡ ጽሑፍ፡ ተሣህሎ።</l>
+                    <l n="7">መላእክተ፡ ኢተለውከ፡ እስከ፡ ቀራንዮ፡ ለተሰቅሎ።</l>
+                    <l n="8">እመኒ፡ ፩፡ ዮሐንስ፡ በገቦ፡ መስቀልከ፡ ሀሎ<supplied reason="omitted" resp="CH">።</supplied></l>
+                    <l n="9">ይፁር፡ መስቀለከ፡ ለዮሐንስ፡ ኢተክህሎ። ። ።</l>
+                </ab>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7301QeneBalelit.xml
+++ b/new/LIT7301QeneBalelit.xml
@@ -5,9 +5,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">በሌሊት፡ ለሞዓብ፡ አመ፡ ያጠፍአ፡</title>
-                <title xml:lang="gez" type="normalized" corresp="#t1">Ba-lelit la-Moʿāb ʾama yāṭaffǝʾa (qǝne)</title>
-                <title xml:lang="en" corresp="#t1">...</title>
+                <title xml:lang="gez" xml:id="t1">በሌሊት፡ ለሞዓብ፡ አመ፡ ያጠፍኣ፡ ወአመ፡ ተካፈሉ፡ ሕዝብ፡ በርበረ፡ ቤተ፡ ሞዓብ፡ ኵሎ።</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">Ba-lelit la-Moʿāb ʾama yāṭaffǝʾā wa-ʾama takāfelu ḥǝzb ba-rǝbara 
+                    beta Moʿāb kʷǝllo (qǝne)</title>
+                <title xml:lang="en" corresp="#t1">In the night, when he was destroying Moab, and when the people got separated, he 
+                    ransacked the entire house of Moab...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -33,17 +35,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <creation/>
             <abstract>
                 <p>Neither type nor author of the qǝne are indicated in the manuscript. According to the classification by 
-                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl> possibly a qǝne of the 
-                    mawaddǝs-kʷǝllǝkǝmu-type with nine verses ending in <foreign xml:lang="gez">ሎ</foreign>, if the insertion of three more
-                    verse breaks after <foreign xml:lang="gez">ተከፍሎ፡</foreign> (verse 2), <foreign xml:lang="gez">ይጠበልሎ፡</foreign> (verse 5)
-                    and <foreign xml:lang="gez">ሀሎ፡</foreign> (verse 8) can be accepted.</p>
+                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl> a qǝne of the 
+                    śǝllāse-type.</p>
             </abstract>
             <textClass>
                 <keywords>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="ChristianLiterature"/>
-                    <term key="Kwellekomu"/>
+                    <term key="Sellase"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -62,14 +62,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     The end of the poem is indicated with ። ። ።.</note>
                 <ab>
                     <l n="1">በሌሊት፡ ለሞዓብ፡ አመ፡ ያጠፍአ፡ ወአመ፡ ተካፈሉ፡ ሕዝብ፡ በርበረ፡ ቤተ፡ ሞዓብ፡ ኵሎ።</l> 
-                    <l n="2">እምነ፡ ገቦሁ፡ ሰሜን፡ ኢያእመሩ፡ ተከፍሎ<supplied reason="omitted" resp="CH">።</supplied></l>
-                    <l n="3"> ነጐድጓድ፡ አቢሳ፡ ወኢዮዓብ፡ ዓውሎ።</l>
-                    <l n="4">ለዳዊት፡ መብረቀ፡ ሴሎ።</l>
-                    <l n="5">ደመና፡ አኪሚሌከ፡ ወልታ፡ ዘእምቀዳሚ፡ ይጠበልሎ<supplied reason="omitted" resp="CH">።</supplied></l>
-                    <l n="6">ለከሰ፡ አማኑኤል፡ ሐዋርያ፡ ጽሑፍ፡ ተሣህሎ።</l>
-                    <l n="7">መላእክተ፡ ኢተለውከ፡ እስከ፡ ቀራንዮ፡ ለተሰቅሎ።</l>
-                    <l n="8">እመኒ፡ ፩፡ ዮሐንስ፡ በገቦ፡ መስቀልከ፡ ሀሎ<supplied reason="omitted" resp="CH">።</supplied></l>
-                    <l n="9">ይፁር፡ መስቀለከ፡ ለዮሐንስ፡ ኢተክህሎ። ። ።</l>
+                    <l n="2">እምነ፡ ገቦሁ፡ ሰሜን፡ ኢያእመሩ፡ ተከፍሎ፡ ነጐድጓድ፡ አቢሳ፡ ወኢዮዓብ፡ ዓውሎ።</l>
+                    <l n="3">ለዳዊት፡ መብረቀ፡ ሴሎ።</l>
+                    <l n="4">ደመና፡ አኪሚሌከ፡ ወልታ፡ ዘእምቀዳሚ፡ ይጠበልሎ፡ ለከሰ፡ አማኑኤል፡ ሐዋርያ፡ ጽሑፍ፡ ተሣህሎ።</l>
+                    <l n="5">መላእክተ፡ ኢተለውከ፡ እስከ፡ ቀራንዮ፡ ለተሰቅሎ።</l>
+                    <l n="6">እመኒ፡ ፩፡ ዮሐንስ፡ በገቦ፡ መስቀልከ፡ ሀሎ፡ ይፁር፡ መስቀለከ፡ ለዮሐንስ፡ ኢተክህሎ። ። ።</l>
                 </ab>
             </div>
         </body>


### PR DESCRIPTION
I created a record for a qene found in BNFabb145 (the last one in this collection). 

In my edition, this is a qene of the mawaddǝs-kʷǝllǝkǝmu-type having nine verses. However, the insertion of three more verse breaks after words ending in ሎ was necessary to achieve this number. Without these emendations, the number of verses would have been six ending up in a śǝllāse-type. 

I do not know the story, that this qene is referring to. I identified Moʿāb with the biblical Moab and translated Barbara with 'Barbaria', but I am not quite sure about the latter. I also emended ያጠፍእ to ያጠፍኡ. Would you please check the translation and the text following after and give me a note, whether you think these emendations are appropriate and correct?

![grafik](https://github.com/user-attachments/assets/92f9002f-d0c0-4d84-b7b6-c9c506bee761)
