### PR TITLE
Title modified

### DIFF
--- a/1001-2000/LIT1076GadlaTensaeWald.xml
+++ b/1001-2000/LIT1076GadlaTensaeWald.xml
@@ -5,9 +5,13 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1" xml:lang="gez">ገድለ፡ ተንስአ፡ ወልድ፡</title>
-            <title corresp="#t1" xml:lang="gez"  type="normalized">Gadla Tansǝʾa Wald</title>
-            <title corresp="#t1" xml:lang="en">Life of Tansǝʾa Wald</title>
+            <title xml:id="t1" xml:lang="gez">ገድለ፡ ተንስአ፡ ወልድ፡ ወመዓዛ፡ ድንግል </title>
+            <title corresp="#t1" xml:lang="gez"  type="normalized">Gadla Tansǝʾa Wald Wa-Maʿāzā Dǝngǝl</title>
+            <title corresp="#t1" xml:lang="en">Life of Tansǝʾa Wald and Maʿāzā Dǝngǝl</title>
+            <title xml:id="t2" xml:lang="gez">መጽሐፈ፡ አኅብሮ፡ ፡ድሙር፡ ገድሎሙ፡ ለአቡነ፡ ተንሥአ፡ ወልድ፡ ወመዓዛ ፡ድንግል </title>
+            <title corresp="#t2" xml:lang="gez"  type="normalized">Maṣḥafa ʾaḫbǝro gadlomu la-ʾAbuna Tansǝʾa Wald Wa-Maʿāzā Dǝngǝl</title>
+            <title corresp="#t2" xml:lang="en">A Combined Hagiography of Tansǝʾa Wald and Maʿāzā Dǝngǝl</title>
+           
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
@@ -47,6 +51,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
       </profileDesc>
       <revisionDesc>
          <change who="ES" when="2024-02-02">CREATED: text record</change>
+         <change who="GS" when="2025-04-16">EDITED: title modified </change>
+         
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">


### PR DESCRIPTION
The manuscript tradition of Tansǝʾa Wald and Maʿāzā Dǝngǝl, respectively the founding and deputy abbots, reflects their close spiritual and devotional connection. Although the Clavis ID is technically applicable as it stands, I have made a slight modification to the title of the work, since it is traditionally known as a combined hagiography. The roles, miracles, and sälǝmāt of the two monks are, in all known cases, compiled together in a single manuscript that narrates the lives of both saints. While the text predominantly offers a detailed biography of ʾAbbā Tansǝʾa Wald, the founder, it presents their stories jointly. Moreover, the church preserves the tabots of both monks, further affirming their shared sanctity and veneration.