### PR TITLE
Create LIT14520QeneZawahabkani.xml

### DIFF
--- a/new/LIT14520QeneZawahabkani.xml
+++ b/new/LIT14520QeneZawahabkani.xml
@@ -1,0 +1,67 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT14520QeneZawahabkani" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">ዘወሀብከኒ፡ ግብረ፡ አምጣነ፡ በትጋህ፡ ፈጸምኩ፡</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">Za-wahabkani gǝbra ʾamṭāna ba-tǝgāh faṣṣamku ... (qǝne of the zaʾamlākiya-type)</title>
+                <title xml:lang="en" corresp="#t1">I completed the task of the vigil you gave to me ...</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>The author of the qǝne is not indicated in the manuscript. The type of the qǝne was indicated in the incipit with 
+                    <foreign xml:lang="gez">ዘአምላኪየ፡</foreign> as an abbreviation for the wāzemā-type.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Poetry"/>
+                    <term key="Qene"/>
+                    
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-03-18">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="edition" xml:lang="gez">
+                <note>This edition is based on <ref type="mss" corresp="EMIP00499"/>, fol. 160b. Division into verses is indicated with ። .</note>
+                <ab>
+                    <l n="1">ዘአምላኪየ፡ ዘወሀብከኒ፡ ግብረ፡ አምጣነ፡ በትጋህ፡ ፈጸምኩ።</l> 
+                    <l n="2">እንዘ፡ ይቀንየኒ፡ ለተፅናስ፡ ላእኩ።</l>
+                    <l n="3">በፍታ፡ ቀሚስ፡ ጎርጎርዮስ፡ ጸግወኒ፡ እስኩ።</l>
+                </ab>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT14520QeneZawahabkani.xml
+++ b/new/LIT14520QeneZawahabkani.xml
@@ -6,7 +6,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ዘወሀብከኒ፡ ግብረ፡ አምጣነ፡ በትጋህ፡ ፈጸምኩ፡</title>
-                <title xml:lang="gez" type="normalized" corresp="#t1">Za-wahabkani gǝbra ʾamṭāna ba-tǝgāh faṣṣamku ... (qǝne of the zaʾamlākiya-type)</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">Za-wahabkanni gǝbra ʾamṭāna ba-tǝgāh faṣṣamku ... (qǝne of the za-ʾamlākiya-type)</title>
                 <title xml:lang="en" corresp="#t1">I completed the task of the vigil you gave to me ...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
@@ -55,9 +55,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="edition" xml:lang="gez">
-                <note>This edition is based on <ref type="mss" corresp="EMIP00499"/>, fol. 160b. Division into verses is indicated with ። .</note>
+                <note>This edition is based on <ref type="mss" corresp="EMIP00499"/>, fol. 160r. Division into verses is indicated with ። .</note>
                 <ab>
-                    <l n="1">ዘአምላኪየ፡ ዘወሀብከኒ፡ ግብረ፡ አምጣነ፡ በትጋህ፡ ፈጸምኩ።</l> 
+                    <l n="1">ዘወሀብከኒ፡ ግብረ፡ አምጣነ፡ በትጋህ፡ ፈጸምኩ።</l> 
                     <l n="2">እንዘ፡ ይቀንየኒ፡ ለተፅናስ፡ ላእኩ።</l>
                     <l n="3">በፍታ፡ ቀሚስ፡ ጎርጎርዮስ፡ ጸግወኒ፡ እስኩ።</l>
                 </ab>

--- a/new/LIT7275QeneWaEsagged.xml
+++ b/new/LIT7275QeneWaEsagged.xml
@@ -59,7 +59,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         <note>This edition is based on <ref type="mss" corresp="BNFabb145"/>, fol. 56rb. Division into verses is indicated with ። . 
                             The end of the poem is indicated with ። ። .</note>
                         <ab>
-                            <l n="1">ዋ። እሰግድ፡ በብረክየ፡ ወበልብየ፡ እገኒ፡ በዕፀ፡ ቅዱስ፡ መስቀል።</l> 
+                            <l n="1">እሰግድ፡ በብረክየ፡ ወበልብየ፡ እገኒ፡ በዕፀ፡ ቅዱስ፡ መስቀል።</l> 
                             <l n="2">እስመ፡ ተቀደሳ፡ በደሙ፡ ለቃል።</l>
                             <l n="3">ኤፍሬምሰ፡ በዕፀ፡ ገዳም፡ ወሐቅል።</l>
                             <l n="4">መንፈቆ፡ ይወዲ፡ ውስተ፡ ነበልባል።</l>

--- a/new/LIT7319QeneZawahab.xml
+++ b/new/LIT7319QeneZawahab.xml
@@ -1,7 +1,7 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT14520QeneZawahabkani" xml:lang="en" type="work">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7319QeneZawahab" xml:lang="en" type="work">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -15,11 +15,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
-                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
                     <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
-                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
                 </availability>
             </publicationStmt>
             <sourceDesc>

--- a/new/LIT7319QeneZawahab.xml
+++ b/new/LIT7319QeneZawahab.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ዘወሀብከኒ፡ ግብረ፡ አምጣነ፡ በትጋህ፡ ፈጸምኩ፡</title>
                 <title xml:lang="gez" type="normalized" corresp="#t1">Za-wahabkanni gǝbra ʾamṭāna ba-tǝgāh faṣṣamku ... (qǝne of the za-ʾamlākiya-type)</title>
-                <title xml:lang="en" corresp="#t1">I completed the task of the vigil you gave to me ...</title>
+                <title xml:lang="en" corresp="#t1">Since I diligently completed the task you gave to me ...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -57,9 +57,18 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <div type="edition" xml:lang="gez">
                 <note>This edition is based on <ref type="mss" corresp="EMIP00499"/>, fol. 157rb. Division into verses is indicated with ። .</note>
                 <ab>
+                    ዘአምላኪየ፡
                     <l n="1">ዘወሀብከኒ፡ ግብረ፡ አምጣነ፡ በትጋህ፡ ፈጸምኩ።</l> 
                     <l n="2">እንዘ፡ ይቀንየኒ፡ ለተፅናስ፡ ላእኩ።</l>
                     <l n="3">በፍታ፡ ቀሚስ፡ ጎርጎርዮስ፡ ጸግወኒ፡ እስኩ።</l>
+                </ab>
+            </div>
+            <div type="translation" xml:lang="en">
+                <note>Translation by Denis Nosnitsin.</note>
+                <ab>
+                    <l n="1">Since I diligently completed the task you gave to me.</l>
+                    <l n="2">I wrote, while he was subjecting me to the hardship.</l>
+                    <l n="3">A piece of cloth, Gorgoryos, please offer me as gift!</l>
                 </ab>
             </div>
         </body>

--- a/new/LIT7319QeneZawahab.xml
+++ b/new/LIT7319QeneZawahab.xml
@@ -55,7 +55,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <div type="edition" xml:lang="gez">
-                <note>This edition is based on <ref type="mss" corresp="EMIP00499"/>, fol. 160r. Division into verses is indicated with ። .</note>
+                <note>This edition is based on <ref type="mss" corresp="EMIP00499"/>, fol. 157rb. Division into verses is indicated with ። .</note>
                 <ab>
                     <l n="1">ዘወሀብከኒ፡ ግብረ፡ አምጣነ፡ በትጋህ፡ ፈጸምኩ።</l> 
                     <l n="2">እንዘ፡ ይቀንየኒ፡ ለተፅናስ፡ ላእኩ።</l>

--- a/new/LIT7319QeneZawahab.xml
+++ b/new/LIT7319QeneZawahab.xml
@@ -68,7 +68,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <ab>
                     <l n="1">Since I diligently completed the task you gave to me.</l>
                     <l n="2">I wrote, while he was subjecting me to the hardship.</l>
-                    <l n="3">A piece of cloth, Gorgoryos, please offer me as gift!</l>
+                    <l n="3">A piece of cloth, Gorgoryos, please bestow upon me!</l>
                 </ab>
             </div>
         </body>


### PR DESCRIPTION
I created record for a Qene poem, which Denis has directed me to. However, the creation of the ID through the app ended up with the unhappy number of LIT14520, what is beyond the expected number in the 7300s. I suggest to change the number, before the branch may be eventually merged.

I did not find an authority file for the Qene-type Za-ʾamlākiya and pronounced the wish to create one in https://github.com/BetaMasaheft/Documentation/issues/2504 and  https://github.com/BetaMasaheft/Documentation/issues/2830.

For the end of the poem, there is one more phrase, which I think, does not belong to the poem (ተፈጸመ፡ ግብረ፡ ሰዓታት።), but may be some instruction or indication of the end of the service or something similar. I did not include this line to the edition of the text.

![grafik](https://github.com/user-attachments/assets/29f0581e-cec4-4535-9c9b-3a579e1cecde)
