### PR TITLE
Added change notes to qene records

### DIFF
--- a/7001-8000/LIT7047Qene.xml
+++ b/7001-8000/LIT7047Qene.xml
@@ -23,9 +23,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"></witness>
-                </listWit> </sourceDesc>
+                <p/>
+            </sourceDesc>
         </fileDesc>
         <encodingDesc>
             <p>A digital born TEI file</p>
@@ -38,6 +37,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Wazema"/>
@@ -50,6 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-08-27">Created entity</change>
+            <change when="2024-09-01" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -64,11 +65,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="4">ገብረ፡ መንፈስ፡ ቅዱስ፡ ዓለመ፡ ሰማየ፡ አፍራስ።</l>
                     <l n="5">ዘወረድከ፡ ይእዜ፡ በነፍስ። ።</l>
                 </ab>
-            </div>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT7047Qene" passive="BNFabb145"></relation>
-                </listRelation>
             </div>
         </body>
     </text>

--- a/7001-8000/LIT7052Qene.xml
+++ b/7001-8000/LIT7052Qene.xml
@@ -25,9 +25,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -42,6 +40,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Kwellekomu"/>
@@ -54,6 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-08-30">Created entity</change>
+            <change when="2024-09-01" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -72,11 +72,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="8">በተራከቡ፡ ኢንበል፡ ለፀዊረ፡ ዝንቱ፡ ፀሐይ።</l>
                     <l n="9">አእዱግ፡ በቢታንያ፡ ወኪሩቤል፡ በሰማይ። ።</l>
                 </ab>
-            </div>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT7052Qene" passive="BNFabb145"/>
-                </listRelation>
             </div>
         </body>
     </text>

--- a/7001-8000/LIT7055Qene.xml
+++ b/7001-8000/LIT7055Qene.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -39,6 +37,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Wazema"/>
@@ -51,6 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-08-31">Created entity</change>
+            <change when="2024-09-01" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -65,11 +65,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="4">ቅንዋት፡ ርእሱ፡ ለወልድ፡ ዳእሙ፡ ለበወ።</l>
                     <l n="5">ወለኵሉ፡ በአምሳል፡ ዜነወ። ።</l>
                 </ab>
-            </div>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT7055Qene" passive="BNFabb145"/>
-                </listRelation>
             </div>
         </body>
     </text>

--- a/7001-8000/LIT7056Qene.xml
+++ b/7001-8000/LIT7056Qene.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -39,6 +37,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Sellase"/>
@@ -51,6 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-08-31">Created entity</change>
+            <change when="2024-09-01" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -66,11 +66,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="5">መዋቴ፡ መትሩ፡ በሰይፈ፡ ተግሣጽ።</l>
                     <l n="6">ወስቁለ፡ ሰቀሉ፡ በዕፅ። ።</l>
                 </ab>
-            </div>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT7056Qene" passive="BNFabb145"/>
-                </listRelation>
             </div>
         </body>
     </text>

--- a/7001-8000/LIT7060Qene.xml
+++ b/7001-8000/LIT7060Qene.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -39,6 +37,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Wazema"/>
@@ -51,6 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-09-03">Created entity</change>
+            <change when="2024-09-10" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -65,11 +65,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="4">ቅድስና፡ ኪሩቤል፡ ጉባዔሃ፡ ወጻድቅ፡ ነጋዲ፡ ዘይጸንሐ።</l>
                     <l n="5">በኅዳጥ፡ ይሣየጥ፡ ብዙኃ። ።</l>
                 </ab>
-            </div>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT7060Qene" passive="BNFabb145"></relation>
-                </listRelation>
             </div>
         </body>
     </text>

--- a/7001-8000/LIT7061Qene.xml
+++ b/7001-8000/LIT7061Qene.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -39,6 +37,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Mawaddes"/>
@@ -51,6 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-09-03">Created entity</change>
+            <change when="2024-09-10" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -70,12 +70,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="8">ወከመ፡ ደመና፡ ሞተ፡ በግዕ፡ ሠወራ፡ ለቤርሳቤሕ። ።</l>
                 </ab>
             </div>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT7061Qene" passive="BNFabb145"/>
-                </listRelation>
-            </div><!---->
         </body>
-    </text>
-    
+    </text> 
 </TEI>

--- a/7001-8000/LIT7062Qene.xml
+++ b/7001-8000/LIT7062Qene.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -40,6 +38,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Kwellekomu"></term>
@@ -52,6 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-09-03">Created entity</change>
+            <change when="2024-09-10" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -70,11 +70,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="8">ኦነባቢ፡ በግዕ፡ ጊዜ፡ ተዋቅሶ፡ ወፍትሕ።</l>
                     <l n="9">እሳት፡ ዘነብከ፡ ወቀርንከ፡ ማየ፡ አይኅ።</l>
                 </ab>
-            </div>
-            <div type="bibliography">
-                <listRelation>
-                    <relation name="lawd:hasAttestation" active="LIT7062Qene" passive="BNFabb145"/>
-                </listRelation>
             </div>
         </body>
     </text>

--- a/7001-8000/LIT7067Qene.xml
+++ b/7001-8000/LIT7067Qene.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -39,6 +37,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Sellase"/>
@@ -51,6 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-09-09">Created entity</change>
+            <change when="2024-09-10" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -66,8 +66,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <l n="5">እስመ፡ አናኵዕ፡ አጥፍአ፡ እክለ፡ ገራውኅ።</l>
                     <l n="6">ወማዕረረ፡ አማሰነ፡ አይኅ። ።</l>
                 </ab>
-            </div><!---->
+            </div>
         </body>
-        
     </text>
 </TEI>

--- a/7001-8000/LIT7070Qene.xml
+++ b/7001-8000/LIT7070Qene.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -40,6 +38,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Kwellekomu"/>
@@ -52,6 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-09-12">Created entity</change>
+            <change when="2024-09-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7071Qene.xml
+++ b/7001-8000/LIT7071Qene.xml
@@ -25,9 +25,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -41,6 +39,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Sellase"/>
@@ -53,6 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-09-16">Created entity</change>
+            <change when="2024-09-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7125QeneRufael.xml
+++ b/7001-8000/LIT7125QeneRufael.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -40,6 +38,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianLiterature"/>
                     <term key="Poetry"/>
                     <term key="Qene"/>
                     <term key="Wazema"/>
@@ -52,7 +51,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-10-30">Created entity.</change>
-            <change who="CH" when="2024-10-30">Updated edition with several readings supplied by Nafisa Valieva.</change>
+            <change when="2024-10-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski
+                with several readings supplied by Nafisa Valieva.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7128QeneOzyan.xml
+++ b/7001-8000/LIT7128QeneOzyan.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -54,7 +52,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-11-01">Created entity.</change>
-            <change who="CH" when="2024-11-01">Updated edition with several readings supplied by Nafisa Valieva.</change>
+            <change when="2024-11-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski
+                with several readings supplied by Nafisa Valieva.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7221QeneBeelomu.xml
+++ b/7001-8000/LIT7221QeneBeelomu.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -54,6 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
             <change who="CH" when="2024-12-23">Created entity and an edition of the text with several readings supplied by Nafisa Valieva
                 and Denis Nosnitsin.</change>
+            <change when="2024-12-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7222QeneAgbertihu.xml
+++ b/7001-8000/LIT7222QeneAgbertihu.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -55,6 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-12-26">Created entity.</change>
+            <change when="2024-12-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7223QeneMenase.xml
+++ b/7001-8000/LIT7223QeneMenase.xml
@@ -24,9 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -54,7 +52,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2024-11-01">Created entity.</change>
-            <change who="CH" when="2024-11-01">Updated edition with several readings supplied by Nafisa Valieva.</change>
+            <change who="CH" when="2024-11-01">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski
+                with several readings supplied by Nafisa Valieva.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7237QeneFequrana.xml
+++ b/7001-8000/LIT7237QeneFequrana.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFabb145"/>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -53,6 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-01-12">Created entity</change>
+            <change when="2025-01-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7247QeneSemaetena.xml
+++ b/7001-8000/LIT7247QeneSemaetena.xml
@@ -23,9 +23,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <listWit>
-                    <witness corresp="BNFet145">Paris, Bibliothèque nationale de France, BnF Éthiopien 145, fol. 56rb</witness>
-                </listWit>
+                <p/>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -54,6 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-01-16">Created entity</change>
+            <change when="2025-01-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7262QeneHatsibana.xml
+++ b/7001-8000/LIT7262QeneHatsibana.xml
@@ -52,6 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-01-30">Created entity</change>
+            <change when="2025-01-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/7001-8000/LIT7275QeneWaEsagged.xml
+++ b/7001-8000/LIT7275QeneWaEsagged.xml
@@ -51,6 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </profileDesc>
                 <revisionDesc>
                     <change who="CH" when="2025-02-11">Created entity</change>
+                    <change when="2025-03-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski.</change>
                 </revisionDesc>
             </teiHeader>
             <text>

--- a/7001-8000/LIT7279QeneAlbeki.xml
+++ b/7001-8000/LIT7279QeneAlbeki.xml
@@ -53,6 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </profileDesc>
             <revisionDesc>
                 <change who="CH" when="2025-02-13">Created entity</change>
+                <change when="2025-03-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski.</change>
             </revisionDesc>
         </teiHeader>
         <text>

--- a/new/LIT7301QeneBalelit.xml
+++ b/new/LIT7301QeneBalelit.xml
@@ -53,6 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-02-26">Created entity</change>
+            <change when="2025-03-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski.</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT7319QeneZawahab.xml
+++ b/new/LIT7319QeneZawahab.xml
@@ -32,7 +32,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>The author of the qǝne is not indicated in the manuscript. The type of the qǝne was indicated in the incipit with 
+                <p>The author of the qǝne is not indicated in the manuscript. The type of the qǝne was indicated as 
                     <foreign xml:lang="gez">ዘአምላኪየ፡</foreign>.</p>
             </abstract>
             <textClass>
@@ -50,6 +50,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-03-18">Created entity</change>
+            <change when="2025-03-30" who="CH">Corrections according to reviews of Denis Nosnitsin, Jonas Karlsson and Eugenia Sokolinski and
+                added translation by Denis Nosnitsin.</change>
         </revisionDesc>
     </teiHeader>
     <text>


### PR DESCRIPTION
I added change notes to all qene records, that I have created so far, as it was requested in https://github.com/BetaMasaheft/Documentation/issues/2700 in order not to indicate them as "stubs".

I also made some minor updates (deleted source desc, attestation in div, added keyword "Christian Literature" and changed on abstract ("indicated as" to avoid "indicated in incipit" as requested by Denis in another pull request).