### PR TITLE
Updated excerpts of Tārika Walda ʾAmid from edition Kropp 2016 (Zekra Nagar)

### DIFF
--- a/4001-5000/LIT4089Introduction.xml
+++ b/4001-5000/LIT4089Introduction.xml
@@ -79,6 +79,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                   <citedRange unit="page">224-229</citedRange>
                </bibl>
             </listBibl>
+            <listRelation>
+               <relation name="ecrm:CLP46i_may_form_part_of" active="LIT4089Introduction" passive="LIT2352ShortC"/>
+               <relation name="saws:isShorterVersionOf" active="LIT4089Introduction" passive="LIT4723TarikaWaldaAmid"/>
+               <relation name="saws:isDifferentTo" active="LIT4089Introduction" passive="LIT4839IntroductionWaldaAmid"/>
+               <relation name="saws:isDifferentTo" active="LIT4089Introduction" passive="LIT4724WaldaAmidIntroduction"/>
+            </listRelation>
          </div>
       </body>
    </text>

--- a/4001-5000/LIT4089Introduction.xml
+++ b/4001-5000/LIT4089Introduction.xml
@@ -53,6 +53,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <change who="DR" when="2017-03-31">Added keywords and adjustments</change>
          <change who="DR" when="2017-03-31">Added bibliography</change>
          <change when="2025-05-11" who="CH">Updated titles and added abstract.</change>
+         <change when="2025-08-20" who="CH">Added listRelation</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">

--- a/4001-5000/LIT4724WaldaAmidIntroduction.xml
+++ b/4001-5000/LIT4724WaldaAmidIntroduction.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title xml:lang="en" xml:id="t1">Abbreviated Introduction of Walda ʾAmid</title>
+                <title xml:lang="en" xml:id="t1">Abbreviated Excerpt of Walda ʾAmid</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="DR"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -36,8 +36,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         <profileDesc>
             <creation/>
             <abstract>
-                <p>This work is composed of abbreviated excerpts from the introduction of <ref type="work" corresp="LIT6936TarWaAmidBeta"/> and included as an introduction in many historiographic works, among them the
-                    <ref type="work" corresp="LIT4090Haylu"/>. It is different from <ref type="work" corresp="LIT4089Introduction"/>, another abbreviated introduction of <ref type="work" corresp="LIT4723TarikaWaldaAmid"/>, which  
+                <p>This work is composed of abbreviated excerpts from the <ref type="work" corresp="LIT4723TarikaWaldaAmid"/> and included as an introduction in historiographic works, among them the
+                    <ref type="work" corresp="LIT4090Haylu"/>. It is different from <ref type="work" corresp="LIT4089Introduction"/>, another abbreviated excerpt of <ref type="work" corresp="LIT4723TarikaWaldaAmid"/>, which  
                     forms the introduction of a type of the <ref type="work" corresp="LIT2352ShortC"/>.
                 </p>
             </abstract>
@@ -51,6 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         </profileDesc>
         <revisionDesc>
             <change who="DR" when="2017-10-11">Created entity</change>
+            <change when="2025-08-20" who="CH">Updated abstract and title</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
@@ -74,9 +75,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <listBibl type="translation">
                     <bibl>
                   <ptr target="bm:Kropp2016Zekra"/>
-                  <citedRange unit="page">141-191</citedRange>
+                  <citedRange unit="page">142-191</citedRange>
                </bibl>
                 </listBibl>
+                <listRelation>
+                    <relation name="saws:isShorterVersionOf" active="LIT4724WaldaAmidIntroduction" passive="LIT4723TarikaWaldaAmid"/>
+                    <relation name="saws:isDifferentTo" active="LIT4724WaldaAmidIntroduction" passive="LIT4089Introduction"/>
+                    <relation name="saws:isDifferentTo" active="LIT4724WaldaAmidIntroduction" passive="LIT4839IntroductionWaldaAmid"/>
+                </listRelation>
             </div>
         </body>
     </text>

--- a/4001-5000/LIT4839IntroductionWaldaAmid.xml
+++ b/4001-5000/LIT4839IntroductionWaldaAmid.xml
@@ -4,7 +4,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
     <teiHeader xml:base="https://betamasaheft.eu/">
         <fileDesc>
             <titleStmt>
-                <title xml:id="t1">Introduction of Walda ʾAmid</title>
+                <title xml:id="t1">Excerpt of Walda ʾAmid</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="DR"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -45,14 +45,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 </keywords>
             </textClass>
             <abstract>
-                <p>Excerpt from <ref type="work" corresp="LIT6936TarWaAmidBeta"/> as contained in <ref type="mss" corresp="FSUor40"/>. This excerpt is lengthier
-                than <ref type="work" corresp="LIT4724WaldaAmidIntroduction"/> and <ref type="work" corresp="LIT4089Introduction"/> and includes the beginning of the work.</p>
+                <p>Excerpt from <ref type="work" corresp="LIT4723TarikaWaldaAmid"/>, which is lengthier
+                than <ref type="work" corresp="LIT4724WaldaAmidIntroduction"/> and <ref type="work" corresp="LIT4089Introduction"/>.</p>
          </abstract>
             <langUsage><language ident="en">English</language></langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="DR" when="2017-11-21">Created entity</change>
             <change when="2025-03-11" who="CH">Updated LIT reference and title</change>
+            <change when="2025-08-20" who="CH">Updated abstract and title</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
@@ -65,8 +66,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                </bibl>
                 </listBibl>
                 <listRelation>
-                    <relation name="saws:isRelatedTo" active="LIT4839IntroductionWaldaAmid" passive="LIT6936TarWaAmidBeta"/>
-            </listRelation>
+                    <relation name="saws:isShorterVersionOf" active="LIT4839IntroductionWaldaAmid" passive="LIT4723TarikaWaldaAmid"/>
+                    <relation name="saws:isDifferentTo" active="LIT4839IntroductionWaldaAmid" passive="LIT4089Introduction"/>
+                    <relation name="saws:isDifferentTo" active="LIT4839IntroductionWaldaAmid" passive="LIT4724WaldaAmidIntroduction"/>
+                </listRelation>
             </div>
             <div type="edition">
                 <div type="textpart" subtype="part" xml:id="ChrIntroduction">


### PR DESCRIPTION
I am not content with two records related to Tārika Walda ʾAmid. These texts, which are edited by Kropp 2016 do not contain the introductory chapters of the Tārika Walda ʾAmid, but contain excerpts from nearly all parts of the chronicle. They form the introduction to later chronological works. The titles 'Introduction of Walda ʾAmid' and 'Abbreviated Introduction of Walda ʾAmid' is therefore confusing and should be changed. I see them as excerpts from the Tārika Walda ʾAmid and added therefore saws:isShorterVersionOf as relations. 

As well, the reference to the Beta-recension (LIT6936TarWaAmidBeta) is not justified. As far as I can see, the relation to any specific recension is not established yet. Therefore, we should stay with the general LIT4723TarikaWaldaAmid.