### PR TITLE
Create LIT7324QeneIfatara

### DIFF
--- a/new/LIT7301QeneBalelit.xml
+++ b/new/LIT7301QeneBalelit.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">በሌሊት፡ ለሞዓብ፡ አመ፡ ያጠፍኣ፡ ወአመ፡ ተካፈሉ፡ ሕዝብ፡ በርበረ፡ ቤተ፡ ሞዓብ፡ ኵሎ።</title>
                 <title xml:lang="gez" type="normalized" corresp="#t1">Ba-lelit la-Moʿāb ʾama yāṭaffǝʾā wa-ʾama takāfalu ḥǝzb barbara 
-                    beta Moʿāb kʷǝllo (qǝne)</title>
+                    beta Moʿāb kʷǝllo (qǝne of the śǝllāse-type)</title>
                 <title xml:lang="en" corresp="#t1">In the night, when he was destroying Moab, and when the people got separated, he 
                     ransacked the entire house of Moab...</title>
                 <editor role="generalEditor" key="AB"/>

--- a/new/LIT7324QeneIfatara.xml
+++ b/new/LIT7324QeneIfatara.xml
@@ -1,0 +1,70 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7324QeneIfatara" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">ኢፈጠረ፡ ስመ፡ በላዕለ፡ ስሙ፡</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">ʾI-faṭara sǝma ba-lāʿla sǝmu … (qǝne of the śāhlǝka-type)</title>
+                <title xml:lang="en" corresp="#t1">He did not invent the name above his name ...</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>The type of the qǝne is indicated in the manuscript śāhlǝka, which is not mentioned in the classification by 
+                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl>, who instead described qǝne
+                    with three verses as <ref type="authFile" corresp="Mibazhu">Mibazḫu-type</ref> or Za-ʾamlākiya-type.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Poetry"/>
+                    <term key="Qene"/>
+                    
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-03-21">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="edition" xml:lang="gez">
+                <note>This edition is based on <ref type="mss" corresp="EMIP00764"/>, fol. 2r. The end of the poem is indicated with ። .</note>
+                <ab>
+                    ሣህልከ፡
+                    <l n="1">ኢፈጠረ፡ ስመ፡ በላዕለ፡ ስሙ፡</l> 
+                    <l n="2">ወል<sic>ዳ</sic>፡ ሥላሴ፡ መስፍን፡ ዘኢይትሜካህ፡ በአቅ<supplied reason="subaudible" resp="CH">ሙ</supplied>፡</l>
+                    <l n="3">እስመ፡ ብሂለ፡ ዝወልደ፡ ሥላሴ፡ ታሕተ፡ ስም፡ አኮ፡ ሳዕለ፡ ስም፡ ዳዕሙ።</l>
+                </ab>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created a record for a qene from EMIP00764, which Denis recommended to me and which is mentioned in [Issue 2830](https://github.com/BetaMasaheft/Documentation/issues/2830).

The type is indicated above with Śāhlǝka as I understand Denis request in a facebook message. However, this type is not mentioned in Guidi 1901 and we do not have it as an authFile and should possibly create one.

The text is written in a crude hand as an addition on the upper margin. One character is partly lost and I needed to restore it to ሙ to achieve three verses rhymed in ሙ. I hope, you will agree with this emendation.

The content seems to be very abstract and panegyric. You may have a look on the translation and on the edition of the text and may help me with some improvements.

![grafik](https://github.com/user-attachments/assets/4e9bd2f6-b362-4d34-9efd-84f61dbee716)
