### PR TITLE
Create LIT7374Zar, Update LIT5844MagicPrayer

### DIFF
--- a/5001-6000/LIT5844MagicPrayer.xml
+++ b/5001-6000/LIT5844MagicPrayer.xml
@@ -31,7 +31,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Generic record for magic prayers against Zār, when no further information is available.</p>
+                <p>Generic record for magic prayers against Zār, to be used, when no further information is available.</p>
             </abstract>
             <textClass>
                 <keywords>

--- a/5001-6000/LIT5844MagicPrayer.xml
+++ b/5001-6000/LIT5844MagicPrayer.xml
@@ -5,8 +5,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <fileDesc>
             <titleStmt>
                 <title xml:lang="gez" xml:id="t1">ጸሎት፡ በእንተ፡ ዛር፡</title>
-                <title xml:lang="gez" corresp="#t1" type="normalized">Ṣalot baʾǝnta zār</title>
-                <title xml:lang="en" xml:id="t2">Magic prayer against zār</title>
+                <title xml:lang="gez" corresp="#t1" type="normalized">Ṣalot baʾǝnta Zār (generic record)</title>
+                <title xml:lang="en" xml:id="t2">Magic prayer against Zār</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="DE"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -31,19 +31,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <profileDesc>
             <creation/>
             <abstract>
-                <p/>
+                <p>Generic record for magic prayers against Zār, when no further information is available.</p>
             </abstract>
             <textClass>
                 <keywords>
                     <term key="ChristianLiterature"/>
                     <term key="Magic"/>
                     <term key="Prayers"/>
+                    <term key="demon"/>
                 </keywords>
             </textClass>
             <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="DE" when="2020-03-05">Created entity</change>
+            <change when="2025-04-23" who="CH">Updated record towards a generic record</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT7374Zar.xml
+++ b/new/LIT7374Zar.xml
@@ -1,13 +1,13 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7341AynatQabu" xml:lang="en" type="work">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7374Zar" xml:lang="en" type="work">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:lang="gez" xml:id="t1">ጸሎተ፡ ዓይነት፡ ቀበሹን፡</title>
-                <title xml:lang="gez" type="normalized" corresp="#t1">Ṣalota ʿāynat qabašun</title>
-                <title xml:lang="en" corresp="#t1">Prayer of the (Evil) eye, qabašun</title>
+                <title xml:lang="gez" xml:id="t1">ጸሎተ፡ ዛር፡ ቄቄል፡ ቤቴል፡ ሮቤል፡</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">Ṣalota Zār qeqel betel robel</title>
+                <title xml:lang="en" corresp="#t1">Prayer (against) Zār, qeqel, betel, robel</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -32,13 +32,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Magic prayer against the Evil eye using ʾasmāt similar to <ref type="work" corresp="LIT6751PPAynat"/>.</p>
+                <p>Magic prayer against Zār using ʾasmāt.</p>
             </abstract>
             <textClass>
                 <keywords>
                     <term key="Magic"/>
                     <term key="Prayers"/>
-                    <term key="EvilEye"/>
+                    <term key="demon"/>
                     <term key="Asmat"/>
                 </keywords>
             </textClass>
@@ -48,23 +48,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="CH" when="2025-04-02">Created entity</change>
+            <change who="CH" when="2025-04-23">Created entity</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
             <div type="edition">
                 <note>The following incipit is taken from <ref type="mss" corresp="BLorient3716c"/> according to the catalogue description in 
-                    <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">142</citedRange></bibl>.</note>
+                    <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="page">141</citedRange></bibl>.</note>
                 <div type="textpart" subtype="incipit">
-                    <ab>ጸሎተ፡ ዓይነት፡ ቀበሹን፡ ቀበሹን፡ ቀበሹን፡ ሐረፃን፡ ሐረፃን፡ ሐረፃን፡</ab>
+                    <ab>በስመ፡ <gap reason="omitted"/> ጸሎተ፡ ዛር፡ ቄቄል፡ ቤቴል፡ ሮቤል፡</ab>
                 </div>
-            </div>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="dc:relation" active="LIT7341AynatQabu" passive="LIT6751PPAynat"><desc>Thematically similar and with
-                        similar ʾasmāt as <ref type="work" corresp="LIT6751PPAynat"/>.</desc></relation>
-                </listRelation>
             </div>
         </body>
     </text>


### PR DESCRIPTION
I created a new work record for a prayer attested in BLorient3716c and transformed LIT5844MagicPrayer to a generic ID for Magic prayers against Zār as outlined in https://github.com/BetaMasaheft/Documentation/issues/2925.

In addition, I made a correction in LIT7341AynatQabu.