### PR TITLE
Created LIT7426HomilyBenj and LIT7427VitaSua

### DIFF
--- a/2001-3000/LIT2122OntheF.xml
+++ b/2001-3000/LIT2122OntheF.xml
@@ -69,11 +69,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <listBibl type="secondary">
                <bibl>
                   <ptr target="bm:Lusini1988patristica"/>
-                  <citedRange>486</citedRange>
+                  <citedRange unit="page">486</citedRange>
                </bibl>
                <bibl>
                   <ptr target="bm:Bausi2007John"/>
-                  <citedRange>294a</citedRange>
+                  <citedRange unit="page">294a</citedRange>
                </bibl>
             </listBibl>
          </div>

--- a/5001-6000/LIT5812OntheC.xml
+++ b/5001-6000/LIT5812OntheC.xml
@@ -6,7 +6,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <titleStmt>
                 <title xml:id="t1" xml:lang="en">On the Crucifixion</title>
                 <title xml:id="t2" xml:lang="en">Homily by Dionysius the Aeropagite on the crucifixion</title>
-                <author ref="PRS7973PseudoD"/>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="DR"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -44,7 +43,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         </profileDesc>
         <revisionDesc>
             <change who="DR" when="2019-12-09">Created entity to substitute LIT5811OntheC</change>
-            <change when="2025-05-13" who="CH">Added relations and author reference to PRS7973PseudoD</change>
+            <change when="2025-05-13" who="CH">Added relations and bibliography as requested by Dorothea Reule</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -53,11 +52,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <listRelation>
                     <relation name="saws:isAttributedToAuthor" active="LIT5812OntheC" passive="PRS7973PseudoD"/>
                     <relation name="saws:isDifferentTo" active="LIT5812OntheC" passive="LIT7427VitaSua"/>
-                    <relation name="saws:isAttributedToAuthor" active="LIT5812OntheC" passive="PRS7973PseudoD"/>
+                    <relation name="ecrm:P129_is_about" active="LIT5812OntheC" passive="PRS7973PseudoD"/>
                 </listRelation>
                 <listBibl type="secondary">
                     <bibl>
                         <ptr target="bm:Muthreich2019Narratio"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Muthreich2022Dionysius"/>
                     </bibl>
                 </listBibl>
             </div>

--- a/new/LIT7426HomilyBenj.xml
+++ b/new/LIT7426HomilyBenj.xml
@@ -1,0 +1,75 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7426HomilyBenj" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:id="t1">Homily of Benjamin of Alexandria for Easter Tuesday</title>
+                <author ref="PRS2659Benjamin"/>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Homily of <persName ref="PRS2659Benjamin"/> on the Resurrection for Easter Tuesday, in which is embedded the 
+                    <ref type="work" corresp="LIT7427VitaSua"/> of <persName ref="PRS7973PseudoD"/>. Copies of this homily offer the 
+                    earliest Geʿez evidence for this apocryphon by far, but a definitive answer to the important question of whether the Narratio de vita
+                    sua was interpolated into the Ethiopic version of the homily soon after its translation or belonged to the original translated text and
+                    then served as the basis for a fuller version subsequently executed from Arabic must await the publication of the full 
+                    pseudo-Benjamin sermon.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianContent"/>
+                    <term key="ChristianLiterature"/>
+                    <term key="Homily"/>
+                    <term key="Translation"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="grc">Greek</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-05-13">Created entity</change>
+            <change when="2025-05-18" who="CH">Corrections after reviews by Dorothea Reule and Nafisa Valieva</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isAttributedToAuthor" active="LIT7426HomilyBenj" passive="PRS2659Benjamin"/>
+                    <relation name="dcterms:hasPart" active="LIT7426HomilyBenj" passive="LIT7427VitaSua"/>
+                </listRelation>
+                <listBibl type="secondary">
+                    <bibl>
+                        <ptr target="bm:Erho2025Palimpsests"/>
+                        <citedRange unit="page">418</citedRange>
+                    </bibl>
+                </listBibl>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7426HomilyBenj.xml
+++ b/new/LIT7426HomilyBenj.xml
@@ -33,10 +33,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p>Homily of <persName ref="PRS2659Benjamin"/> on the Resurrection for Easter Tuesday, in which is embedded the 
                     <ref type="work" corresp="LIT7427VitaSua"/> of <persName ref="PRS7973PseudoD"/>. Copies of this homily offer the 
-                    earliest Geʿez evidence for this apocryphon by far, but a definitive answer to the important question of whether the Narratio de vita
-                    sua was interpolated into the Ethiopic version of the homily soon after its translation or belonged to the original translated text and
-                    then served as the basis for a fuller version subsequently executed from Arabic must await the publication of the full 
-                    pseudo-Benjamin sermon.</p>
+                    earliest Geʿez evidence for this apocryphon.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -53,7 +50,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-05-13">Created entity</change>
-            <change when="2025-05-18" who="CH">Corrections after reviews by Dorothea Reule and Nafisa Valieva</change>
+            <change when="2025-05-13" who="CH">Corrections after review by Nafisa Valieva</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT7426HomilyBenj.xml
+++ b/new/LIT7426HomilyBenj.xml
@@ -32,8 +32,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <creation/>
             <abstract>
                 <p>Homily of <persName ref="PRS2659Benjamin"/> on the Resurrection for Easter Tuesday, in which is embedded the 
-                    <ref type="work" corresp="LIT7427VitaSua"/> of <persName ref="PRS7973PseudoD"/>. Copies of this homily offer the 
-                    earliest Geʿez evidence for this apocryphon.</p>
+                    <ref type="work" corresp="LIT7427VitaSua"/> of <persName ref="PRS7973PseudoD"/>. According to
+                    <bibl><ptr target="bm:Erho2025Palimpsests"/><citedRange unit="page">418</citedRange></bibl>, copies of this homily 
+                    offer the earliest Geʿez evidence for this apocryphon.</p>
             </abstract>
             <textClass>
                 <keywords>
@@ -50,7 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-05-13">Created entity</change>
-            <change when="2025-05-13" who="CH">Corrections after review by Nafisa Valieva</change>
+            <change when="2025-05-13" who="CH">Corrections after reviews by Nafisa Valieva and Dorothea Reule</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT7427VitaSua.xml
+++ b/new/LIT7427VitaSua.xml
@@ -53,6 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <language ident="en">English</language>
                 <language ident="la">Latin</language>
                 <language ident="grc">Greek</language>
+                <language ident="gez">Gǝʿǝz</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
@@ -67,17 +68,33 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <relation name="saws:isAttributedToAuthor" active="LIT7427VitaSua" passive="PRS7973PseudoD"/>
                     <relation name="saws:formsPartOf" active="LIT7427VitaSua" passive="LIT7426HomilyBenj"/>
                 </listRelation>
-            </div>
-            <div type="bibliography">
                 <listBibl type="secondary">
                     <bibl>
                         <ptr target="bm:Muthreich2019Narratio"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Muthreich2022Dionysius"/>
                     </bibl>
                     <bibl>
                         <ptr target="bm:Erho2025Palimpsests"/>
                         <citedRange unit="page">418</citedRange>
                     </bibl>
                 </listBibl>
+            </div>
+            <div type="edition">
+                <div type="textpart" subtype="incipit" xml:lang="gez">
+                    <note>This incipit is taken from <bibl><ptr target="bm:Muthreich2022Dionysius"/>
+                        <citedRange unit="page">32</citedRange></bibl>.</note>
+                    <ab>ይቤ፡ ደዮናስዮስ፡ ገናዊ፡ ዘጸሐፈ፡ በእንተ፡ ስቅለቱ፡ ለመድኃኒነ፡ በእለት፡ ንጽሕት፡ ተጋብዑ፡ አረማውያን፡ ከመ፡ ይሡዑ፡ ውሉደመ፡</ab>
+                </div>
+            </div>
+            <div type="translation">
+                <div type="textpart" subtype="incipit" xml:lang="en">
+                    <note>This translation of the incipit is taken from <bibl><ptr target="bm:Muthreich2022Dionysius"/>
+                        <citedRange unit="page">32</citedRange></bibl>.</note>
+                    <ab>Dionysius the heathen priest <supplied reason="explanation">who wrote</supplied> about the crucifixion of our 
+                        Saviour said: At the time of purification the heathens gathered to sacrifice their sons.</ab>
+                </div>
             </div>
         </body>
     </text>

--- a/new/LIT7427VitaSua.xml
+++ b/new/LIT7427VitaSua.xml
@@ -1,19 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
-type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT5812OntheC" xml:lang="en" type="work">
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7427VitaSua" xml:lang="en" type="work">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title xml:id="t1" xml:lang="en">On the Crucifixion</title>
-                <title xml:id="t2" xml:lang="en">Homily by Dionysius the Aeropagite on the crucifixion</title>
+                <title xml:lang="la" xml:id="t1">Narratio de vita sua</title>
+                <title xml:lang="grc" xml:id="t2greek">CPG 6633</title>
                 <author ref="PRS7973PseudoD"/>
                 <editor role="generalEditor" key="AB"/>
-                <editor key="DR"/>
+                <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
             </titleStmt>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
-                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas:  Eine multimediale
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
                             Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
@@ -22,7 +23,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 </availability>
             </publicationStmt>
             <sourceDesc>
-                <p/>
+                <p>
+                    <listBibl type="clavis">
+                        <bibl type="CPG">
+                            <ptr target="bm:CPG2"/>
+                            <citedRange unit="item">6633</citedRange>
+                        </bibl>
+                    </listBibl>
+                </p>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
@@ -35,29 +43,39 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             </abstract>
             <textClass>
                 <keywords>
+                    <term key="ChristianContent"/>
                     <term key="ChristianLiterature"/>
                     <term key="Homily"/>
-                    <term key="Theology"/>
+                    <term key="Translation"/>
                 </keywords>
             </textClass>
-            <langUsage><language ident="en">English</language></langUsage>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="la">Latin</language>
+                <language ident="grc">Greek</language>
+            </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change who="DR" when="2019-12-09">Created entity to substitute LIT5811OntheC</change>
-            <change when="2025-05-13" who="CH">Added relations and author reference to PRS7973PseudoD</change>
+            <change who="CH" when="2025-05-13">Created entity</change>
+            <change when="2025-05-18" who="CH">Corrections after reviews by Dorothea Reule and Nafisa Valieva</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
             <div type="bibliography">
                 <listRelation>
-                    <relation name="saws:isAttributedToAuthor" active="LIT5812OntheC" passive="PRS7973PseudoD"/>
-                    <relation name="saws:isDifferentTo" active="LIT5812OntheC" passive="LIT7427VitaSua"/>
-                    <relation name="saws:isAttributedToAuthor" active="LIT5812OntheC" passive="PRS7973PseudoD"/>
+                    <relation name="saws:isAttributedToAuthor" active="LIT7427VitaSua" passive="PRS7973PseudoD"/>
+                    <relation name="saws:formsPartOf" active="LIT7427VitaSua" passive="LIT7426HomilyBenj"/>
                 </listRelation>
+            </div>
+            <div type="bibliography">
                 <listBibl type="secondary">
                     <bibl>
                         <ptr target="bm:Muthreich2019Narratio"/>
+                    </bibl>
+                    <bibl>
+                        <ptr target="bm:Erho2025Palimpsests"/>
+                        <citedRange unit="page">418</citedRange>
                     </bibl>
                 </listBibl>
             </div>


### PR DESCRIPTION
I created two new records for the text in PetermannIINachtrag24 and its incorporated test of "Narratio de vita sua" as proposed in https://github.com/BetaMasaheft/Documentation/issues/2944.

I updated LIT5812OntheC as proposed by Dorothea in https://github.com/BetaMasaheft/Documentation/issues/2678.

For indicating author and Clavis ID, I followed the example of LIT2122OntheF, even though, personally, I do not like to indicate CPG6633 both in the title and in source desc, because I think, the first indication in title is redundant.