### PR TITLE
deleted witnesses that were not used in the edition by Bezold

### DIFF
--- a/1001-2000/LIT1709Kebran.xml
+++ b/1001-2000/LIT1709Kebran.xml
@@ -58,13 +58,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <listWit rend="edition">
                         <witness corresp="BNFet5" xml:id="bnfet5">BnF éthiopien 5</witness>
                        <witness corresp="BNFet146" xml:id="bnfet146">BnF éthiopien 146</witness>
-                       <witness corresp="BNFabb97" xml:id="bnfabb97">BnF d'Abbadie 97</witness>
-                       <witness corresp="BNFabb132" xml:id="bnfabb132">BnF d'Abbadie 132</witness>
-                       <witness corresp="BNFabb152" xml:id="bnfabb152">BnF d'Abbadie 152</witness>
                         <witness corresp="BLorient818" xml:id="blor818">BL oriental 818</witness>
-                       <witness corresp="BLorient819" xml:id="blor819">BL oriental 819</witness>
-                        <witness corresp="EMML50" xml:id="emml50">EMML 50</witness>
-                        <witness corresp="ANLcr27" xml:id="anlcr27">ANL Conti Rossini 27</witness>
                         <witness corresp="BDLbruce87" xml:id="bdlbruce87">Bodleian Bruce 87</witness>
                         <witness corresp="BDLbruce93" xml:id="bdlbruce93">Bodleian Bruce 93</witness>
                        <witness corresp="BerOrFol395" xml:id="berlin395">Berlin, SPK or. fol. 395</witness>


### PR DESCRIPTION
Because everything is said to be based on Bezold´s edition, I have deleted witnesses he did not use. (Abbadie mss will appear in the box and further witnesses since I am describing them now)