### PR TITLE
Create LIT7629PresFright.xml

### DIFF
--- a/new/LIT7629PresFright.xml
+++ b/new/LIT7629PresFright.xml
@@ -1,0 +1,60 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LIT7629PresFright" xml:lang="en" type="work">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title xml:lang="en" xml:id="t1">Prescriptions for undoing magic and against fright in children</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Prescriptions for undoing magic 
+                    (<foreign xml:lang="gez">መፍትሔ፡ ኪ<supplied reason="undefined" resp="PRS8999Strelcyn">ን፡</supplied></foreign>) 
+                    and against fright in children (<foreign xml:lang="gez">ለዘ፡ አደንገፆ፡ ሕፃን፡</foreign>) attested in 
+                    <ref type="mss" corresp="BLorient12034#p2_i66"/>.</p>
+            </abstract>
+            <textClass>
+                <keywords>
+                    <term key="ChristianLiterature"/>
+                    <term key="Magic"/>
+                    <term key="Medicine"/>
+                </keywords>
+            </textClass>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-09-01">Created record</change>
+            <!-- Add change element after review -->
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <div type="bibliography"/>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I created a record for prescriptions attested in BLorient12034. Contrary to my suggestion in https://github.com/BetaMasaheft/Documentation/issues/3113#issuecomment-3241243133, I did not create two sub-ID. I think, it is easier to explain the two parts in an abstract, since I do not have distinct loci for the two parts, I find, it is meaningless to create sub-IDs at this point. All relevant information can similarily be retrieved from an abstract. Do you agree?