### PR TITLE
Create LIT7346QeneLasabaya.xml

### DIFF
--- a/new/LIT7346QeneLasabaya.xml
+++ b/new/LIT7346QeneLasabaya.xml
@@ -1,0 +1,69 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7346QeneLasabaya" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">ለሰብናየ፡ ቤተ፤ ንጉሥ፡ ሀልዮ፡ ሰርዌሁ፡ ዘኢይሰፈር፡ ምጠቁ።</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">La-sabbǝnāya beta nǝguś hallǝyo sǝrwehu za-ʾi-yǝssaffar mǝṭaqu... 
+                    (qǝne of the kʷǝllǝkǝmu mawaddǝs-type)</title>
+                <title xml:lang="en" corresp="#t1">Concerning my scarf of the house, the king after he was bribing his army, who did not 
+                    distribute his elevated (?)...</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Qǝne poem. The type is indicated as mawaddǝs in the manuscript. According to 
+                    <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl>, it is a 
+                    kʷǝllǝkǝmu mawaddǝs-type with nine verses. The author is not indicated.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Poetry"/>
+                    <term key="Qene"/>
+                    <term key="Mawaddes"/>
+                    <term key="Kwellekomu"/>
+                </keywords>                        
+            <div type="edition" xml:lang="gez">
+                <note>This edition is based on <ref type="mss" corresp="PetermannIINachtrag24"/>, fol. 7ra. Division into verses is indicated 
+                    with ። .</note>
+                <ab>
+                    መወድስ፡<!-- Kwellekemu Mawaddes usually has nine verses according to Guidi. However in LIT7279QeneAlbeki, a qene with nine 
+                        verses was indicated with Kwellekemu.-->
+                    <l n="1">ለሰብናየ፡ ቤተ፤ ን<add place="margin">ጉሥ</add><supplied reason="omitted">፡</supplied> ሀልዮ፡ 
+                        <choice resp="CH"><sic>ስ</sic><corr>ሰ</corr></choice>ርዌሁ፡ ዘኢይሰፈር፡ ምጠቁ።</l> 
+                    <l n="2">አምጣነ፡ ብዙሕ፡ ኮነ፡ ትካዘ፡ ዓለም፡ ስዋቁ።</l>
+                    <l n="3">ለማእምራን፡ ኢይትአምር፡ ኍልቁ።</l>
+                    <l n="4">እስከ፡ መጠነዝ፡ ይትላጸቁ።</l> 
+                    <l n="5">ኢያድ<choice resp="CH"><sic>ኃ</sic><corr>ኅ</corr></choice>ንዎ፡ ለምንት፡ እምነፋስ፡ ንጼት፡ ለለ፡ ሠርቁ።</l>
+                    <l n="6">እንዘ፡ ይገፈትዖሙ፡ ከመ፡ በዓቢይ፡ ይደቁ።</l>
+                    <l n="7">ምስሌሁ፡ በኣሕብሮ፡ ዕለ፡ ርእይዎ፡ እስከ፡ ይለህቁ።</l>
+                    <l n="8">አኮኑ፡ ለዝ፡ ቤት፡ አኀተ፡ ኬንዖሁ፡ ወሊቁ።</l>
+                    <l n="9">እግዚእየ፡ ፈኑ፡ እመላእክት፡ ኣቂቦቱ፡ እምዕለ፡ ጽሕቁ።</l>
+                </ab>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7346QeneLasabaya.xml
+++ b/new/LIT7346QeneLasabaya.xml
@@ -5,10 +5,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">ለሰብናየ፡ ቤተ፤ ንጉሥ፡ ሀልዮ፡ ሰርዌሁ፡ ዘኢይሰፈር፡ ምጠቁ።</title>
-                <title xml:lang="gez" type="normalized" corresp="#t1">La-sabbǝnnāya beta nǝguś hallǝyo sǝrwehu za-ʾi-yǝssaffar mǝṭaqu... 
-                    (qǝne of the mawaddǝs za-kʷǝllǝkǝmu-type)</title>
-                <title xml:lang="en" corresp="#t1">For my humanity, the palace, mind, its root has no size...</title>
+                <title xml:lang="gez" xml:id="t1">ለሰብእናየ፡ ቤተ፤ ንጉሥ፡ ሀልዮ፡ ሰርዌሁ፡ ዘኢይሰፈር፡ ምጥቁ።</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">La-sabbʾǝnnāya beta nǝguś hallǝyo sǝrwehu za-ʾi-yǝssaffar mǝṭqu 
+                    (Qǝne of the mawaddǝs za-kʷǝllǝkǝmu-type)</title>
+                <title xml:lang="en" corresp="#t1">Think about my humanity, the house of the King, of immensurable height…</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -61,15 +61,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     with ። .</note>
                 <ab>
                     መወድስ፡
-                    <l n="1">ለሰብናየ፡ ቤተ፤ ን<add place="margin">ጉሥ</add><supplied reason="omitted">፡</supplied> ሀልዮ፡ 
-                        <choice resp="CH"><sic>ስ</sic><corr>ሰ</corr></choice>ርዌሁ፡ ዘኢይሰፈር፡ ምጠቁ።</l> 
+                    <l n="1">ለሰብ<supplied reason="omitted" resp="DN">እ</supplied>ናየ፡ ቤተ፤ 
+                        ን<add place="margin">ጉሥ</add><supplied reason="omitted">፡</supplied> ሀልዮ፡ 
+                        <choice resp="CH"><sic>ስ</sic><corr>ሰ</corr></choice>ርዌሁ፡ ዘኢይሰፈር፡ 
+                        ም<choice resp="JK"><sic>ጠ</sic><corr>ጥ</corr></choice>ቁ።</l> 
                     <l n="2">አምጣነ፡ ብዙሕ፡ ኮነ፡ ትካዘ፡ ዓለም፡ ስዋቁ።</l>
-                    <l n="3">ለማእምራን፡ ኢይትአምር፡ ኍልቁ።</l>
+                    <l n="3">ለማእምራን፡ ኢይትአመር፡ ኍልቁ።</l>
                     <l n="4">እስከ፡ መጠነዝ፡ ይትላጸቁ።</l> 
                     <l n="5">ኢያድ<choice resp="CH"><sic>ኃ</sic><corr>ኅ</corr></choice>ንዎ፡ ለምንት፡ እምነፋስ፡ ንዴት፡ ለለ፡ ሠርቁ።</l>
                     <l n="6">እንዘ፡ ይገፈትዖሙ፡ ከመ፡ በዓቢይ፡ ይደቁ።</l>
                     <l n="7">ምስሌሁ፡ በኣሕብሮ፡ ዕለ፡ ርእይዎ፡ እስከ፡ ይስሀቁ።</l>
-                    <l n="8">አኮኑ፡ ለዝ፡ ቤት፡ አኀተ፡ ኬንያሁ፡ ወሊቁ።</l>
+                    <l n="8">አኮኑ፡ ለዝ፡ ቤት፡ አንተ፡ ኬንያሁ፡ ወሊቁ።</l>
                     <l n="9">እግዚእየ፡ ፈኑ፡ እመላእክት፡ ኣቂቦቱ፡ እምዕለ፡ ጽሕቁ።</l>
                 </ab>
             </div>

--- a/new/LIT7346QeneLasabaya.xml
+++ b/new/LIT7346QeneLasabaya.xml
@@ -53,7 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2025-02-13">Created entity</change>
+            <change who="CH" when="2025-04-22">Created entity</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT7346QeneLasabaya.xml
+++ b/new/LIT7346QeneLasabaya.xml
@@ -8,7 +8,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <title xml:lang="gez" xml:id="t1">ለሰብናየ፡ ቤተ፤ ንጉሥ፡ ሀልዮ፡ ሰርዌሁ፡ ዘኢይሰፈር፡ ምጠቁ።</title>
                 <title xml:lang="gez" type="normalized" corresp="#t1">La-sabbǝnnāya beta nǝguś hallǝyo sǝrwehu za-ʾi-yǝssaffar mǝṭaqu... 
                     (qǝne of the mawaddǝs za-kʷǝllǝkǝmu-type)</title>
-                <title xml:lang="en" corresp="#t1">For my humanity, the palace, mind its root has no size...</title>
+                <title xml:lang="en" corresp="#t1">For my humanity, the palace, mind, its root has no size...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>

--- a/new/LIT7346QeneLasabaya.xml
+++ b/new/LIT7346QeneLasabaya.xml
@@ -7,7 +7,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ለሰብናየ፡ ቤተ፤ ንጉሥ፡ ሀልዮ፡ ሰርዌሁ፡ ዘኢይሰፈር፡ ምጠቁ።</title>
                 <title xml:lang="gez" type="normalized" corresp="#t1">La-sabbǝnāya beta nǝguś hallǝyo sǝrwehu za-ʾi-yǝssaffar mǝṭaqu... 
-                    (qǝne of the kʷǝllǝkǝmu mawaddǝs-type)</title>
+                    (qǝne of the mawaddǝs za-kʷǝllǝkǝmu-type)</title>
                 <title xml:lang="en" corresp="#t1">Concerning my scarf of the house, the king after he was bribing his army, who did not 
                     distribute his elevated (?)...</title>
                 <editor role="generalEditor" key="AB"/>
@@ -36,7 +36,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p>Qǝne poem. The type is indicated as mawaddǝs in the manuscript. According to 
                     <bibl><ptr target="bm:Guidi1900Qene"/><citedRange unit="page">4-5</citedRange></bibl>, it is a 
-                    kʷǝllǝkǝmu mawaddǝs-type with nine verses. The author is not indicated.</p>
+                   mawaddǝs za-kʷǝllǝkǝmu-type with nine verses. The name of the author is not indicated.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -68,7 +68,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="2">አምጣነ፡ ብዙሕ፡ ኮነ፡ ትካዘ፡ ዓለም፡ ስዋቁ።</l>
                     <l n="3">ለማእምራን፡ ኢይትአምር፡ ኍልቁ።</l>
                     <l n="4">እስከ፡ መጠነዝ፡ ይትላጸቁ።</l> 
-                    <l n="5">ኢያድ<choice resp="CH"><sic>ኃ</sic><corr>ኅ</corr></choice>ንዎ፡ ለምንት፡ እምነፋስ፡ ንጼት፡ ለለ፡ ሠርቁ።</l>
+                    <l n="5">ኢያድ<choice resp="CH"><sic>ኃ</sic><corr>ኅ</corr></choice>ንዎ፡ ለምንት፡ እምነፋስ፡ ንዴት፡ ለለ፡ ሠርቁ።</l>
                     <l n="6">እንዘ፡ ይገፈትዖሙ፡ ከመ፡ በዓቢይ፡ ይደቁ።</l>
                     <l n="7">ምስሌሁ፡ በኣሕብሮ፡ ዕለ፡ ርእይዎ፡ እስከ፡ ይለህቁ።</l>
                     <l n="8">አኮኑ፡ ለዝ፡ ቤት፡ አኀተ፡ ኬንዖሁ፡ ወሊቁ።</l>

--- a/new/LIT7346QeneLasabaya.xml
+++ b/new/LIT7346QeneLasabaya.xml
@@ -45,13 +45,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <term key="Qene"/>
                     <term key="Mawaddes"/>
                     <term key="Kwellekomu"/>
-                </keywords>                        
+                </keywords>        
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-02-13">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>                
             <div type="edition" xml:lang="gez">
                 <note>This edition is based on <ref type="mss" corresp="PetermannIINachtrag24"/>, fol. 7ra. Division into verses is indicated 
                     with ። .</note>
                 <ab>
-                    መወድስ፡<!-- Kwellekemu Mawaddes usually has nine verses according to Guidi. However in LIT7279QeneAlbeki, a qene with nine 
-                        verses was indicated with Kwellekemu.-->
+                    መወድስ፡
                     <l n="1">ለሰብናየ፡ ቤተ፤ ን<add place="margin">ጉሥ</add><supplied reason="omitted">፡</supplied> ሀልዮ፡ 
                         <choice resp="CH"><sic>ስ</sic><corr>ሰ</corr></choice>ርዌሁ፡ ዘኢይሰፈር፡ ምጠቁ።</l> 
                     <l n="2">አምጣነ፡ ብዙሕ፡ ኮነ፡ ትካዘ፡ ዓለም፡ ስዋቁ።</l>

--- a/new/LIT7346QeneLasabaya.xml
+++ b/new/LIT7346QeneLasabaya.xml
@@ -6,10 +6,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ለሰብናየ፡ ቤተ፤ ንጉሥ፡ ሀልዮ፡ ሰርዌሁ፡ ዘኢይሰፈር፡ ምጠቁ።</title>
-                <title xml:lang="gez" type="normalized" corresp="#t1">La-sabbǝnāya beta nǝguś hallǝyo sǝrwehu za-ʾi-yǝssaffar mǝṭaqu... 
+                <title xml:lang="gez" type="normalized" corresp="#t1">La-sabbǝnnāya beta nǝguś hallǝyo sǝrwehu za-ʾi-yǝssaffar mǝṭaqu... 
                     (qǝne of the mawaddǝs za-kʷǝllǝkǝmu-type)</title>
-                <title xml:lang="en" corresp="#t1">Concerning my scarf of the house, the king after he was bribing his army, who did not 
-                    distribute his elevated (?)...</title>
+                <title xml:lang="en" corresp="#t1">For my humanity, the palace, mind its root has no size...</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -43,7 +42,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
-                    <term key="Mawaddes"/>
                     <term key="Kwellekomu"/>
                 </keywords>        
             </textClass>
@@ -70,8 +68,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="4">እስከ፡ መጠነዝ፡ ይትላጸቁ።</l> 
                     <l n="5">ኢያድ<choice resp="CH"><sic>ኃ</sic><corr>ኅ</corr></choice>ንዎ፡ ለምንት፡ እምነፋስ፡ ንዴት፡ ለለ፡ ሠርቁ።</l>
                     <l n="6">እንዘ፡ ይገፈትዖሙ፡ ከመ፡ በዓቢይ፡ ይደቁ።</l>
-                    <l n="7">ምስሌሁ፡ በኣሕብሮ፡ ዕለ፡ ርእይዎ፡ እስከ፡ ይለህቁ።</l>
-                    <l n="8">አኮኑ፡ ለዝ፡ ቤት፡ አኀተ፡ ኬንዖሁ፡ ወሊቁ።</l>
+                    <l n="7">ምስሌሁ፡ በኣሕብሮ፡ ዕለ፡ ርእይዎ፡ እስከ፡ ይስሀቁ።</l>
+                    <l n="8">አኮኑ፡ ለዝ፡ ቤት፡ አኀተ፡ ኬንያሁ፡ ወሊቁ።</l>
                     <l n="9">እግዚእየ፡ ፈኑ፡ እመላእክት፡ ኣቂቦቱ፡ እምዕለ፡ ጽሕቁ።</l>
                 </ab>
             </div>


### PR DESCRIPTION
I created a new LIT ID for a qene in PetermannIINachtrag24 as suggested in https://github.com/BetaMasaheft/Documentation/issues/2830#issuecomment-2802066886.

This Qene has 9 verses and is indicated as Mawaddes. It should be thus classified as kʷǝllǝkǝmu mawaddǝs according to Guidis classification.

![Screenshot 2025_kwellekemu mawaddes](https://github.com/user-attachments/assets/ea65c09a-46da-49c8-900e-5e627b9df1ff)

However, I found the same situation in LIT7279QeneAlbeki, which was classified just as kʷǝllǝkǝmu and which must probably be updated to kʷǝllǝkǝmu mawaddǝs, as well as soon as Jonas latest standardisation updates are merged (cf. https://github.com/BetaMasaheft/Works/pull/1550/files).

My translation of the title is rather hazard and may possibly need some improvements.