### PR TITLE
Create records for Maṣḥafa Madḫanit

### DIFF
--- a/1001-2000/LIT1171Awdana.xml
+++ b/1001-2000/LIT1171Awdana.xml
@@ -41,7 +41,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <term key="Chronography"/>
                <term key="Translation"/>
                <term key="Magic"/>
-               <!-- A keyword for Divination could be inserted, if this is decided in Issue #2993 -->
+               <term key="Divination"/>
             </keywords>
          </textClass>
          <langUsage>

--- a/1001-2000/LIT1942Mashaf.xml
+++ b/1001-2000/LIT1942Mashaf.xml
@@ -4,9 +4,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <teiHeader xml:base="https://betamasaheft.eu/">
       <fileDesc>
          <titleStmt>
-            <title xml:id="t1" xml:lang="gez">መጽሐፈ፡ መድኃኒት፡</title>
-            <title corresp="#t1" xml:lang="gez" type="normalized">Maṣḥafa madḫānit</title>
-            <title xml:lang="en" corresp="#t1">Book of Pharmacy</title>
+            <title xml:id="t1" xml:lang="am">መጽሐፈ፡ መድኃኒት፡</title>
+            <title corresp="#t1" xml:lang="am" type="normalized">Maṣḥafa madḫānit</title>
+            <title xml:lang="en" corresp="#t1">Book of Medicine</title>
             <editor role="generalEditor" key="AB"/>
             <funder>Akademie der Wissenschaften in Hamburg</funder>
          </titleStmt>
@@ -35,7 +35,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
+         <abstract>
+            <p>Collection of medical prescriptions, which is reported to originate from Jerusalem, which differs from 
+               <ref type="work" corresp="LIT7529Madhanit"/> and <ref type="work" corresp="LIT7530MashafaMad"/>.</p>
+         </abstract>
+         <langUsage><language ident="en">English</language><language ident="am">Amharic</language></langUsage>
          <textClass>
             <keywords>
                <term key="ChristianLiterature"/>
@@ -49,11 +53,48 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: text record</change>
          <change who="DR" when="2017-03-21">Added keywords and title</change>
+         <change when="2025-06-12" who="CH">Changed title; Added abstract and disambiguated from LIT7529Madhanit and LIT7530MashafaMad</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
-         <ab/>
+         <div type="bibliography">
+            <listRelation>
+               <relation name="saws:isDifferentTo" active="LIT1942Mashaf" passive="LIT7529Madhanit"/>
+               <relation name="saws:isDifferentTo" active="LIT1942Mashaf" passive="LIT7530MashafaMad"/>
+            </listRelation>
+         </div>
+         <div type="edition" xml:lang="am">
+            <note>The division in textparts and the incipits are taken from <ref type="mss" corresp="BLorient828"/> according to the 
+               description in <bibl><ptr target="bm:Wright1877BM"/><citedRange unit="item">CCCC</citedRange>
+                  <citedRange unit="page">324</citedRange></bibl>.</note>
+            <div type="textpart" subtype="chapter" xml:id="Intro">
+               <label>Introduction</label>
+               <ab>ዛቲ፡ መጽሐፈ፡ መድኃኒት፡ ዘውጽአት፡ እምኢየሩሳሌም፡ ለበሽታ፡ ሁሉ፡ ላካላትም፡ ሁሉ፡ በፊት፡ አዋዊወች፡ ሁሉ፡ ያከማቿት፡ ነች፡ ለበሽታ፡ ሁሉ፡ እንድትፈውስ፡</ab>
+            </div>
+            <div type="textpart" subtype="chapter" xml:id="Hair">
+               <label>Chapter 1 - About the growing hair</label>
+               <ab>፩ አንቀጽ፡ ጠጉር፡ የሚያበቅል።</ab>
+            </div>
+            <div type="textpart" subtype="chapter" xml:id="Grey">
+               <label>Chapter 2 - About the grey hair</label>
+               <ab>፪ አንቀጽ፡ ዘሽበት።</ab>
+            </div>
+            <div type="textpart" subtype="chapter" xml:id="Lasht">
+               <label>Chapter 3 - About Lāšt (?)</label>
+               <ab>፫ አንቀጽ፡ ዘላሽት።</ab>
+            </div>
+            <div type="textpart" subtype="chapter" xml:id="Law">
+               <label>Chapter 4 - About the law (?)</label>
+               <ab>፬ አንቀጽ፡ ዘባኃ።</ab>
+            </div>
+            <div type="textpart" subtype="chapter" xml:id="Eye">
+               <label>Chapter 5 - About a hair growing in the eye</label>
+               <note>Thematically similar to <ref type="work" corresp="LIT000000000000#000000"/> and
+                  <ref type="work" corresp="LIT7529Madhanit#Cataract"/>.</note>
+               <ab>፭ አንቀጽ፡ ዘዓይን፡ ጠጉር፡ እንደያበቅል።</ab>
+            </div>
+         </div>
       </body>
    </text>
 </TEI>

--- a/new/LIT7529Madhanit.xml
+++ b/new/LIT7529Madhanit.xml
@@ -1,0 +1,92 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7529Madhanit" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="am" xml:id="t1">መጽሐፈ፡ መድኀኒት፡</title>
+                <title xml:lang="am" type="normalized" corresp="#t1">Maṣḥafa Madḫanit</title>
+                <title xml:lang="en" corresp="#t1">Book of Medicine</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Collection of short medical prescriptions in Amharic, different from <ref type="work" corresp="LIT1942Mashaf"/> and
+                    <ref type="work" corresp="LIT7530MashafaMad"/>.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="Magic"/>
+                    <term key="Medicine"/>
+                    <term key="ChristianLiterature"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-06-12">Created record</change>
+            <!-- Add change element after review -->
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="edition" xml:lang="am">
+                <note>The division in textparts and the incipits are taken from <ref type="mss" corresp="BLorient12034"/> according to the 
+                        description in <bibl><ptr target="bm:Strelcyn1978BritishLibrary"/><citedRange unit="item">98,9</citedRange>
+                            <citedRange unit="page">145</citedRange></bibl>.</note>
+                    <div type="textpart" subtype="chapter" xml:id="Shotalay">
+                        <label>Against Šotalāy</label>
+                        <ab>ሾተላይ፡</ab>
+                    </div>
+                    <div type="textpart" subtype="chapter" xml:id="Impotence">
+                        <label>Against impotence</label>
+                        <ab>ለዘሞተ፡ እስኪቱ፡</ab>
+                    </div>
+                    <div type="textpart" subtype="chapter" xml:id="Genitals">
+                        <label>Against swelling of the genitals</label>
+                        <ab>እስኪቱ፡ ሶበ፡ የሐብጥ፡</ab>
+                    </div>
+                    <div type="textpart" subtype="chapter" xml:id="Child">
+                        <label>Against night terror of a sick child</label>
+                        <ab>ሕፃን፡ በሌሊት፡ በታመመ፡ ጊዜ፡ ቢደነግፅ፡</ab>
+                    </div>
+                    <div type="textpart" subtype="chapter" xml:id="Cataract">
+                        <label>Against cataract</label>
+                        <note>Thematically similar to <ref type="work" corresp="LIT000000000000#000000"/>.</note>
+                        <ab>ለዘይመሰሉ፡ ዓይኑ፡ ጊሜ፡</ab>
+                    </div>
+            </div>
+            <div type="bibliography">
+                <listRelation>
+                    <relation name="saws:isDifferentTo" active="LIT7529Madhanit" passive="LIT1942Mashaf"/>
+                    <relation name="saws:isDifferentTo" active="LIT7529Madhanit" passive="LIT7530MashafaMad"/>
+                    <relation name="saws:isDifferentTo" active="LIT7529Madhanit" passive="LIT000000000000"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/new/LIT7530MashafaMad.xml
+++ b/new/LIT7530MashafaMad.xml
@@ -1,0 +1,71 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7530MashafaMad" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="am" xml:id="t1">መጽሐፈ፡ መድኀኒት፡</title>
+                <title xml:lang="am" type="normalized" corresp="#t1">Maṣḥafa Madḫanit</title>
+                <title xml:lang="en" corresp="#t1">Book of Medicine</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Collection of medical prescriptions in Amharic, which is different from <ref type="work" corresp="LIT1942Mashaf"/> and
+                    <ref type="work" corresp="LIT7529Madhanit"/>. An imperfect index in alphabetical order is prefixed. Presented as a facsimile in 
+                    <bibl><ptr target="bm:Strelcyn1968Medecine"/><citedRange unit="page">597-747</citedRange></bibl> with the siglum C.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
+                    <term key="Medicine"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-06-12">Created record</change>
+            <!-- Add change elements after review -->
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography">
+                <listBibl type="editions">
+                    <bibl> 
+                        <ptr target="bm:Strelcyn1968Medecine"/><citedRange unit="page">597-747</citedRange>
+                    </bibl>
+                </listBibl>
+                <listRelation>
+                    <relation name="saws:isDifferentTo" active="LIT7530MashafaMad" passive="LIT7529Madhanit"/>
+                    <relation name="saws:isDifferentTo" active="LIT7530MashafaMad" passive="LIT1942Mashaf"/>
+                </listRelation>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created two new work records for distinct versions of the Maṣḥafa Madḫanit and updated the existing one (LIT1942Mashaf) according to our discussion in https://github.com/BetaMasaheft/Documentation/issues/3017.

I added the keyword Divination to LIT1171Awdana.