### PR TITLE
Create ID for Maṣḥafa saʾalt (another text)

### DIFF
--- a/new/LIT7479Saalt.xml
+++ b/new/LIT7479Saalt.xml
@@ -53,7 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-05-26">Created record</change>
-            <change when="2025-05-26" who="CH">Corrections after reviews by Nafisa Valieva and Magdalena Krzyżanowska</change>
+            <change when="2025-05-26" who="CH">Corrections after reviews by Nafisa Valieva and Dorothea Reule</change>
             <change when="2025-06-10" who="CH">Add relation to disambiguate from LIT7516MashafaSa</change>
         </revisionDesc>
     </teiHeader>

--- a/new/LIT7479Saalt.xml
+++ b/new/LIT7479Saalt.xml
@@ -53,7 +53,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-05-26">Created record</change>
-            <!-- Add change element after reviews -->
+            <change when="2025-05-26" who="CH">Corrections after reviews by Nafisa Valieva and Magdalena Krzyżanowska</change>
+            <change when="2025-06-10" who="CH">Add relation to disambiguate from LIT7516MashafaSa</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -198,6 +199,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <label>Chapter 30 - Concerning the coming of events</label>
                     <ab>አንቀጽ፡ በእንተ፡ ዘይመጽእ፡ ወኢይመጽእ።</ab>
                 </div>
+            </div>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isDifferentTo" active="LIT7479Saalt" passive="LIT7516MashafaSa"/>
+                </listRelation>
             </div>
         </body>
     </text>

--- a/new/LIT7479Saalt.xml
+++ b/new/LIT7479Saalt.xml
@@ -43,7 +43,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <keywords>
                     <term key="Magic"/>
                     <term key="ChristianLiterature"/>
-                    <!-- Add keyword Divination according to our discussion in #2993. -->
+                    <term key="Divination"/>
                 </keywords>
             </textClass>
             <langUsage>
@@ -54,7 +54,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <revisionDesc>
             <change who="CH" when="2025-05-26">Created record</change>
             <change when="2025-05-26" who="CH">Corrections after reviews by Nafisa Valieva and Dorothea Reule</change>
-            <change when="2025-06-10" who="CH">Add relation to disambiguate from LIT7516MashafaSa</change>
+            <change when="2025-06-10" who="CH">Add relation to disambiguate from LIT7516MashafaSa, add keyword Divination</change>
         </revisionDesc>
     </teiHeader>
     <text>

--- a/new/LIT7516MashafaSa.xml
+++ b/new/LIT7516MashafaSa.xml
@@ -43,7 +43,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <term key="Magic"/>
                     <term key="Medicine"/>
                     <term key="ChristianLiterature"/>
-                    <!-- Add keyword Divination according to our discussion in #2993. -->
+                    <term key="Divination"/>
                 </keywords>
             </textClass>
             <langUsage>

--- a/new/LIT7516MashafaSa.xml
+++ b/new/LIT7516MashafaSa.xml
@@ -1,0 +1,68 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7516MashafaSa" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="gez" xml:id="t1">መጽሐፈ፡ ሰአልት፡</title>
+                <title xml:lang="gez" type="normalized" corresp="#t1">Maṣḥafa saʾalt</title>
+                <title xml:lang="en" corresp="#t1">Book of Questions</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p>
+                    <listWit>
+                        <witness corresp="BLorient12034"/>
+                    </listWit>
+                </p>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>A treatise on divination different from <ref type="work" corresp="LIT7479Saalt"/>.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Magic"/>
+                    <term key="Medicine"/>
+                    <term key="ChristianLiterature"/>
+                    <!-- Add keyword Divination according to our discussion in #2993. -->
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-06-10">Created record</change>
+            <!-- Add change element after review -->
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isDifferentTo" active="LIT7516MashafaSa" passive="LIT7479Saalt"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created another record for a text, which is described as "Maṣḥafa saʾalt", but different from the one mentioned in the same manuscript (LIT7479Saalt).

I added relations both to LIT7579Saalt and to LIT7516MashafaSa to disambiguate the two from one another.

Cf. https://github.com/BetaMasaheft/Documentation/issues/2992